### PR TITLE
Correção: Nova lógica  p/ obter mimetype quando não consta na url e no filename

### DIFF
--- a/src/whatsapp/services/typebot.service.ts
+++ b/src/whatsapp/services/typebot.service.ts
@@ -201,8 +201,8 @@ const id = Math.floor(Math.random() * 10000000000).toString();
       typebot: {
         ...instance,
         typebot: {
-          // linha incluida  por Francis:
-          enabled_typebot: enabled_typebot,
+          // linha incluida  por Francis neu 4:
+       //   enabled_typebot: enabled_typebot,
           url: url,
           remoteJid: remoteJid,
           typebot: typebot,
@@ -281,8 +281,8 @@ const id = Math.floor(Math.random() * 10000000000).toString();
       });
 
       const typebotData = {
-        // linha incluida  por Francis:
-        enabled: data.enabled_typebot,
+        // linha incluida  por Francis new4:
+        // enabled: data.enabled_typebot,
         url: data.url,
         typebot: data.typebot,
         expire: data.expire,

--- a/src/whatsapp/services/typebot.service.ts
+++ b/src/whatsapp/services/typebot.service.ts
@@ -99,6 +99,8 @@ export class TypebotService {
     const remoteJid = data.remoteJid;
     const url = data.url;
     const typebot = data.typebot;
+    // linha incluida  por Francis:
+    const enabled_typebot = data.enabled_typebot;
     const variables = data.variables;
     const findTypebot = await this.find(instance);
     const sessions = (findTypebot.sessions as Session[]) ?? [];
@@ -115,9 +117,16 @@ export class TypebotService {
     variables.forEach((variable) => {
       prefilledVariables[variable.name] = variable.value;
     });
+    // linha incluida  por Francis:
+    if (enabled_typebot !== false  ) {
+ 
+    let enabled_typebot = true;
+  
 
-    const response = await this.createNewSession(instance, {
+const response = await this.createNewSession(instance, {
       url: url,
+      // linha incluida  por Francis:
+      enabled_typebot: enabled_typebot,
       typebot: typebot,
       remoteJid: remoteJid,
       expire: expire,
@@ -141,6 +150,8 @@ export class TypebotService {
       this.waMonitor.waInstances[instance.instanceName].sendDataWebhook(Events.TYPEBOT_START, {
         remoteJid: remoteJid,
         url: url,
+        // linha incluida  por Francis:
+        enabled_typebot: enabled_typebot,
         typebot: typebot,
         prefilledVariables: prefilledVariables,
         sessionId: `${response.sessionId}`, 
@@ -148,11 +159,50 @@ export class TypebotService {
     } else {
         throw new Error("Session ID not found in response");
     }
+  
+} else {
+
+const id = Math.floor(Math.random() * 10000000000).toString();
+
+    const reqData = {
+      sessionId: id,
+      startParams: {
+        typebot: data.typebot,
+        prefilledVariables: prefilledVariables,
+      },
+    };
+
+    const request = await axios.post(data.url + '/api/v1/sendMessage', reqData);
+
+    await this.sendWAMessage(
+      instance,
+      remoteJid,
+      request.data.messages,
+      request.data.input,
+      request.data.clientSideActions,
+    );
+
+    this.waMonitor.waInstances[instance.instanceName].sendDataWebhook(Events.TYPEBOT_START, {
+      remoteJid: remoteJid,
+      url: url,
+      typebot: typebot,
+      variables: variables,
+      sessionId: id,
+    });
+
+
+}
+
+
+
+    // ate aqui
 
     return {
       typebot: {
         ...instance,
         typebot: {
+          // linha incluida  por Francis:
+          enabled_typebot: enabled_typebot,
           url: url,
           remoteJid: remoteJid,
           typebot: typebot,
@@ -231,7 +281,8 @@ export class TypebotService {
       });
 
       const typebotData = {
-        enabled: true,
+        // linha incluida  por Francis:
+        enabled: data.enabled_typebot,
         url: data.url,
         typebot: data.typebot,
         expire: data.expire,
@@ -469,7 +520,6 @@ export class TypebotService {
     });
 
     const typebotData = {
-      enabled: true,
       url: url,
       typebot: typebot,
       expire: expire,
@@ -504,7 +554,6 @@ export class TypebotService {
       sessions.splice(sessions.indexOf(session), 1);
 
       const typebotData = {
-        enabled: true,
         url: url,
         typebot: typebot,
         expire: expire,

--- a/src/whatsapp/services/whatsapp.service.ts
+++ b/src/whatsapp/services/whatsapp.service.ts
@@ -2308,37 +2308,35 @@ export class WAStartupService {
         mediaMessage.fileName = arrayMatch[1];
         this.logger.verbose('File name: ' + mediaMessage.fileName);
       }
-      // *inserido francis inicio
-      let mimetype: string;
-      // *inserido francis final
-
 
       if (mediaMessage.mediatype === 'image' && !mediaMessage.fileName) {
-        mediaMessage.fileName = 'image.png';
-        // inserido francis inicio
-        mimetype = 'image/png';
-        // inserido francis inicio
-
+       mediaMessage.fileName = 'image.png';     
       }
 
       if (mediaMessage.mediatype === 'video' && !mediaMessage.fileName) {
         mediaMessage.fileName = 'video.mp4';
-        // inserido francis inicio
-        mimetype = 'video/mp4';
-        // inserido francis final
       }
 
- // ocultado francis inicio
-   //   let mimetype: string;
+ 
+      let mimetype: string;
 
-
-   //   if (isURL(mediaMessage.media)) {
-   //     mimetype = getMIMEType(mediaMessage.media);
-   //   } else {
-   //     mimetype = getMIMEType(mediaMessage.fileName);
-   //   }
-  // ocultado francis final
-
+      // novo critério para adotar mimetype quando nao está presente na url e no filename - inicio
+      if (isURL(mediaMessage.media) || mediaMessage.fileName) {
+      if (isURL(mediaMessage.media)) {
+        mimetype = getMIMEType(mediaMessage.media);
+      } else {
+        mimetype = getMIMEType(mediaMessage.fileName);
+      }
+      } else {
+      if (mediaMessage.mediatype === 'image') {
+        mimetype = 'image/png';
+      }
+      if (mediaMessage.mediatype === 'video') {
+        mimetype = 'video/mp4';
+      }     
+      }
+      // novo critério para adotar mimetype quando nao está presente na url e no filename - fim
+ 
       this.logger.verbose('Mimetype: ' + mimetype);
 
       prepareMedia[mediaType].caption = mediaMessage?.caption;

--- a/src/whatsapp/services/whatsapp.service.ts
+++ b/src/whatsapp/services/whatsapp.service.ts
@@ -2335,6 +2335,7 @@ export class WAStartupService {
         mimetype = 'video/mp4';
       }     
       }
+
       // novo critério para adotar mimetype quando nao está presente na url e no filename - fim
  
       this.logger.verbose('Mimetype: ' + mimetype);


### PR DESCRIPTION
Melhora a lógica e novo critério para adotar mimetype quando nao está presente na url e no filename . Nos casos que a URL da midia vem com um formato sem extenxão da midia (minio, Amazaon S3, etc). Foi mantido o padrão anterior de buscar o mimetype pela url da midia e pelo filename. Caso não for possível e adotado o mimetype em função do buuble usado no typebot