### PR TITLE
Remove toLowerCase from InstanceName

### DIFF
--- a/src/whatsapp/controllers/instance.controller.ts
+++ b/src/whatsapp/controllers/instance.controller.ts
@@ -65,7 +65,6 @@ export class InstanceController {
         this.cache,
       );
       instance.instanceName = instanceName
-        .toLowerCase()
         .replace(/[^a-z0-9]/g, '')
         .replace(' ', '');
       this.logger.verbose('instance: ' + instance.instanceName + ' created');


### PR DESCRIPTION
Acredito que cada um crie o nome de suas instancias com base em algo interno em seu sistema, além de que, esta sendo aplicado na criação, mas não na verificação dos demais campos, o que gera uma incompatibilidade entre endpoints.

Estava testando o Postman, com as configurações padrões, e simplesmente não funcionava, por que no cria fica tudo minusculo e nos demais não.