### PR TITLE
fix messages not received: error handling when updating contact

### DIFF
--- a/src/whatsapp/services/chatwoot.service.ts
+++ b/src/whatsapp/services/chatwoot.service.ts
@@ -338,14 +338,18 @@ export class ChatwootService {
     }
 
     this.logger.verbose('update contact in chatwoot');
-    const contact = await client.contacts.update({
-      accountId: this.provider.account_id,
-      id,
-      data,
-    });
+    try {
+      const contact = await client.contacts.update({
+        accountId: this.provider.account_id,
+        id,
+        data,
+      });
 
-    this.logger.verbose('contact updated');
-    return contact;
+      this.logger.verbose('contact updated');
+      return contact;
+    } catch (error) {
+      this.logger.error(error);
+    }
   }
 
   public async findContact(instance: InstanceDto, phoneNumber: string) {
@@ -487,6 +491,9 @@ export class ChatwootService {
             contact = await this.updateContact(instance, findContact.id, {
               avatar_url: picture_url.profilePictureUrl || null,
             });
+          }
+          if (!contact) {
+            contact = await this.findContact(instance, chatId);
           }
         } else {
           const jid = isGroup ? null : body.key.remoteJid;


### PR DESCRIPTION
It was observed that not all messages arrived on Chatwoot, I carried out stress tests on the computer to simulate and correct it.

When our server was overloaded, some messages did not arrive on Chatwoot, when looking at the logs and code, we noticed that when Evolution Api receives a message, the contact's profile photo is updated to Chatwoot, if for some reason it fails this PATCH, the evolution API did not continue with the message, I made a treatment so that if this happens, the "contact" object does not become null.
As a result, messages were no longer lost.