### PR TITLE
Chatwoot format

### DIFF
--- a/src/validate/validate.schema.ts
+++ b/src/validate/validate.schema.ts
@@ -889,6 +889,7 @@ export const chatwootSchema: JSONSchema7 = {
     token: { type: 'string' },
     url: { type: 'string' },
     sign_msg: { type: 'boolean', enum: [true, false] },
+    sign_delimiter: { type: ['string', 'null'] },
     reopen_conversation: { type: 'boolean', enum: [true, false] },
     conversation_pending: { type: 'boolean', enum: [true, false] },
     auto_create: { type: 'boolean', enum: [true, false] },

--- a/src/whatsapp/controllers/chatwoot.controller.ts
+++ b/src/whatsapp/controllers/chatwoot.controller.ts
@@ -37,6 +37,7 @@ export class ChatwootController {
       if (data.sign_msg !== true && data.sign_msg !== false) {
         throw new BadRequestException('sign_msg is required');
       }
+      if (data.sign_msg === false) data.sign_delimiter = null;
     }
 
     if (!data.enabled) {
@@ -45,6 +46,7 @@ export class ChatwootController {
       data.token = '';
       data.url = '';
       data.sign_msg = false;
+      data.sign_delimiter = null;
       data.reopen_conversation = false;
       data.conversation_pending = false;
       data.auto_create = false;

--- a/src/whatsapp/dto/chatwoot.dto.ts
+++ b/src/whatsapp/dto/chatwoot.dto.ts
@@ -5,6 +5,7 @@ export class ChatwootDto {
   url?: string;
   name_inbox?: string;
   sign_msg?: boolean;
+  sign_delimiter?: string;
   number?: string;
   reopen_conversation?: boolean;
   conversation_pending?: boolean;

--- a/src/whatsapp/models/chatwoot.model.ts
+++ b/src/whatsapp/models/chatwoot.model.ts
@@ -10,6 +10,7 @@ export class ChatwootRaw {
   url?: string;
   name_inbox?: string;
   sign_msg?: boolean;
+  sign_delimiter?: string;
   number?: string;
   reopen_conversation?: boolean;
   conversation_pending?: boolean;
@@ -23,6 +24,7 @@ const chatwootSchema = new Schema<ChatwootRaw>({
   url: { type: String, required: true },
   name_inbox: { type: String, required: true },
   sign_msg: { type: Boolean, required: true },
+  sign_delimiter: { type: String, required: false },
   number: { type: String, required: true },
   reopen_conversation: { type: Boolean, required: true },
   conversation_pending: { type: Boolean, required: true },

--- a/src/whatsapp/services/chatwoot.service.ts
+++ b/src/whatsapp/services/chatwoot.service.ts
@@ -1019,7 +1019,13 @@ export class ChatwootService {
       this.logger.verbose('check if is group');
       const chatId =
         body.conversation.meta.sender?.phone_number?.replace('+', '') || body.conversation.meta.sender?.identifier;
-      const messageReceived = body.content;
+      // Alterado por Edison Martins em 16/12/2023
+      // const messageReceived = body.content;
+      const messageReceived = body.content
+        .replaceAll(/\*((?!\s)([^\n*]+?)(?<!\s))\*/g, '_$1_') // Substitui * por _
+        .replaceAll(/\*{2}((?!\s)([^\n*]+?)(?<!\s))\*{2}/g, '*$1*') // Substitui ** por *
+        .replace(/~{2}((?!\s)([^\n*]+?)(?<!\s))~{2}/g, '~$1~'); // Substitui ~~ por ~
+
       const senderName = body?.sender?.name;
       const waInstance = this.waMonitor.waInstances[instance.instanceName];
 
@@ -1470,7 +1476,15 @@ export class ChatwootService {
         }
 
         this.logger.verbose('get conversation message');
-        const bodyMessage = await this.getConversationMessage(body.message);
+
+        // Alterado por Edison Martins em 15/12/2023
+        // const bodyMessage = await this.getConversationMessage(body.message);
+        const bodyMessage = await this.getConversationMessage(body.message)
+          .replaceAll(/\*((?!\s)([^\n*]+?)(?<!\s))\*/g, '**$1**')
+          .replaceAll(/_((?!\s)([^\n_]+?)(?<!\s))_/g, '*$1*')
+          .replaceAll(/~((?!\s)([^\n~]+?)(?<!\s))~/g, '~~$1~~');
+
+        this.logger.verbose('body message: ' + bodyMessage);
 
         if (bodyMessage && bodyMessage.includes('Por favor, classifique esta conversa, http')) {
           this.logger.verbose('conversation is closed');

--- a/src/whatsapp/services/chatwoot.service.ts
+++ b/src/whatsapp/services/chatwoot.service.ts
@@ -1121,7 +1121,13 @@ export class ChatwootService {
         if (senderName === null || senderName === undefined) {
           formatText = messageReceived;
         } else {
-          formatText = this.provider.sign_msg ? `*${senderName}:*\n${messageReceived}` : messageReceived;
+          const formattedDelimiter = this.provider.sign_delimiter
+            ? this.provider.sign_delimiter.replaceAll('\\n', '\n')
+            : '\n';
+          const textToConcat = this.provider.sign_msg ? [`*${senderName}:*`] : [];
+          textToConcat.push(messageReceived);
+
+          formatText = textToConcat.join(formattedDelimiter);
         }
 
         for (const message of body.conversation.messages) {

--- a/src/whatsapp/services/chatwoot.service.ts
+++ b/src/whatsapp/services/chatwoot.service.ts
@@ -1019,8 +1019,6 @@ export class ChatwootService {
       this.logger.verbose('check if is group');
       const chatId =
         body.conversation.meta.sender?.phone_number?.replace('+', '') || body.conversation.meta.sender?.identifier;
-      // Alterado por Edison Martins em 16/12/2023
-      // const messageReceived = body.content;
       const messageReceived = body.content
         .replaceAll(/\*((?!\s)([^\n*]+?)(?<!\s))\*/g, '_$1_') // Substitui * por _
         .replaceAll(/\*{2}((?!\s)([^\n*]+?)(?<!\s))\*{2}/g, '*$1*') // Substitui ** por *
@@ -1483,8 +1481,6 @@ export class ChatwootService {
 
         this.logger.verbose('get conversation message');
 
-        // Alterado por Edison Martins em 15/12/2023
-        // const bodyMessage = await this.getConversationMessage(body.message);
         const bodyMessage = await this.getConversationMessage(body.message)
           .replaceAll(/\*((?!\s)([^\n*]+?)(?<!\s))\*/g, '**$1**')
           .replaceAll(/_((?!\s)([^\n_]+?)(?<!\s))_/g, '*$1*')

--- a/src/whatsapp/services/whatsapp.service.ts
+++ b/src/whatsapp/services/whatsapp.service.ts
@@ -357,10 +357,12 @@ export class WAStartupService {
     this.logger.verbose(`Chatwoot url: ${data.url}`);
     this.logger.verbose(`Chatwoot inbox name: ${data.name_inbox}`);
     this.logger.verbose(`Chatwoot sign msg: ${data.sign_msg}`);
+    this.logger.verbose(`Chatwoot sign delimiter: ${data.sign_delimiter}`);
     this.logger.verbose(`Chatwoot reopen conversation: ${data.reopen_conversation}`);
     this.logger.verbose(`Chatwoot conversation pending: ${data.conversation_pending}`);
 
-    Object.assign(this.localChatwoot, data);
+    Object.assign(this.localChatwoot, { ...data, sign_delimiter: data.sign_msg ? data.sign_delimiter : null });
+
     this.logger.verbose('Chatwoot set');
   }
 
@@ -378,6 +380,7 @@ export class WAStartupService {
     this.logger.verbose(`Chatwoot url: ${data.url}`);
     this.logger.verbose(`Chatwoot inbox name: ${data.name_inbox}`);
     this.logger.verbose(`Chatwoot sign msg: ${data.sign_msg}`);
+    this.logger.verbose(`Chatwoot sign delimiter: ${data.sign_delimiter}`);
     this.logger.verbose(`Chatwoot reopen conversation: ${data.reopen_conversation}`);
     this.logger.verbose(`Chatwoot conversation pending: ${data.conversation_pending}`);
 
@@ -388,6 +391,7 @@ export class WAStartupService {
       url: data.url,
       name_inbox: data.name_inbox,
       sign_msg: data.sign_msg,
+      sign_delimiter: data.sign_delimiter || null,
       reopen_conversation: data.reopen_conversation,
       conversation_pending: data.conversation_pending,
     };


### PR DESCRIPTION
Nesse PR foram feitas 2 coisas solicitadas pelo @edisoncm-ti

1. Corrigido a formatação do **Negrito**, _Italico_ e Sublinhado usando Regex
![image](https://github.com/EvolutionAPI/evolution-api/assets/58153955/255b79e4-8702-4247-b53d-1764aa7346e2)

2. Adicionado a propriedade `sign_delimiter` na configuração do Chatwoot, permitindo definir um delimitador diferente para a assinatura. Padrão quando não definido `\n`
![image](https://github.com/EvolutionAPI/evolution-api/assets/58153955/e80b4e6b-ff4d-4adb-a89b-72ad4d66a9e8)

Extra: Essa nova opção já foi adicionado ao Manager: https://github.com/EvolutionAPI/evolution-manager/pull/7
![image](https://github.com/EvolutionAPI/evolution-api/assets/58153955/70a7b24d-3959-4658-b376-0900db203800)
