### PR TITLE
simple add keep open

### DIFF
--- a/Docker/.env.example
+++ b/Docker/.env.example
@@ -107,6 +107,7 @@ QRCODE_COLOR=#198754
 
 # old | latest
 TYPEBOT_API_VERSION=latest
+TYPEBOT_KEEP_OPEN=false
 
 # Defines an authentication type for the api
 # We recommend using the apikey because it will allow you to use a custom token,

--- a/src/config/env.config.ts
+++ b/src/config/env.config.ts
@@ -130,7 +130,7 @@ export type SslConf = { PRIVKEY: string; FULLCHAIN: string };
 export type Webhook = { GLOBAL?: GlobalWebhook; EVENTS: EventsWebhook };
 export type ConfigSessionPhone = { CLIENT: string; NAME: string };
 export type QrCode = { LIMIT: number; COLOR: string };
-export type Typebot = { API_VERSION: string };
+export type Typebot = { API_VERSION: string; KEEP_OPEN: boolean };
 export type Production = boolean;
 
 export interface Env {
@@ -308,6 +308,7 @@ export class ConfigService {
       },
       TYPEBOT: {
         API_VERSION: process.env?.TYPEBOT_API_VERSION || 'old',
+        KEEP_OPEN: process.env.TYPEBOT_KEEP_OPEN === 'true',
       },
       AUTHENTICATION: {
         TYPE: process.env.AUTHENTICATION_TYPE as 'apikey',

--- a/src/dev-env.yml
+++ b/src/dev-env.yml
@@ -148,6 +148,7 @@ QRCODE:
 
 TYPEBOT:
   API_VERSION: 'old' # old | latest
+  KEEP_OPEN: false
 
 # Defines an authentication type for the api
 # We recommend using the apikey because it will allow you to use a custom token,

--- a/src/whatsapp/services/typebot.service.ts
+++ b/src/whatsapp/services/typebot.service.ts
@@ -16,6 +16,9 @@ export class TypebotService {
     private readonly eventEmitter: EventEmitter2,
   ) {
     this.eventEmitter.on('typebot:end', async (data) => {
+      const keep_open = this.configService.get<Typebot>('TYPEBOT').KEEP_OPEN;
+      if (keep_open) return;
+
       await this.clearSessions(data.instance, data.remoteJid);
     });
   }


### PR DESCRIPTION
Simplesmente adiciona um novo env `TYPEBOT_KEEP_OPEN` que tem como valor padrão `false`, porem quando está como `true` impede o fechamento da sessão no fim do fluxo do typebot para atender as requisições feita no issue  https://github.com/EvolutionAPI/evolution-api/issues/273

![image](https://github.com/EvolutionAPI/evolution-api/assets/58153955/d6b1c451-f5b3-4921-930c-2121d344181f)