### PR TITLE
Chatwoot Agent Name

### DIFF
--- a/src/whatsapp/services/chatwoot.service.ts
+++ b/src/whatsapp/services/chatwoot.service.ts
@@ -1028,7 +1028,7 @@ export class ChatwootService {
             .replaceAll(/(?<!`)`((?!\s)([^`*]+?)(?<!\s))`(?!`)/g, '```$1```') // Substitui ` por ```
         : body.content;
 
-      const senderName = body?.sender?.name;
+      const senderName = body?.sender?.available_name || body?.sender?.name;
       const waInstance = this.waMonitor.waInstances[instance.instanceName];
 
       this.logger.verbose('check if is a message deletion');


### PR DESCRIPTION
Esse PR muda o código para o nome usar o nome de exibição do agente preferencialmente ao invés do nome completo.
Mantendo o nome completo como "fallback" caso o nome de exibição não esteja definido

![image](https://github.com/EvolutionAPI/evolution-api/assets/58153955/dc9bf12d-9ec2-46d9-ba1c-1334a2267da7)
