### PR TITLE
Recuperar base64 de media enviada por webhook

### DIFF
--- a/src/dev-env.yml
+++ b/src/dev-env.yml
@@ -97,6 +97,7 @@ WEBHOOK:
     WEBHOOK_BY_EVENTS: false
   # Automatically maps webhook paths
   # Set the events you want to hear
+    WEBHOOK_BASE64: false 
   EVENTS:
     APPLICATION_STARTUP: false
     QRCODE_UPDATED: true

--- a/src/whatsapp/controllers/instance.controller.ts
+++ b/src/whatsapp/controllers/instance.controller.ts
@@ -41,6 +41,7 @@ export class InstanceController {
     instanceName,
     webhook,
     webhook_by_events,
+    webhook_base64,
     events,
     qrcode,
     number,
@@ -139,6 +140,7 @@ export class InstanceController {
             url: webhook,
             events: newEvents,
             webhook_by_events,
+            webhook_base64,
           });
 
           webhookEvents = (await this.webhookService.find(instance)).events;
@@ -297,6 +299,7 @@ export class InstanceController {
           webhook: {
             webhook,
             webhook_by_events,
+            webhook_base64,
             events: webhookEvents,
           },
           websocket: {
@@ -390,6 +393,7 @@ export class InstanceController {
         webhook: {
           webhook,
           webhook_by_events,
+          webhook_base64,
           events: webhookEvents,
         },
         websocket: {

--- a/src/whatsapp/dto/instance.dto.ts
+++ b/src/whatsapp/dto/instance.dto.ts
@@ -5,6 +5,7 @@ export class InstanceDto {
   token?: string;
   webhook?: string;
   webhook_by_events?: boolean;
+  webhook_base64?: boolean;
   events?: string[];
   reject_call?: boolean;
   msg_call?: string;

--- a/src/whatsapp/models/webhook.model.ts
+++ b/src/whatsapp/models/webhook.model.ts
@@ -8,6 +8,7 @@ export class WebhookRaw {
   enabled?: boolean;
   events?: string[];
   webhook_by_events?: boolean;
+  webhook_base64?: boolean;
 }
 
 const webhookSchema = new Schema<WebhookRaw>({
@@ -16,6 +17,7 @@ const webhookSchema = new Schema<WebhookRaw>({
   enabled: { type: Boolean, required: true },
   events: { type: [String], required: true },
   webhook_by_events: { type: Boolean, required: true },
+  webhook_base64: { type: Boolean, required: true },
 });
 
 export const WebhookModel = dbserver?.model(WebhookRaw.name, webhookSchema, 'webhook');

--- a/src/whatsapp/services/webhook.service.ts
+++ b/src/whatsapp/services/webhook.service.ts
@@ -26,7 +26,7 @@ export class WebhookService {
 
       return result;
     } catch (error) {
-      return { enabled: false, url: '', events: [], webhook_by_events: false };
+       return { enabled: false, url: '', events: [], webhook_by_events: false, webhook_base64 : false };
     }
   }
 }

--- a/src/whatsapp/types/wa.types.ts
+++ b/src/whatsapp/types/wa.types.ts
@@ -50,6 +50,7 @@ export declare namespace wa {
     url?: string;
     events?: string[];
     webhook_by_events?: boolean;
+    webhook_base64?: boolean;
   };
 
   export type LocalChatwoot = {


### PR DESCRIPTION
Foi criado uma nova alteração para recuperar o base64 de arquivos de media enviar por webhook
Foi acrescentado no arquivo de env  a variável **WEBHOOK_BASE64** que por padrão vem desativado. 
Também foi criar a plausibilidade de enviar o evento ao criar o webhook. 
![Captura de tela 2023-10-03 172536](https://github.com/EvolutionAPI/evolution-api/assets/24901391/b6f5d804-f1ee-4e4a-a000-e288417154ab)

Imagem de retorno
![Captura de tela 2023-10-03 173124](https://github.com/EvolutionAPI/evolution-api/assets/24901391/4f696522-2faa-4fea-8a1b-e1f1f8494e96)
