### PR TITLE
Fix chatwoot find

### DIFF
--- a/src/whatsapp/controllers/chatwoot.controller.ts
+++ b/src/whatsapp/controllers/chatwoot.controller.ts
@@ -64,7 +64,7 @@ export class ChatwootController {
 
     const urlServer = this.configService.get<HttpServer>('SERVER').URL;
 
-    if (Object.keys(result).length === 0) {
+    if (Object.keys(result || {}).length === 0) {
       return {
         enabled: false,
         url: '',


### PR DESCRIPTION
Isso simplesmente corrige o erro que ocorre quando usa o end-point `chatwoot/find` e ele ainda não esta configurado
![Imagem do WhatsApp de 2023-12-11 à(s) 11 46 17_e2c3cac1](https://github.com/EvolutionAPI/evolution-api/assets/58153955/28a8954d-7fd5-40a9-a8de-136fed412d8f)

A correção foi simples, apenas colocando `|| {}` para quando usar um objeto vazio ao invés de `null`
![image](https://github.com/EvolutionAPI/evolution-api/assets/58153955/5407a081-f8ba-491b-88f0-831a817c5ff2)
