### PR TITLE
fix(chatwoot): when possible use the original file extension

### DIFF
--- a/src/whatsapp/services/chatwoot.service.ts
+++ b/src/whatsapp/services/chatwoot.service.ts
@@ -1561,20 +1561,21 @@ export class ChatwootService {
             },
           });
 
-          let prependFilename: string;
-          if (
-            body?.message[body?.messageType]?.fileName ||
-            body?.message[body?.messageType]?.message?.documentMessage?.fileName
-          ) {
-            prependFilename = path.parse(
-              body?.message[body?.messageType]?.fileName ||
-                body?.message[body?.messageType]?.message?.documentMessage?.fileName,
-            ).name;
-            prependFilename += `-${Math.floor(Math.random() * (99 - 10 + 1) + 10)}`;
-          } else {
-            prependFilename = Math.random().toString(36).substring(7);
+          let nameFile: string;
+          const messageBody = body?.message[body?.messageType];
+          const originalFilename = messageBody?.fileName || messageBody?.message?.documentMessage?.fileName;
+          if (originalFilename) {
+            const parsedFile = path.parse(originalFilename);
+            if (parsedFile.name && parsedFile.ext) {
+              nameFile = `${parsedFile.name}-${Math.floor(Math.random() * (99 - 10 + 1) + 10)}${parsedFile.ext}`;
+            }
           }
-          const nameFile = `${prependFilename}.${mimeTypes.extension(downloadBase64.mimetype)}`;
+
+          if (!nameFile) {
+            nameFile = `${Math.random().toString(36).substring(7)}.${
+              mimeTypes.extension(downloadBase64.mimetype) || ''
+            }`;
+          }
 
           const fileData = Buffer.from(downloadBase64.base64, 'base64');
 


### PR DESCRIPTION
In some cases mimeTypes.extension() return false to csv and other file types