### PR TITLE
Update typebot.service.ts - element.underline change ~ for *

### DIFF
--- a/src/whatsapp/services/typebot.service.ts
+++ b/src/whatsapp/services/typebot.service.ts
@@ -323,7 +323,7 @@ export class TypebotService {
               }
 
               if (element.underline) {
-                text = `~${text}~`;
+                text = `*${text}*`;
               }
 
               if (element.url) {


### PR DESCRIPTION
There's no underline in WhatsApp ~ use strikethrough instead, I switched to * bold.