### PR TITLE
Handle erros in Typebot

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,5 +7,7 @@
   "editor.codeActionsOnSave": {
      "source.fixAll.eslint": true,
      "source.fixAll": true
-  }
+  },
+  "prisma-smart-formatter.typescript.defaultFormatter": "esbenp.prettier-vscode",
+  "prisma-smart-formatter.prisma.defaultFormatter": "Prisma.prisma"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Correction of messages sent by the api and typebot not appearing in chatwoot
 * Adjustment to start typebot, added startSession parameter
 * Chatwoot now receives messages sent via api and typebot
+* Fixed problem with starting with an input in typebot
 
 # 1.5.2 (2023-09-28 17:56)
 

--- a/src/whatsapp/services/typebot.service.ts
+++ b/src/whatsapp/services/typebot.service.ts
@@ -96,6 +96,8 @@ export class TypebotService {
   }
 
   public async startTypebot(instance: InstanceDto, data: any) {
+    if (data.remoteJid === 'status@broadcast') return;
+
     const remoteJid = data.remoteJid;
     const url = data.url;
     const typebot = data.typebot;
@@ -155,7 +157,13 @@ export class TypebotService {
         },
       };
 
-      const request = await axios.post(data.url + '/api/v1/sendMessage', reqData);
+      let request: any;
+      try {
+        request = await axios.post(data.url + '/api/v1/sendMessage', reqData);
+      } catch (error) {
+        this.logger.error(error);
+        return;
+      }
 
       await this.sendWAMessage(
         instance,
@@ -224,7 +232,9 @@ export class TypebotService {
   }
 
   public async createNewSession(instance: InstanceDto, data: any) {
+    if (data.remoteJid === 'status@broadcast') return;
     const id = Math.floor(Math.random() * 10000000000).toString();
+
     const reqData = {
       startParams: {
         typebot: data.typebot,
@@ -237,7 +247,13 @@ export class TypebotService {
       },
     };
 
-    const request = await axios.post(data.url + '/api/v1/sendMessage', reqData);
+    let request: any;
+    try {
+      request = await axios.post(data.url + '/api/v1/sendMessage', reqData);
+    } catch (error) {
+      this.logger.error(error);
+      return;
+    }
 
     if (request.data.sessionId) {
       data.sessions.push({
@@ -503,7 +519,13 @@ export class TypebotService {
             sessionId: data.sessionId,
           };
 
-          const request = await axios.post(url + '/api/v1/sendMessage', reqData);
+          let request: any;
+          try {
+            request = await axios.post(url + '/api/v1/sendMessage', reqData);
+          } catch (error) {
+            this.logger.error(error);
+            return;
+          }
 
           console.log('request', request);
           await this.sendWAMessage(
@@ -583,7 +605,13 @@ export class TypebotService {
           sessionId: data.sessionId,
         };
 
-        const request = await axios.post(url + '/api/v1/sendMessage', reqData);
+        let request: any;
+        try {
+          request = await axios.post(url + '/api/v1/sendMessage', reqData);
+        } catch (error) {
+          this.logger.error(error);
+          return;
+        }
 
         console.log('request', request);
         await this.sendWAMessage(
@@ -660,7 +688,13 @@ export class TypebotService {
       sessionId: session.sessionId.split('-')[1],
     };
 
-    const request = await axios.post(url + '/api/v1/sendMessage', reqData);
+    let request: any;
+    try {
+      request = await axios.post(url + '/api/v1/sendMessage', reqData);
+    } catch (error) {
+      this.logger.error(error);
+      return;
+    }
 
     await this.sendWAMessage(
       instance,

--- a/src/whatsapp/services/typebot.service.ts
+++ b/src/whatsapp/services/typebot.service.ts
@@ -482,16 +482,102 @@ export class TypebotService {
 
     const session = sessions.find((session) => session.remoteJid === remoteJid);
 
-    if (session && expire && expire > 0) {
-      const now = Date.now();
+    try {
+      if (session && expire && expire > 0) {
+        const now = Date.now();
 
-      const diff = now - session.updateAt;
+        const diff = now - session.updateAt;
 
-      const diffInMinutes = Math.floor(diff / 1000 / 60);
+        const diffInMinutes = Math.floor(diff / 1000 / 60);
 
-      if (diffInMinutes > expire) {
-        const newSessions = await this.clearSessions(instance, remoteJid);
+        if (diffInMinutes > expire) {
+          const newSessions = await this.clearSessions(instance, remoteJid);
 
+          const data = await this.createNewSession(instance, {
+            enabled: findTypebot.enabled,
+            url: url,
+            typebot: typebot,
+            expire: expire,
+            keyword_finish: keyword_finish,
+            delay_message: delay_message,
+            unknown_message: unknown_message,
+            listening_from_me: listening_from_me,
+            sessions: newSessions,
+            remoteJid: remoteJid,
+            pushName: msg.pushName,
+          });
+
+          await this.sendWAMessage(instance, remoteJid, data.messages, data.input, data.clientSideActions);
+
+          if (data.messages.length === 0) {
+            const content = this.getConversationMessage(msg.message);
+
+            if (!content) {
+              if (unknown_message) {
+                this.waMonitor.waInstances[instance.instanceName].textMessage({
+                  number: remoteJid.split('@')[0],
+                  options: {
+                    delay: delay_message || 1000,
+                    presence: 'composing',
+                  },
+                  textMessage: {
+                    text: unknown_message,
+                  },
+                });
+              }
+              return;
+            }
+
+            if (keyword_finish && content.toLowerCase() === keyword_finish.toLowerCase()) {
+              const newSessions = await this.clearSessions(instance, remoteJid);
+
+              const typebotData = {
+                enabled: findTypebot.enabled,
+                url: url,
+                typebot: typebot,
+                expire: expire,
+                keyword_finish: keyword_finish,
+                delay_message: delay_message,
+                unknown_message: unknown_message,
+                listening_from_me: listening_from_me,
+                sessions: newSessions,
+              };
+
+              this.create(instance, typebotData);
+
+              return;
+            }
+
+            const reqData = {
+              message: content,
+              sessionId: data.sessionId,
+            };
+
+            try {
+              const request = await axios.post(url + '/api/v1/sendMessage', reqData);
+
+              await this.sendWAMessage(
+                instance,
+                remoteJid,
+                request.data.messages,
+                request.data.input,
+                request.data.clientSideActions,
+              );
+            } catch (error) {
+              this.logger.error(error);
+              return;
+            }
+          }
+
+          return;
+        }
+      }
+
+      if (session && session.status !== 'opened') {
+        return;
+      }
+
+      if (!session) {
         const data = await this.createNewSession(instance, {
           enabled: findTypebot.enabled,
           url: url,
@@ -501,7 +587,7 @@ export class TypebotService {
           delay_message: delay_message,
           unknown_message: unknown_message,
           listening_from_me: listening_from_me,
-          sessions: newSessions,
+          sessions: sessions,
           remoteJid: remoteJid,
           pushName: msg.pushName,
         });
@@ -528,7 +614,7 @@ export class TypebotService {
           }
 
           if (keyword_finish && content.toLowerCase() === keyword_finish.toLowerCase()) {
-            const newSessions = await this.clearSessions(instance, remoteJid);
+            sessions.splice(sessions.indexOf(session), 1);
 
             const typebotData = {
               enabled: findTypebot.enabled,
@@ -539,7 +625,7 @@ export class TypebotService {
               delay_message: delay_message,
               unknown_message: unknown_message,
               listening_from_me: listening_from_me,
-              sessions: newSessions,
+              sessions,
             };
 
             this.create(instance, typebotData);
@@ -552,9 +638,9 @@ export class TypebotService {
             sessionId: data.sessionId,
           };
 
+          let request: any;
           try {
-            const request = await axios.post(url + '/api/v1/sendMessage', reqData);
-
+            request = await axios.post(url + '/api/v1/sendMessage', reqData);
             await this.sendWAMessage(
               instance,
               remoteJid,
@@ -567,134 +653,14 @@ export class TypebotService {
             return;
           }
         }
-
         return;
       }
-    }
 
-    if (session && session.status !== 'opened') {
-      return;
-    }
-
-    if (!session) {
-      const data = await this.createNewSession(instance, {
-        enabled: findTypebot.enabled,
-        url: url,
-        typebot: typebot,
-        expire: expire,
-        keyword_finish: keyword_finish,
-        delay_message: delay_message,
-        unknown_message: unknown_message,
-        listening_from_me: listening_from_me,
-        sessions: sessions,
-        remoteJid: remoteJid,
-        pushName: msg.pushName,
+      sessions.map((session) => {
+        if (session.remoteJid === remoteJid) {
+          session.updateAt = Date.now();
+        }
       });
-
-      await this.sendWAMessage(instance, remoteJid, data.messages, data.input, data.clientSideActions);
-
-      if (data.messages.length === 0) {
-        const content = this.getConversationMessage(msg.message);
-
-        if (!content) {
-          if (unknown_message) {
-            this.waMonitor.waInstances[instance.instanceName].textMessage({
-              number: remoteJid.split('@')[0],
-              options: {
-                delay: delay_message || 1000,
-                presence: 'composing',
-              },
-              textMessage: {
-                text: unknown_message,
-              },
-            });
-          }
-          return;
-        }
-
-        if (keyword_finish && content.toLowerCase() === keyword_finish.toLowerCase()) {
-          sessions.splice(sessions.indexOf(session), 1);
-
-          const typebotData = {
-            enabled: findTypebot.enabled,
-            url: url,
-            typebot: typebot,
-            expire: expire,
-            keyword_finish: keyword_finish,
-            delay_message: delay_message,
-            unknown_message: unknown_message,
-            listening_from_me: listening_from_me,
-            sessions,
-          };
-
-          this.create(instance, typebotData);
-
-          return;
-        }
-
-        const reqData = {
-          message: content,
-          sessionId: data.sessionId,
-        };
-
-        let request: any;
-        try {
-          request = await axios.post(url + '/api/v1/sendMessage', reqData);
-          await this.sendWAMessage(
-            instance,
-            remoteJid,
-            request.data.messages,
-            request.data.input,
-            request.data.clientSideActions,
-          );
-        } catch (error) {
-          this.logger.error(error);
-          return;
-        }
-      }
-      return;
-    }
-
-    sessions.map((session) => {
-      if (session.remoteJid === remoteJid) {
-        session.updateAt = Date.now();
-      }
-    });
-
-    const typebotData = {
-      enabled: findTypebot.enabled,
-      url: url,
-      typebot: typebot,
-      expire: expire,
-      keyword_finish: keyword_finish,
-      delay_message: delay_message,
-      unknown_message: unknown_message,
-      listening_from_me: listening_from_me,
-      sessions,
-    };
-
-    this.create(instance, typebotData);
-
-    const content = this.getConversationMessage(msg.message);
-
-    if (!content) {
-      if (unknown_message) {
-        this.waMonitor.waInstances[instance.instanceName].textMessage({
-          number: remoteJid.split('@')[0],
-          options: {
-            delay: delay_message || 1000,
-            presence: 'composing',
-          },
-          textMessage: {
-            text: unknown_message,
-          },
-        });
-      }
-      return;
-    }
-
-    if (keyword_finish && content.toLowerCase() === keyword_finish.toLowerCase()) {
-      sessions.splice(sessions.indexOf(session), 1);
 
       const typebotData = {
         enabled: findTypebot.enabled,
@@ -710,17 +676,50 @@ export class TypebotService {
 
       this.create(instance, typebotData);
 
-      return;
-    }
+      const content = this.getConversationMessage(msg.message);
 
-    const reqData = {
-      message: content,
-      sessionId: session.sessionId.split('-')[1],
-    };
+      if (!content) {
+        if (unknown_message) {
+          this.waMonitor.waInstances[instance.instanceName].textMessage({
+            number: remoteJid.split('@')[0],
+            options: {
+              delay: delay_message || 1000,
+              presence: 'composing',
+            },
+            textMessage: {
+              text: unknown_message,
+            },
+          });
+        }
+        return;
+      }
 
-    let request: any;
-    try {
-      request = await axios.post(url + '/api/v1/sendMessage', reqData);
+      if (keyword_finish && content.toLowerCase() === keyword_finish.toLowerCase()) {
+        sessions.splice(sessions.indexOf(session), 1);
+
+        const typebotData = {
+          enabled: findTypebot.enabled,
+          url: url,
+          typebot: typebot,
+          expire: expire,
+          keyword_finish: keyword_finish,
+          delay_message: delay_message,
+          unknown_message: unknown_message,
+          listening_from_me: listening_from_me,
+          sessions,
+        };
+
+        this.create(instance, typebotData);
+
+        return;
+      }
+
+      const reqData = {
+        message: content,
+        sessionId: session.sessionId.split('-')[1],
+      };
+
+      const request = await axios.post(url + '/api/v1/sendMessage', reqData);
 
       await this.sendWAMessage(
         instance,
@@ -729,11 +728,11 @@ export class TypebotService {
         request.data.input,
         request.data.clientSideActions,
       );
+
+      return;
     } catch (error) {
       this.logger.error(error);
       return;
     }
-
-    return;
   }
 }

--- a/src/whatsapp/services/typebot.service.ts
+++ b/src/whatsapp/services/typebot.service.ts
@@ -157,29 +157,28 @@ export class TypebotService {
         },
       };
 
-      let request: any;
       try {
-        request = await axios.post(data.url + '/api/v1/sendMessage', reqData);
+        const request = await axios.post(data.url + '/api/v1/sendMessage', reqData);
+
+        await this.sendWAMessage(
+          instance,
+          remoteJid,
+          request.data.messages,
+          request.data.input,
+          request.data.clientSideActions,
+        );
+
+        this.waMonitor.waInstances[instance.instanceName].sendDataWebhook(Events.TYPEBOT_START, {
+          remoteJid: remoteJid,
+          url: url,
+          typebot: typebot,
+          variables: variables,
+          sessionId: id,
+        });
       } catch (error) {
         this.logger.error(error);
         return;
       }
-
-      await this.sendWAMessage(
-        instance,
-        remoteJid,
-        request.data.messages,
-        request.data.input,
-        request.data.clientSideActions,
-      );
-
-      this.waMonitor.waInstances[instance.instanceName].sendDataWebhook(Events.TYPEBOT_START, {
-        remoteJid: remoteJid,
-        url: url,
-        typebot: typebot,
-        variables: variables,
-        sessionId: id,
-      });
     }
 
     return {
@@ -255,7 +254,7 @@ export class TypebotService {
       return;
     }
 
-    if (request.data.sessionId) {
+    if (request?.data?.sessionId) {
       data.sessions.push({
         remoteJid: data.remoteJid,
         sessionId: `${id}-${request.data.sessionId}`,
@@ -519,22 +518,21 @@ export class TypebotService {
             sessionId: data.sessionId,
           };
 
-          let request: any;
           try {
-            request = await axios.post(url + '/api/v1/sendMessage', reqData);
+            const request = await axios.post(url + '/api/v1/sendMessage', reqData);
+
+            console.log('request', request);
+            await this.sendWAMessage(
+              instance,
+              remoteJid,
+              request.data.messages,
+              request.data.input,
+              request.data.clientSideActions,
+            );
           } catch (error) {
             this.logger.error(error);
             return;
           }
-
-          console.log('request', request);
-          await this.sendWAMessage(
-            instance,
-            remoteJid,
-            request.data.messages,
-            request.data.input,
-            request.data.clientSideActions,
-          );
         }
 
         return;
@@ -608,19 +606,19 @@ export class TypebotService {
         let request: any;
         try {
           request = await axios.post(url + '/api/v1/sendMessage', reqData);
+
+          console.log('request', request);
+          await this.sendWAMessage(
+            instance,
+            remoteJid,
+            request.data.messages,
+            request.data.input,
+            request.data.clientSideActions,
+          );
         } catch (error) {
           this.logger.error(error);
           return;
         }
-
-        console.log('request', request);
-        await this.sendWAMessage(
-          instance,
-          remoteJid,
-          request.data.messages,
-          request.data.input,
-          request.data.clientSideActions,
-        );
       }
       return;
     }
@@ -691,18 +689,18 @@ export class TypebotService {
     let request: any;
     try {
       request = await axios.post(url + '/api/v1/sendMessage', reqData);
+
+      await this.sendWAMessage(
+        instance,
+        remoteJid,
+        request.data.messages,
+        request.data.input,
+        request.data.clientSideActions,
+      );
     } catch (error) {
       this.logger.error(error);
       return;
     }
-
-    await this.sendWAMessage(
-      instance,
-      remoteJid,
-      request.data.messages,
-      request.data.input,
-      request.data.clientSideActions,
-    );
 
     return;
   }

--- a/src/whatsapp/services/typebot.service.ts
+++ b/src/whatsapp/services/typebot.service.ts
@@ -320,37 +320,6 @@ export class TypebotService {
     return sessions;
   }
 
-  public async clearSessions(instance: InstanceDto, remoteJid: string) {
-    const findTypebot = await this.find(instance);
-    const sessions = (findTypebot.sessions as Session[]) ?? [];
-
-    const sessionWithRemoteJid = sessions.filter((session) => session.remoteJid === remoteJid);
-
-    if (sessionWithRemoteJid.length > 0) {
-      sessionWithRemoteJid.forEach((session) => {
-        sessions.splice(sessions.indexOf(session), 1);
-      });
-
-      const typebotData = {
-        enabled: findTypebot.enabled,
-        url: findTypebot.url,
-        typebot: findTypebot.typebot,
-        expire: findTypebot.expire,
-        keyword_finish: findTypebot.keyword_finish,
-        delay_message: findTypebot.delay_message,
-        unknown_message: findTypebot.unknown_message,
-        listening_from_me: findTypebot.listening_from_me,
-        sessions,
-      };
-
-      this.create(instance, typebotData);
-
-      return sessions;
-    }
-
-    return sessions;
-  }
-
   public async sendWAMessage(
     instance: InstanceDto,
     remoteJid: string,


### PR DESCRIPTION
Refactor TypebotService to handle error responses from axios

The TypebotService in `typebot.service.ts` file has been refactored to handle error responses from the axios library. Error handling has been added to the `startTypebot`, `createNewSession`, and other related methods to catch and log errors from failed axios requests. 