### PR TITLE
Handle optional chaining for 'settings.msg_call', this change prevent…

### DIFF
--- a/src/whatsapp/services/whatsapp.service.ts
+++ b/src/whatsapp/services/whatsapp.service.ts
@@ -1801,7 +1801,7 @@ export class WAStartupService {
             this.client.rejectCall(call.id, call.from);
           }
 
-          if (settings?.msg_call.trim().length > 0 && call.status == 'offer') {
+          if (settings?.msg_call?.trim().length > 0 && call.status == 'offer') {
             this.logger.verbose('Sending message in call');
             const msg = await this.client.sendMessage(call.from, {
               text: settings.msg_call,


### PR DESCRIPTION
I encountered a runtime error due to 'settings.msg_call' being potentially undefined, leading to crashes.

`origin: Promise {
    <rejected> TypeError: Cannot read properties of undefined (reading 'trim')
        at WAStartupService.<anonymous> (/evolution/dist/src/whatsapp/services/whatsapp.service.js:1477:96)
        at Generator.next (<anonymous>)
        at fulfilled (/evolution/dist/src/whatsapp/services/whatsapp.service.js:28:58)
        at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
  },

  stderr: 2,
  error: TypeError: Cannot read properties of undefined (reading 'trim')
      at WAStartupService.<anonymous> (/evolution/dist/src/whatsapp/services/whatsapp.service.js:1477:96)
      at Generator.next (<anonymous>)
      at fulfilled (/evolution/dist/src/whatsapp/services/whatsapp.service.js:28:58)
      at process.processTicksAndRejections (node:internal/process/task_queues:95:5)`