### PR TITLE
Fix: Variables null

### DIFF
--- a/src/whatsapp/services/typebot.service.ts
+++ b/src/whatsapp/services/typebot.service.ts
@@ -114,9 +114,11 @@ export class TypebotService {
       instanceName: instance.instanceName,
     };
 
-    variables.forEach((variable) => {
-      prefilledVariables[variable.name] = variable.value;
-    });
+    if (variables?.length) {
+      variables.forEach((variable: { name: string | number; value: string }) => {
+        prefilledVariables[variable.name] = variable.value;
+      });
+    }
 
     if (startSession) {
       const response = await this.createNewSession(instance, {


### PR DESCRIPTION
Corrige erro no endpoint {{baseUrl}}/typebot/start/{{instance}}
- Adiciona verificação para garantir que `variables `não esteja vazio antes de executar o foreach.