### PR TITLE
Melhoria no método "startTypebot" para criar sessão persistente quando acionado

### DIFF
--- a/src/whatsapp/dto/typebot.dto.ts
+++ b/src/whatsapp/dto/typebot.dto.ts
@@ -4,6 +4,13 @@ export class Session {
   status?: string;
   createdAt?: number;
   updateAt?: number;
+  prefilledVariables?: PrefilledVariables;
+}
+
+export class PrefilledVariables {
+  remoteJid?: string;
+  pushName?: string;
+  additionalData?: { [key: string]: any };
 }
 
 export class TypebotDto {

--- a/src/whatsapp/models/typebot.model.ts
+++ b/src/whatsapp/models/typebot.model.ts
@@ -8,6 +8,11 @@ class Session {
   status?: string;
   createdAt?: number;
   updateAt?: number;
+  prefilledVariables?: {
+    remoteJid?: string;
+    pushName?: string;
+    additionalData?: { [key: string]: any };
+  };
 }
 
 export class TypebotRaw {
@@ -40,6 +45,11 @@ const typebotSchema = new Schema<TypebotRaw>({
       status: { type: String, required: true },
       createdAt: { type: Number, required: true },
       updateAt: { type: Number, required: true },
+      prefilledVariables: {
+        remoteJid: { type: String, required: false },
+        pushName: { type: String, required: false },
+        additionalData: { type: Schema.Types.Mixed, required: false }
+      },
     },
   ],
 });

--- a/src/whatsapp/services/typebot.service.ts
+++ b/src/whatsapp/services/typebot.service.ts
@@ -205,10 +205,10 @@ export class TypebotService {
       startParams: {
         typebot: data.typebot,
         prefilledVariables: {
+          ...data.prefilledVariables,
           remoteJid: data.remoteJid,
           pushName: data.pushName || 'Default Name',
           instanceName: instance.instanceName,
-          ...data.prefilledVariables,
         },
       },
     };
@@ -223,10 +223,10 @@ export class TypebotService {
         createdAt: Date.now(),
         updateAt: Date.now(),
         prefilledVariables: {
+          ...data.prefilledVariables,
           remoteJid: data.remoteJid,
           pushName: data.pushName || 'Default Name',
           instanceName: instance.instanceName,
-          ...data.prefilledVariables,
         }
       });
 

--- a/src/whatsapp/services/typebot.service.ts
+++ b/src/whatsapp/services/typebot.service.ts
@@ -409,7 +409,7 @@ export class TypebotService {
     const listening_from_me = findTypebot.listening_from_me;
 
     const session = sessions.find((session) => session.remoteJid === remoteJid);
-    session.prefilledVariables.pushName = msg.pushName;
+    //session.prefilledVariables.pushName = msg.pushName;
 
     if (session && expire && expire > 0) {
       const now = Date.now();

--- a/src/whatsapp/services/typebot.service.ts
+++ b/src/whatsapp/services/typebot.service.ts
@@ -409,7 +409,6 @@ export class TypebotService {
     const listening_from_me = findTypebot.listening_from_me;
 
     const session = sessions.find((session) => session.remoteJid === remoteJid);
-    //session.prefilledVariables.pushName = msg.pushName;
 
     if (session && expire && expire > 0) {
       const now = Date.now();

--- a/src/whatsapp/services/typebot.service.ts
+++ b/src/whatsapp/services/typebot.service.ts
@@ -223,10 +223,10 @@ export class TypebotService {
         createdAt: Date.now(),
         updateAt: Date.now(),
         prefilledVariables: {
-          ...data.prefilledVariables,
           remoteJid: data.remoteJid,
           pushName: data.pushName || 'Default Name',
           instanceName: instance.instanceName,
+          ...data.prefilledVariables,
         }
       });
 


### PR DESCRIPTION
## Descrição

Este PR aborda a solicitação de recurso mencionada na issue #124. Adiciona mudanças que aprimoram a função `startTypebot` para criar uma sessão persistente, inicializando o `sessionId` em StartTypebot.

## Mudanças

- A função `startTypebot` agora tem a capacidade de:
  - Criar uma nova sessão persistente.
  - Vincular o `sessionId` desde o início, garantindo uma continuidade nas interações subsequentes.
  - Passar variáveis em startTypebot que são consistentes para no typebot.
  
- Atualizado o DTO e o Modelo do Typebot para acomodar `prefilledVariables`.

## Benefícios

- Resolve o problema de reinicialização do bot durante a primeira interação do usuário no WhatsApp.
- Proporciona uma experiência de usuário mais fluída associando o `sessionId` logo de início.

## Como Testar

1. Inicie um bot usando o endpoint "Start Typebot" informando variáveis.
2. Use o endpoint "Change Session Status" e verifique que um `sessionId` foi gerado e associado assim que start Typebot é acionado.
3. Envie uma mensagem responda no whatsapp e veja que o bot não foi reiniciado a as variáveis mantidas.
4. Use novamente o endpoint "Change Session Status" e verifique que não foi criado outra sessão e foi atualizado do Timestamp.

## Screenshots e Detalhes

### Exemplo de acionamento do gatilho no n8n:
Comando curl para acionar um webhook no n8n e fornecer as variáveis para teste:
```
curl -X POST https://vt-n8n.teste.com.br/webhook-test/{key-ocultada} -H "Content-Type: application/json" -d '{
  "contact[id]": "290",
  "contact[email]": "emaildeteste@gmail.com",
  "contact[first_name]": "Fulano",
  "contact[last_name]": "de Tal Junior",
  "contact[phone]": "(61) 982XX-XXXX",
  "contact[orgname]": "",
  "contact[customer_acct_name]": "",
  "contact[tags]": "typebot-sessao-start",
  "contact[ip4]": "164.163.34.99",
  "contact[fields][utm_campaign]": "{:utm_campaing}",
  "contact[fields][utm_source]": "whatsapp",
  "contact[fields][utm_term]": "{:utm_term}",
  "contact[fields][utm_content]": "{:utm_content}",
  "contact[fields][utm_medium]": "{:utm_medium}",
  "contact[fields][utm_id]": "{:utm_id}",
  "contact[fields][faturamento_da_sua_empresa_em_2022]": "1MM a 1,9MM",
  "contact[fields][nome_da_empresa]": "Tech",
  "contact[fields][data]": "2023-09-24",
  "seriesid": "7"
}'
```

### Fluxo no n8n
Aqui o fluxo trata os dados recebidos no webhook e repassar para a chamada de Start Typebot
![Imagem do fluxo no n8n](https://i.imgur.com/LYEcPDz.jpg)

### Fluxo no Typebot
![Imagem do fluxo no Typebot](https://i.imgur.com/PDZI8SF.jpg)

### Teste de persistência das variáveis nas mensagens do WhatsApp
![Teste de chegada de mensagens no WhatsApp](https://i.imgur.com/0Zu6U4R.jpg)

### Teste no Endpoint FindTypebot - Primeira Interação
![Teste no Endpoint FindTypebot após início](https://i.imgur.com/eLzOC4b.jpg)


### Teste no Endpoint FindTypebot - Time stamp atualizado.
![Teste no Endpoint FindTypebot após progresso](https://i.imgur.com/J99aux6.jpg)

### Teste no WhatsApp do fluxo iniciado pelo usuário
![Interação no WhatsApp sem acionar StartTypebot](https://i.imgur.com/NMXITfO.jpg)

## Issue Relacionada

- Solicitação de Recurso Issue: #124 

---