### PR TITLE
Fix set event rabbitmq/websocket

### DIFF
--- a/src/whatsapp/controllers/instance.controller.ts
+++ b/src/whatsapp/controllers/instance.controller.ts
@@ -181,7 +181,7 @@ export class InstanceController {
               'CHAMA_AI_ACTION',
             ];
           } else {
-            newEvents = events;
+            newEvents = websocket_events;
           }
           this.websocketService.create(instance, {
             enabled: true,
@@ -232,7 +232,7 @@ export class InstanceController {
           }
           this.rabbitmqService.create(instance, {
             enabled: true,
-            events: newEvents,
+            events: rabbitmq_events,
           });
 
           rabbitmqEvents = (await this.rabbitmqService.find(instance)).events;


### PR DESCRIPTION
Essa correção resolve o problema de quando criar uma conexão utilizando o rabbitmq ou websocket falhar ao consumir uma mensagem. 