### PR TITLE
clean: docker network declaration and build of the `evolution/api` image

### DIFF
--- a/Docker/mongodb/docker-compose.yaml
+++ b/Docker/mongodb/docker-compose.yaml
@@ -35,7 +35,8 @@ volumes:
   evolution_mongodb_data:
   evolution_mongodb_configdb:
 
+
 networks:
   evolution-net:
-    external: true
-    
+    name: evolution-net
+    driver: bridge

--- a/Docker/redis/docker-compose.yaml
+++ b/Docker/redis/docker-compose.yaml
@@ -5,17 +5,17 @@ services:
     image: redis:latest
     container_name: redis
     command: >
-      redis-server
-      --port 6379
-      --appendonly yes
+      redis-server --port 6379 --appendonly yes
     volumes:
       - evolution_redis:/data
     ports:
       - 6379:6379
-    
+
 volumes:
   evolution_redis:
 
+
 networks:
   evolution-net:
-    external: true
+    name: evolution-net
+    driver: bridge

--- a/docker-compose.yaml.example
+++ b/docker-compose.yaml.example
@@ -4,6 +4,7 @@ services:
   api:
     container_name: evolution_api
     image: evolution/api:local
+    build: .
     restart: always
     ports:
       - 8080:8080

--- a/docker-compose.yaml.example
+++ b/docker-compose.yaml.example
@@ -24,5 +24,5 @@ volumes:
 
 networks:
   evolution-net:
-    external: true
-  
+    name: evolution-net
+    driver: bridge

--- a/docker-compose.yaml.example.complete
+++ b/docker-compose.yaml.example.complete
@@ -4,6 +4,7 @@ services:
   api:
     container_name: evolution_api
     image: evolution/api:local
+    build: .
     restart: always
     ports:
       - 8080:8080

--- a/docker-compose.yaml.example.complete
+++ b/docker-compose.yaml.example.complete
@@ -75,5 +75,5 @@ volumes:
 
 networks:
   evolution-net:
-    external: true
-  
+    name: evolution-net
+    driver: bridge

--- a/docker-compose.yaml.example.dockerhub
+++ b/docker-compose.yaml.example.dockerhub
@@ -24,5 +24,5 @@ volumes:
 
 networks:
   evolution-net:
-    external: true
-  
+    name: evolution-net
+    driver: bridge

--- a/docker.sh
+++ b/docker.sh
@@ -1,6 +1,0 @@
-#!/bin/bash
-IMAGE='evolution/api:local'
-
-docker build -t ${IMAGE} .
-
-docker compose up -d

--- a/docker.sh
+++ b/docker.sh
@@ -1,12 +1,5 @@
 #!/bin/bash
-
-NET='evolution-net'
 IMAGE='evolution/api:local'
-
-if !(docker network ls | grep ${NET} > /dev/null)
-then
-  docker network create -d bridge ${NET}
-fi
 
 docker build -t ${IMAGE} .
 


### PR DESCRIPTION
SH code to check existence of unnecessary docker network.

 ```yaml
    external: true
 ```
 It is only for using an existing main network.
 Since the `docker-compose*.yml` files are already primarily responsible for provisioning the main application stack, it doesn't make sense to create the network in a task outside its scope.

 This is just a small contribution from someone who has just arrived and is already impressed with this community!

The docker build command will be removed in future releases in favor of [buildx](https://docs.docker.com/build/architecture/#buildx).
 The Dockerfile build can be done by `docker-compose*.yml` itself by adding the `build: .` property in the api service.
