### PR TITLE
fix: Sending status message

### DIFF
--- a/src/whatsapp/services/whatsapp.service.ts
+++ b/src/whatsapp/services/whatsapp.service.ts
@@ -2434,6 +2434,21 @@ export class WAStartupService {
           );
         }
 
+        if (!message['audio'] && sender != 'status@broadcast') {
+          this.logger.verbose('Sending message');
+          return await this.client.sendMessage(
+            sender,
+            {
+              forward: {
+                key: { remoteJid: this.instance.wuid, fromMe: true },
+                message,
+              },
+              mentions,
+            },
+            option as unknown as MiscMessageGenerationOptions,
+          );
+        }
+
         if (sender === 'status@broadcast') {
           this.logger.verbose('Sending message');
           return await this.client.sendMessage(

--- a/src/whatsapp/services/whatsapp.service.ts
+++ b/src/whatsapp/services/whatsapp.service.ts
@@ -2420,21 +2420,6 @@ export class WAStartupService {
               option as unknown as MiscMessageGenerationOptions,
             );
           }
-
-          if (!message['audio']) {
-            this.logger.verbose('Sending message');
-            return await this.client.sendMessage(
-              sender,
-              {
-                forward: {
-                  key: { remoteJid: this.instance.wuid, fromMe: true },
-                  message,
-                },
-                mentions,
-              },
-              option as unknown as MiscMessageGenerationOptions,
-            );
-          }
         }
         if (message['conversation']) {
           this.logger.verbose('Sending message');
@@ -3097,6 +3082,8 @@ export class WAStartupService {
         if (!group) throw new BadRequestException('Group not found');
 
         onWhatsapp.push(new OnWhatsAppDto(group.id, !!group?.id, group?.subject));
+      } else if (jid === 'status@broadcast') {
+        onWhatsapp.push(new OnWhatsAppDto(jid, false));
       } else {
         jid = !jid.startsWith('+') ? `+${jid}` : jid;
         const verify = await this.client.onWhatsApp(jid);


### PR DESCRIPTION
Fixed when requested to publish status message, it goes into the condition of not being audio and also the jid is defined as "+status@broadcast"