### PR TITLE
Validação de Grupo

### DIFF
--- a/src/whatsapp/services/whatsapp.service.ts
+++ b/src/whatsapp/services/whatsapp.service.ts
@@ -1517,13 +1517,21 @@ export class WAStartupService {
       .split(/\:/)[0]
       .split('@')[0];
 
+    // Verificação de Grupos Antigos
+    if(number.includes('-') && number.length >= 24){
+      this.logger.verbose('Jid created is group: ' + `${number}@g.us`);
+      number = number.replace(/[^\d-]/g, '');
+      return `${number}@g.us`;
+    }
+    
+    number = number.replace(/\D/g, '');
+
+    // Verificação de Grupos Novos
     if (number.length >= 18) {
       this.logger.verbose('Jid created is group: ' + `${number}@g.us`);
       number = number.replace(/[^\d-]/g, '');
       return `${number}@g.us`;
     }
-
-    number = number.replace(/\D/g, '');
 
     this.logger.verbose('Jid created is whatsapp: ' + `${number}@s.whatsapp.net`);
     return `${number}@s.whatsapp.net`;


### PR DESCRIPTION
Os grupos antigamente tinha `-` e mais de 24 caracteres, os grupos novos não tem mais o `-` e tem mais de 18 caracteres.