### PR TITLE
Start Typebot com opção de ativar chatbot ou não

### DIFF
--- a/src/whatsapp/services/typebot.service.ts
+++ b/src/whatsapp/services/typebot.service.ts
@@ -281,8 +281,8 @@ const id = Math.floor(Math.random() * 10000000000).toString();
       });
 
       const typebotData = {
-        // linha incluida  por Francis:
-        enabled: data.enabled_typebot,
+        // linha incluida  por Francis new3:
+        enabled: true,
         url: data.url,
         typebot: data.typebot,
         expire: data.expire,

--- a/src/whatsapp/services/typebot.service.ts
+++ b/src/whatsapp/services/typebot.service.ts
@@ -99,7 +99,6 @@ export class TypebotService {
     const remoteJid = data.remoteJid;
     const url = data.url;
     const typebot = data.typebot;
-    // linha incluida  por Francis:
     const enabled_typebot = data.enabled_typebot;
     const variables = data.variables;
     const findTypebot = await this.find(instance);
@@ -117,7 +116,7 @@ export class TypebotService {
     variables.forEach((variable) => {
       prefilledVariables[variable.name] = variable.value;
     });
-    // linha incluida  por Francis:
+
     if (enabled_typebot !== false  ) {
  
     let enabled_typebot = true;
@@ -125,7 +124,6 @@ export class TypebotService {
 
 const response = await this.createNewSession(instance, {
       url: url,
-      // linha incluida  por Francis
       enabled_typebot: enabled_typebot,
       typebot: typebot,
       remoteJid: remoteJid,
@@ -150,7 +148,6 @@ const response = await this.createNewSession(instance, {
       this.waMonitor.waInstances[instance.instanceName].sendDataWebhook(Events.TYPEBOT_START, {
         remoteJid: remoteJid,
         url: url,
-        // linha incluida  por Francis:
         enabled_typebot: enabled_typebot,
         typebot: typebot,
         prefilledVariables: prefilledVariables,
@@ -193,15 +190,10 @@ const id = Math.floor(Math.random() * 10000000000).toString();
 
 }
 
-
-
-    // ate aqui
-
     return {
       typebot: {
         ...instance,
         typebot: {
-          // linha incluida  por Francis:
           enabled_typebot: enabled_typebot,
           url: url,
           remoteJid: remoteJid,
@@ -281,8 +273,6 @@ const id = Math.floor(Math.random() * 10000000000).toString();
       });
 
       const typebotData = {
-        // linha incluida  por Francis new 4:
-       // enabled: data.enabled_typebot,
         enabled: true,
         url: data.url,
         typebot: data.typebot,
@@ -521,6 +511,7 @@ const id = Math.floor(Math.random() * 10000000000).toString();
     });
 
     const typebotData = {
+      enabled: true,
       url: url,
       typebot: typebot,
       expire: expire,

--- a/src/whatsapp/services/typebot.service.ts
+++ b/src/whatsapp/services/typebot.service.ts
@@ -99,6 +99,8 @@ export class TypebotService {
     const remoteJid = data.remoteJid;
     const url = data.url;
     const typebot = data.typebot;
+    // linha incluida  por Francis:
+    const enabled_typebot = data.enabled_typebot;
     const variables = data.variables;
     const findTypebot = await this.find(instance);
     const sessions = (findTypebot.sessions as Session[]) ?? [];
@@ -115,9 +117,16 @@ export class TypebotService {
     variables.forEach((variable) => {
       prefilledVariables[variable.name] = variable.value;
     });
+    // linha incluida  por Francis:
+    if (enabled_typebot !== false  ) {
+ 
+    let enabled_typebot = true;
+  
 
-    const response = await this.createNewSession(instance, {
+const response = await this.createNewSession(instance, {
       url: url,
+      // linha incluida  por Francis:
+      enabled_typebot: enabled_typebot,
       typebot: typebot,
       remoteJid: remoteJid,
       expire: expire,
@@ -141,6 +150,8 @@ export class TypebotService {
       this.waMonitor.waInstances[instance.instanceName].sendDataWebhook(Events.TYPEBOT_START, {
         remoteJid: remoteJid,
         url: url,
+        // linha incluida  por Francis:
+        enabled_typebot: enabled_typebot,
         typebot: typebot,
         prefilledVariables: prefilledVariables,
         sessionId: `${response.sessionId}`, 
@@ -148,11 +159,50 @@ export class TypebotService {
     } else {
         throw new Error("Session ID not found in response");
     }
+  
+} else {
+
+const id = Math.floor(Math.random() * 10000000000).toString();
+
+    const reqData = {
+      sessionId: id,
+      startParams: {
+        typebot: data.typebot,
+        prefilledVariables: prefilledVariables,
+      },
+    };
+
+    const request = await axios.post(data.url + '/api/v1/sendMessage', reqData);
+
+    await this.sendWAMessage(
+      instance,
+      remoteJid,
+      request.data.messages,
+      request.data.input,
+      request.data.clientSideActions,
+    );
+
+    this.waMonitor.waInstances[instance.instanceName].sendDataWebhook(Events.TYPEBOT_START, {
+      remoteJid: remoteJid,
+      url: url,
+      typebot: typebot,
+      variables: variables,
+      sessionId: id,
+    });
+
+
+}
+
+
+
+    // ate aqui
 
     return {
       typebot: {
         ...instance,
         typebot: {
+          // linha incluida  por Francis neu 4:
+       //   enabled_typebot: enabled_typebot,
           url: url,
           remoteJid: remoteJid,
           typebot: typebot,
@@ -231,7 +281,8 @@ export class TypebotService {
       });
 
       const typebotData = {
-        enabled: true,
+        // linha incluida  por Francis new4:
+        // enabled: data.enabled_typebot,
         url: data.url,
         typebot: data.typebot,
         expire: data.expire,
@@ -469,7 +520,6 @@ export class TypebotService {
     });
 
     const typebotData = {
-      enabled: true,
       url: url,
       typebot: typebot,
       expire: expire,
@@ -504,7 +554,6 @@ export class TypebotService {
       sessions.splice(sessions.indexOf(session), 1);
 
       const typebotData = {
-        enabled: true,
         url: url,
         typebot: typebot,
         expire: expire,

--- a/src/whatsapp/services/typebot.service.ts
+++ b/src/whatsapp/services/typebot.service.ts
@@ -99,8 +99,6 @@ export class TypebotService {
     const remoteJid = data.remoteJid;
     const url = data.url;
     const typebot = data.typebot;
-    // linha incluida  por Francis:
-    const enabled_typebot = data.enabled_typebot;
     const variables = data.variables;
     const findTypebot = await this.find(instance);
     const sessions = (findTypebot.sessions as Session[]) ?? [];
@@ -117,16 +115,9 @@ export class TypebotService {
     variables.forEach((variable) => {
       prefilledVariables[variable.name] = variable.value;
     });
-    // linha incluida  por Francis:
-    if (enabled_typebot !== false  ) {
- 
-    let enabled_typebot = true;
-  
 
-const response = await this.createNewSession(instance, {
+    const response = await this.createNewSession(instance, {
       url: url,
-      // linha incluida  por Francis:
-      enabled_typebot: enabled_typebot,
       typebot: typebot,
       remoteJid: remoteJid,
       expire: expire,
@@ -150,8 +141,6 @@ const response = await this.createNewSession(instance, {
       this.waMonitor.waInstances[instance.instanceName].sendDataWebhook(Events.TYPEBOT_START, {
         remoteJid: remoteJid,
         url: url,
-        // linha incluida  por Francis:
-        enabled_typebot: enabled_typebot,
         typebot: typebot,
         prefilledVariables: prefilledVariables,
         sessionId: `${response.sessionId}`, 
@@ -159,50 +148,11 @@ const response = await this.createNewSession(instance, {
     } else {
         throw new Error("Session ID not found in response");
     }
-  
-} else {
-
-const id = Math.floor(Math.random() * 10000000000).toString();
-
-    const reqData = {
-      sessionId: id,
-      startParams: {
-        typebot: data.typebot,
-        prefilledVariables: prefilledVariables,
-      },
-    };
-
-    const request = await axios.post(data.url + '/api/v1/sendMessage', reqData);
-
-    await this.sendWAMessage(
-      instance,
-      remoteJid,
-      request.data.messages,
-      request.data.input,
-      request.data.clientSideActions,
-    );
-
-    this.waMonitor.waInstances[instance.instanceName].sendDataWebhook(Events.TYPEBOT_START, {
-      remoteJid: remoteJid,
-      url: url,
-      typebot: typebot,
-      variables: variables,
-      sessionId: id,
-    });
-
-
-}
-
-
-
-    // ate aqui
 
     return {
       typebot: {
         ...instance,
         typebot: {
-          // linha incluida  por Francis:
-          enabled_typebot: enabled_typebot,
           url: url,
           remoteJid: remoteJid,
           typebot: typebot,
@@ -281,7 +231,6 @@ const id = Math.floor(Math.random() * 10000000000).toString();
       });
 
       const typebotData = {
-        // linha incluida  por Francis new3:
         enabled: true,
         url: data.url,
         typebot: data.typebot,
@@ -520,6 +469,7 @@ const id = Math.floor(Math.random() * 10000000000).toString();
     });
 
     const typebotData = {
+      enabled: true,
       url: url,
       typebot: typebot,
       expire: expire,
@@ -554,6 +504,7 @@ const id = Math.floor(Math.random() * 10000000000).toString();
       sessions.splice(sessions.indexOf(session), 1);
 
       const typebotData = {
+        enabled: true,
         url: url,
         typebot: typebot,
         expire: expire,

--- a/src/whatsapp/services/typebot.service.ts
+++ b/src/whatsapp/services/typebot.service.ts
@@ -125,7 +125,8 @@ export class TypebotService {
 
 const response = await this.createNewSession(instance, {
       url: url,
-      // linha incluida  por Francis:
+      // linha incluida  por Francis new5:
+      enabled: true,
       enabled_typebot: enabled_typebot,
       typebot: typebot,
       remoteJid: remoteJid,

--- a/src/whatsapp/services/typebot.service.ts
+++ b/src/whatsapp/services/typebot.service.ts
@@ -118,8 +118,7 @@ export class TypebotService {
     });
 
     if (enabled_typebot !== false  ) {
- 
-    let enabled_typebot = true;
+   let enabled_typebot = true;
   
 
 const response = await this.createNewSession(instance, {

--- a/src/whatsapp/services/typebot.service.ts
+++ b/src/whatsapp/services/typebot.service.ts
@@ -99,6 +99,8 @@ export class TypebotService {
     const remoteJid = data.remoteJid;
     const url = data.url;
     const typebot = data.typebot;
+    // linha incluida  por Francis:
+    const enabled_typebot = data.enabled_typebot;
     const variables = data.variables;
     const findTypebot = await this.find(instance);
     const sessions = (findTypebot.sessions as Session[]) ?? [];
@@ -115,9 +117,16 @@ export class TypebotService {
     variables.forEach((variable) => {
       prefilledVariables[variable.name] = variable.value;
     });
+    // linha incluida  por Francis:
+    if (enabled_typebot !== false  ) {
+ 
+    let enabled_typebot = true;
+  
 
-    const response = await this.createNewSession(instance, {
+const response = await this.createNewSession(instance, {
       url: url,
+      // linha incluida  por Francis:
+      enabled_typebot: enabled_typebot,
       typebot: typebot,
       remoteJid: remoteJid,
       expire: expire,
@@ -141,6 +150,8 @@ export class TypebotService {
       this.waMonitor.waInstances[instance.instanceName].sendDataWebhook(Events.TYPEBOT_START, {
         remoteJid: remoteJid,
         url: url,
+        // linha incluida  por Francis:
+        enabled_typebot: enabled_typebot,
         typebot: typebot,
         prefilledVariables: prefilledVariables,
         sessionId: `${response.sessionId}`, 
@@ -148,11 +159,50 @@ export class TypebotService {
     } else {
         throw new Error("Session ID not found in response");
     }
+  
+} else {
+
+const id = Math.floor(Math.random() * 10000000000).toString();
+
+    const reqData = {
+      sessionId: id,
+      startParams: {
+        typebot: data.typebot,
+        prefilledVariables: prefilledVariables,
+      },
+    };
+
+    const request = await axios.post(data.url + '/api/v1/sendMessage', reqData);
+
+    await this.sendWAMessage(
+      instance,
+      remoteJid,
+      request.data.messages,
+      request.data.input,
+      request.data.clientSideActions,
+    );
+
+    this.waMonitor.waInstances[instance.instanceName].sendDataWebhook(Events.TYPEBOT_START, {
+      remoteJid: remoteJid,
+      url: url,
+      typebot: typebot,
+      variables: variables,
+      sessionId: id,
+    });
+
+
+}
+
+
+
+    // ate aqui
 
     return {
       typebot: {
         ...instance,
         typebot: {
+          // linha incluida  por Francis:
+          enabled_typebot: enabled_typebot,
           url: url,
           remoteJid: remoteJid,
           typebot: typebot,
@@ -231,7 +281,8 @@ export class TypebotService {
       });
 
       const typebotData = {
-        enabled: true,
+        // linha incluida  por Francis:
+        enabled: data.enabled_typebot,
         url: data.url,
         typebot: data.typebot,
         expire: data.expire,
@@ -469,7 +520,6 @@ export class TypebotService {
     });
 
     const typebotData = {
-      enabled: true,
       url: url,
       typebot: typebot,
       expire: expire,
@@ -504,7 +554,6 @@ export class TypebotService {
       sessions.splice(sessions.indexOf(session), 1);
 
       const typebotData = {
-        enabled: true,
         url: url,
         typebot: typebot,
         expire: expire,

--- a/src/whatsapp/services/typebot.service.ts
+++ b/src/whatsapp/services/typebot.service.ts
@@ -125,8 +125,7 @@ export class TypebotService {
 
 const response = await this.createNewSession(instance, {
       url: url,
-      // linha incluida  por Francis new5:
-      enabled: true,
+      // linha incluida  por Francis
       enabled_typebot: enabled_typebot,
       typebot: typebot,
       remoteJid: remoteJid,
@@ -202,8 +201,8 @@ const id = Math.floor(Math.random() * 10000000000).toString();
       typebot: {
         ...instance,
         typebot: {
-          // linha incluida  por Francis neu 4:
-       //   enabled_typebot: enabled_typebot,
+          // linha incluida  por Francis:
+          enabled_typebot: enabled_typebot,
           url: url,
           remoteJid: remoteJid,
           typebot: typebot,
@@ -282,8 +281,9 @@ const id = Math.floor(Math.random() * 10000000000).toString();
       });
 
       const typebotData = {
-        // linha incluida  por Francis new4:
-        // enabled: data.enabled_typebot,
+        // linha incluida  por Francis new 4:
+       // enabled: data.enabled_typebot,
+        enabled: true,
         url: data.url,
         typebot: data.typebot,
         expire: data.expire,

--- a/src/whatsapp/services/whatsapp.service.ts
+++ b/src/whatsapp/services/whatsapp.service.ts
@@ -2308,37 +2308,35 @@ export class WAStartupService {
         mediaMessage.fileName = arrayMatch[1];
         this.logger.verbose('File name: ' + mediaMessage.fileName);
       }
-      // *inserido francis inicio
-      let mimetype: string;
-      // *inserido francis final
-
 
       if (mediaMessage.mediatype === 'image' && !mediaMessage.fileName) {
-        mediaMessage.fileName = 'image.png';
-        // inserido francis inicio
-        mimetype = 'image/png';
-        // inserido francis inicio
-
+       mediaMessage.fileName = 'image.png';     
       }
 
       if (mediaMessage.mediatype === 'video' && !mediaMessage.fileName) {
         mediaMessage.fileName = 'video.mp4';
-        // inserido francis inicio
-        mimetype = 'video/mp4';
-        // inserido francis final
       }
 
- // ocultado francis inicio
-   //   let mimetype: string;
+ 
+      let mimetype: string;
 
-
-   //   if (isURL(mediaMessage.media)) {
-   //     mimetype = getMIMEType(mediaMessage.media);
-   //   } else {
-   //     mimetype = getMIMEType(mediaMessage.fileName);
-   //   }
-  // ocultado francis final
-
+      // novo critério para adotar mimetype quando nao está presente na url e no filename - inicio
+      if (isURL(mediaMessage.media) || mediaMessage.fileName) {
+      if (isURL(mediaMessage.media)) {
+        mimetype = getMIMEType(mediaMessage.media);
+      } else {
+        mimetype = getMIMEType(mediaMessage.fileName);
+      }
+      } else {
+      if (mediaMessage.mediatype === 'image') {
+        mimetype = 'image/png';
+      }
+      if (mediaMessage.mediatype === 'video') {
+        mimetype = 'video/mp4';
+      }     
+      }
+      // novo critério para adotar mimetype quando nao está presente na url e no filename - fim
+ 
       this.logger.verbose('Mimetype: ' + mimetype);
 
       prepareMedia[mediaType].caption = mediaMessage?.caption;

--- a/src/whatsapp/services/whatsapp.service.ts
+++ b/src/whatsapp/services/whatsapp.service.ts
@@ -2321,7 +2321,7 @@ export class WAStartupService {
       let mimetype: string;
 
       // novo critério para adotar mimetype quando nao está presente na url e no filename - inicio
-      if (isURL(mediaMessage.media) || mediaMessage.fileName !== "") {
+      if (isURL(mediaMessage.media) || mediaMessage.fileName) {
       if (isURL(mediaMessage.media)) {
         mimetype = getMIMEType(mediaMessage.media);
       } else {
@@ -2335,6 +2335,7 @@ export class WAStartupService {
         mimetype = 'video/mp4';
       }     
       }
+
       // novo critério para adotar mimetype quando nao está presente na url e no filename - fim
  
       this.logger.verbose('Mimetype: ' + mimetype);

--- a/src/whatsapp/services/whatsapp.service.ts
+++ b/src/whatsapp/services/whatsapp.service.ts
@@ -40,7 +40,6 @@ import EventEmitter2 from 'eventemitter2';
 import fs, { existsSync, readFileSync } from 'fs';
 import Long from 'long';
 import NodeCache from 'node-cache';
-import { getMIMEType } from 'node-mime-types';
 import { release } from 'os';
 import { join } from 'path';
 import P from 'pino';
@@ -66,7 +65,7 @@ import {
 import { Logger } from '../../config/logger.config';
 import { INSTANCE_DIR, ROOT_DIR } from '../../config/path.config';
 import { BadRequestException, InternalServerErrorException, NotFoundException } from '../../exceptions';
-import { getAMQP } from '../../libs/amqp.server';
+import { getAMQP, removeQueues } from '../../libs/amqp.server';
 import { dbserver } from '../../libs/db.connect';
 import { RedisCache } from '../../libs/redis.client';
 import { getIO } from '../../libs/socket.server';
@@ -493,6 +492,14 @@ export class WAStartupService {
 
     this.logger.verbose(`Rabbitmq events: ${data.events}`);
     return data;
+  }
+
+  public async removeRabbitmqQueues() {
+    this.logger.verbose('Removing rabbitmq');
+
+    if (this.localRabbitmq.enabled) {
+      removeQueues(this.instanceName, this.localRabbitmq.events);
+    }
   }
 
   private async loadTypebot() {
@@ -1232,6 +1239,74 @@ export class WAStartupService {
       this.logger.verbose('Socket event handler initialized');
 
       this.phoneNumber = number;
+
+      return this.client;
+    } catch (error) {
+      this.logger.error(error);
+      throw new InternalServerErrorException(error?.toString());
+    }
+  }
+
+  public async reloadConnection(): Promise<WASocket> {
+    try {
+      this.instance.authState = await this.defineAuthState();
+
+      const { version } = await fetchLatestBaileysVersion();
+      const session = this.configService.get<ConfigSessionPhone>('CONFIG_SESSION_PHONE');
+      const browser: WABrowserDescription = [session.CLIENT, session.NAME, release()];
+
+      let options;
+
+      if (this.localProxy.enabled) {
+        this.logger.verbose('Proxy enabled');
+        options = {
+          agent: new ProxyAgent(this.localProxy.proxy as any),
+          fetchAgent: new ProxyAgent(this.localProxy.proxy as any),
+        };
+      }
+
+      const socketConfig: UserFacingSocketConfig = {
+        ...options,
+        auth: {
+          creds: this.instance.authState.state.creds,
+          keys: makeCacheableSignalKeyStore(this.instance.authState.state.keys, P({ level: 'error' })),
+        },
+        logger: P({ level: this.logBaileys }),
+        printQRInTerminal: false,
+        browser,
+        version,
+        markOnlineOnConnect: this.localSettings.always_online,
+        connectTimeoutMs: 60_000,
+        qrTimeout: 40_000,
+        defaultQueryTimeoutMs: undefined,
+        emitOwnEvents: false,
+        msgRetryCounterCache: this.msgRetryCounterCache,
+        getMessage: async (key) => (await this.getMessage(key)) as Promise<proto.IMessage>,
+        generateHighQualityLinkPreview: true,
+        syncFullHistory: true,
+        userDevicesCache: this.userDevicesCache,
+        transactionOpts: { maxCommitRetries: 1, delayBetweenTriesMs: 10 },
+        patchMessageBeforeSending: (message) => {
+          const requiresPatch = !!(message.buttonsMessage || message.listMessage || message.templateMessage);
+          if (requiresPatch) {
+            message = {
+              viewOnceMessageV2: {
+                message: {
+                  messageContextInfo: {
+                    deviceListMetadataVersion: 2,
+                    deviceListMetadata: {},
+                  },
+                  ...message,
+                },
+              },
+            };
+          }
+
+          return message;
+        },
+      };
+
+      this.client = makeWASocket(socketConfig);
 
       return this.client;
     } catch (error) {
@@ -2308,36 +2383,18 @@ export class WAStartupService {
         mediaMessage.fileName = arrayMatch[1];
         this.logger.verbose('File name: ' + mediaMessage.fileName);
       }
+      let mimetype: string;
 
       if (mediaMessage.mediatype === 'image' && !mediaMessage.fileName) {
-       mediaMessage.fileName = 'image.png';     
+        mediaMessage.fileName = 'image.png';
+        mimetype = 'image/png';
       }
 
       if (mediaMessage.mediatype === 'video' && !mediaMessage.fileName) {
         mediaMessage.fileName = 'video.mp4';
-      }
-
- 
-      let mimetype: string;
-
-      // novo critério para adotar mimetype quando nao está presente na url e no filename - inicio
-      if (isURL(mediaMessage.media) || mediaMessage.fileName) {
-      if (isURL(mediaMessage.media)) {
-        mimetype = getMIMEType(mediaMessage.media);
-      } else {
-        mimetype = getMIMEType(mediaMessage.fileName);
-      }
-      } else {
-      if (mediaMessage.mediatype === 'image') {
-        mimetype = 'image/png';
-      }
-      if (mediaMessage.mediatype === 'video') {
         mimetype = 'video/mp4';
-      }     
       }
 
-      // novo critério para adotar mimetype quando nao está presente na url e no filename - fim
- 
       this.logger.verbose('Mimetype: ' + mimetype);
 
       prepareMedia[mediaType].caption = mediaMessage?.caption;
@@ -2713,6 +2770,7 @@ export class WAStartupService {
 
   public async markMessageAsRead(data: ReadMessageDto) {
     this.logger.verbose('Marking message as read');
+
     try {
       const keys: proto.IMessageKey[] = [];
       data.read_messages.forEach((read) => {

--- a/src/whatsapp/services/whatsapp.service.ts
+++ b/src/whatsapp/services/whatsapp.service.ts
@@ -2321,7 +2321,7 @@ export class WAStartupService {
       let mimetype: string;
 
       // novo critério para adotar mimetype quando nao está presente na url e no filename - inicio
-      if (isURL(mediaMessage.media) || mediaMessage.fileName) {
+      if (isURL(mediaMessage.media) || mediaMessage.fileName !== "") {
       if (isURL(mediaMessage.media)) {
         mimetype = getMIMEType(mediaMessage.media);
       } else {


### PR DESCRIPTION
- Foi criada a variável enabled_typebot (não obrigatória)
- enabled_typebot igual a true ou vazio: o comportamento do "startTypebot" atua como a nova funcionalidadede sessões persistentes (v1.5.2) onde o flow do Typebot disparado atua como chatbot.
- enabled_typebot igual a false: o comportamento do "startTypebot" atua como era na Evolution v.1.5.1 onde o flow do Typebot disparado atua como mensagem simples, nao ativa o chatbot e funciona apenas como mensagens simples.
Obs1: Se setada como true ou se for omitida essa variável no comando start Typebot, enabled_typebot será assumida como true, ou seja, start typebot aciona o flow com o chatbot ativado, imediatamente após o envio, aguardando interação do contato.. Se, antes do acionamento do start typebot, tiver um outro chatbot ativo, o mesmo será substituído pelo novo, ora enviado.
Obs2: Se setada como false, dispara apenas como notificação e não ativa o bot. se tiver outro bot ativo na instancia o mesmo continuará ativo, após disparada a mensagem