### PR TITLE
Add options to disable docs and manager

### DIFF
--- a/src/config/env.config.ts
+++ b/src/config/env.config.ts
@@ -3,7 +3,13 @@ import { readFileSync } from 'fs';
 import { load } from 'js-yaml';
 import { join } from 'path';
 
-export type HttpServer = { TYPE: 'http' | 'https'; PORT: number; URL: string };
+export type HttpServer = {
+  TYPE: 'http' | 'https';
+  PORT: number;
+  URL: string;
+  DISABLE_DOCS: boolean;
+  DISABLE_MANAGER: boolean;
+};
 
 export type HttpMethods = 'POST' | 'GET' | 'PUT' | 'DELETE';
 export type Cors = {
@@ -186,6 +192,8 @@ export class ConfigService {
         TYPE: (process.env.SERVER_TYPE as 'http' | 'https') || 'http',
         PORT: Number.parseInt(process.env.SERVER_PORT) || 8080,
         URL: process.env.SERVER_URL,
+        DISABLE_DOCS: process.env?.SERVER_DISABLE_DOCS === 'true',
+        DISABLE_MANAGER: process.env?.SERVER_DISABLE_MANAGER === 'true',
       },
       CORS: {
         ORIGIN: process.env.CORS_ORIGIN.split(',') || ['*'],

--- a/src/dev-env.yml
+++ b/src/dev-env.yml
@@ -9,6 +9,9 @@ SERVER:
   TYPE: http # https
   PORT: 8080 # 443
   URL: localhost
+  DISABLE_MANAGER: false
+  DISABLE_DOCS: false
+
 
 CORS:
   ORIGIN:

--- a/src/main.ts
+++ b/src/main.ts
@@ -53,7 +53,8 @@ function bootstrap() {
   app.use('/store', express.static(join(ROOT_DIR, 'store')));
 
   app.use('/', router);
-  app.use(swaggerRouter);
+
+  if (!configService.get('SERVER').DISABLE_DOCS) app.use(swaggerRouter);
 
   app.use(
     (err: Error, req: Request, res: Response, next: NextFunction) => {


### PR DESCRIPTION
Adiciona 2 envs que permitem desativar o `/docs` e `/manager`, por padrão o manager e docs estão sempre ativados, para desativar é preciso adicionar no arquivo env

`DISABLE_DOCS=true`
`DISABLE_MANAGER=true`