### PR TITLE
fix: Removed await from webhook when sending a message

### DIFF
--- a/src/whatsapp/services/whatsapp.service.ts
+++ b/src/whatsapp/services/whatsapp.service.ts
@@ -2159,6 +2159,21 @@ export class WAStartupService {
           !message['conversation'] &&
           sender !== 'status@broadcast'
         ) {
+
+          if (message['reactionMessage']) {
+            this.logger.verbose('Sending reaction');
+            return await this.client.sendMessage(
+                sender,
+                {
+                  react: {
+                    text: message['reactionMessage']['text'],
+                    key: message['reactionMessage']['key']
+                  }
+                } as unknown as AnyMessageContent,
+                option as unknown as MiscMessageGenerationOptions,
+            );
+          }
+
           if (!message['audio']) {
             this.logger.verbose('Sending message');
             return await this.client.sendMessage(
@@ -2174,7 +2189,6 @@ export class WAStartupService {
             );
           }
         }
-
         if (message['conversation']) {
           this.logger.verbose('Sending message');
           return await this.client.sendMessage(

--- a/src/whatsapp/services/whatsapp.service.ts
+++ b/src/whatsapp/services/whatsapp.service.ts
@@ -2222,7 +2222,7 @@ export class WAStartupService {
       this.logger.log(messageRaw);
 
       this.logger.verbose('Sending data to webhook in event SEND_MESSAGE');
-      await this.sendDataWebhook(Events.SEND_MESSAGE, messageRaw);
+      this.sendDataWebhook(Events.SEND_MESSAGE, messageRaw);
 
       if (this.localChatwoot.enabled && !isChatwoot) {
         this.chatwootService.eventWhatsapp(Events.SEND_MESSAGE, { instanceName: this.instance.name }, messageRaw);


### PR DESCRIPTION
Foi removido o await do disparo do webhook ao enviar uma mensagem!

**Motivo**
Quando uma aplicação chamava a rota de enviar mensagem e o webhook estive apontado para a mesma aplicação
a evolution simplesmente trava até que a função que fez a chamada para o envio de mensagem retornasse um time out e a evolution conseguia fazer o disparado do webhook.
Após remover o await tudo funcionou corretamente