### PR TITLE
Add session creation for typebot service

### DIFF
--- a/src/whatsapp/services/typebot.service.ts
+++ b/src/whatsapp/services/typebot.service.ts
@@ -69,6 +69,20 @@ export class TypebotService {
           session.status = status;
         }
       });
+    } else {
+      const session: Session = {
+        remoteJid: remoteJid,
+        sessionId: Math.floor(Math.random() * 10000000000).toString(),
+        status: status,
+        createdAt: Date.now(),
+        updateAt: Date.now(),
+        prefilledVariables: {
+          remoteJid: remoteJid,
+          pushName: '',
+          additionalData: {},
+        },
+      };
+      findData.sessions.push(session);
     }
 
     const typebotData = {


### PR DESCRIPTION
The modification is centered around handling cases where a session status update is attempted for a non-existent session. Previously, the service only updated the status of existing sessions. With this update, if a session does not exist when attempting to update its status, a new session is created.

Key Changes:
1. Added an 'else' block in the Typebot Service to handle the scenario where a session is not found.
2. In this block, a new session is initialized with a unique sessionId, the current status, creation and update timestamps, and prefilled variables including `remoteJid`.
3. This new session is then added to the `findData.sessions` array, ensuring that the service can manage sessions that were not previously tracked.