### PR TITLE
fix: only create if is paused

### DIFF
--- a/src/whatsapp/services/typebot.service.ts
+++ b/src/whatsapp/services/typebot.service.ts
@@ -69,7 +69,7 @@ export class TypebotService {
           session.status = status;
         }
       });
-    } else {
+    } else if (status === 'paused') {
       const session: Session = {
         remoteJid: remoteJid,
         sessionId: Math.floor(Math.random() * 10000000000).toString(),


### PR DESCRIPTION
Correção para https://github.com/EvolutionAPI/evolution-api/pull/233 onde eu coloquei um `else` para criar a sessão quando não existe uma sessão, o objetivo era para pausar a sessão antes mesmo de existir, porem com os testes @matiasduartee quando é tem uma sessão aberta e usa o end-point para mudar o status para `closed` funciona normalmente, a API apaga a sessão, porem se enviar novamente como `closed` o código criava uma sessão com o status `closed` que fazia o bot parar de funcionar.

Para corrigir, agora ele só cria sessões caso não exista e o status seja `paused`, visto que o open já possui um end-point

![image](https://github.com/EvolutionAPI/evolution-api/assets/58153955/d12066a2-f4c1-40dd-aec4-8f015111b438)
