### PR TITLE
Chatwoot format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,17 @@
 # 1.6.1 (develop)
 
+### Feature
+
+* New env `TYPEBOT_KEEP_OPEN` to keep the session open after the end of the flow
+* Add `sign_delimiter` to chatwoot set to change the delimiter of the signature
+
 ### Fixed
 
 * Fixed Lid Messages
 * Fixed sending variables to typebot
 * Fixed sending variables from typebot
 * Correction sending s3/minio media to chatwoot and typebot
+* Fixed message formatting in chatwoot (bold, italic, underline, monospace)
 
 # 1.6.0 (2023-12-12 17:24)
 
@@ -39,8 +45,8 @@
 
 ### Integrations
 
-- Chatwoot: v3.3.1
-- Typebot: v2.20.0
+* Chatwoot: v3.3.1
+* Typebot: v2.20.0
 
 # 1.5.4 (2023-10-09 20:43)
 
@@ -119,9 +125,9 @@
 
 ### Integrations
 
-- Chatwoot: v2.18.0 - v3.0.0
-- Typebot: v2.16.0
-- Manager Evolution API
+* Chatwoot: v2.18.0 - v3.0.0
+* Typebot: v2.16.0
+* Manager Evolution API
 
 # 1.4.8 (2023-07-27 10:27)
 
@@ -174,7 +180,7 @@
 
 ### Fixed
 
-* Fixed validation is set settings 
+* Fixed validation is set settings
 * Adjusts in group validations
 * Ajusts in sticker message to chatwoot
 
@@ -209,7 +215,7 @@
 
 ### Integrations
 
-- Chatwoot: v2.18.0 - v3.0.0 (Beta)
+* Chatwoot: v2.18.0 - v3.0.0 (Beta)
 
 # 1.3.2 (2023-07-21 17:19)
 
@@ -225,7 +231,7 @@
 
 ### Integrations
 
-- Chatwoot: v2.18.0
+* Chatwoot: v2.18.0
 
 # 1.3.1 (2023-07-20 07:48)
 
@@ -235,7 +241,7 @@
 
 ### Integrations
 
-- Chatwoot: v2.18.0
+* Chatwoot: v2.18.0
 
 # 1.3.0 (2023-07-19 11:33)
 
@@ -251,7 +257,7 @@
 * Translation set to default (english) in chatwoot
 
 ### Fixed
- 
+
 * Fixed error to send message in large groups
 * Docker files adjusted
 * Fixed in the postman collection the webhookByEvent parameter by webhook_by_events
@@ -272,7 +278,7 @@
 
 ### Integrations
 
-- Chatwoot: v2.18.0
+* Chatwoot: v2.18.0
 
 # 1.2.2 (2023-07-15 09:36)
 
@@ -283,7 +289,7 @@
 
 ### Integrations
 
-- Chatwoot: v2.18.0
+* Chatwoot: v2.18.0
 
 # 1.2.1 (2023-07-14 19:04)
 

--- a/src/whatsapp/services/chatwoot.service.ts
+++ b/src/whatsapp/services/chatwoot.service.ts
@@ -1019,10 +1019,12 @@ export class ChatwootService {
       this.logger.verbose('check if is group');
       const chatId =
         body.conversation.meta.sender?.phone_number?.replace('+', '') || body.conversation.meta.sender?.identifier;
+      // Chatwoot to Whatsapp
       const messageReceived = body.content
-        .replaceAll(/\*((?!\s)([^\n*]+?)(?<!\s))\*/g, '_$1_') // Substitui * por _
+        .replaceAll(/(?<!\*)\*((?!\s)([^\n*]+?)(?<!\s))\*(?!\*)/g, '_$1_') // Substitui * por _
         .replaceAll(/\*{2}((?!\s)([^\n*]+?)(?<!\s))\*{2}/g, '*$1*') // Substitui ** por *
-        .replace(/~{2}((?!\s)([^\n*]+?)(?<!\s))~{2}/g, '~$1~'); // Substitui ~~ por ~
+        .replaceAll(/~{2}((?!\s)([^\n*]+?)(?<!\s))~{2}/g, '~$1~') // Substitui ~~ por ~
+        .replaceAll(/(?<!`)`((?!\s)([^`*]+?)(?<!\s))`(?!`)/g, '```$1```'); // Substitui ` por ```
 
       const senderName = body?.sender?.name;
       const waInstance = this.waMonitor.waInstances[instance.instanceName];
@@ -1481,6 +1483,7 @@ export class ChatwootService {
 
         this.logger.verbose('get conversation message');
 
+        // Whatsapp to Chatwoot
         const bodyMessage = await this.getConversationMessage(body.message)
           .replaceAll(/\*((?!\s)([^\n*]+?)(?<!\s))\*/g, '**$1**')
           .replaceAll(/_((?!\s)([^\n_]+?)(?<!\s))_/g, '*$1*')


### PR DESCRIPTION
* Corrigido negrito: quando vinha do Chatwoot para o Whatsapp ele alterava o negrito para itálico e negrito
* Corrigido monoespacodo: Quando vinha do Chatwoot para o Whatsapp ele poderia enviar com 3 ou apenas 1 `, agora ele formata para o Whatsapp deixando sempre com 3`

* Adicionado as alterações ao Changelog
