### PR TITLE
Add number parameter to OnWhatsAppDto constructor

### DIFF
--- a/src/whatsapp/dto/chat.dto.ts
+++ b/src/whatsapp/dto/chat.dto.ts
@@ -1,7 +1,12 @@
 import { proto, WAPresence, WAPrivacyOnlineValue, WAPrivacyValue, WAReadReceiptsValue } from '@whiskeysockets/baileys';
 
 export class OnWhatsAppDto {
-  constructor(public readonly jid: string, public readonly exists: boolean, public readonly name?: string) {}
+  constructor(
+    public readonly jid: string,
+    public readonly exists: boolean,
+    public readonly number: string,
+    public readonly name?: string,
+  ) {}
 }
 
 export class getBase64FromMediaMessageDto {

--- a/src/whatsapp/services/whatsapp.service.ts
+++ b/src/whatsapp/services/whatsapp.service.ts
@@ -3137,9 +3137,9 @@ export class WAStartupService {
 
         if (!group) throw new BadRequestException('Group not found');
 
-        onWhatsapp.push(new OnWhatsAppDto(group.id, !!group?.id, group?.subject));
+        onWhatsapp.push(new OnWhatsAppDto(group.id, !!group?.id, number, group?.subject));
       } else if (jid === 'status@broadcast') {
-        onWhatsapp.push(new OnWhatsAppDto(jid, false));
+        onWhatsapp.push(new OnWhatsAppDto(jid, false, number));
       } else {
         jid = !jid.startsWith('+') ? `+${jid}` : jid;
         const verify = await this.client.onWhatsApp(jid);
@@ -3147,9 +3147,9 @@ export class WAStartupService {
         const result = verify[0];
 
         if (!result) {
-          onWhatsapp.push(new OnWhatsAppDto(jid, false));
+          onWhatsapp.push(new OnWhatsAppDto(jid, false, number));
         } else {
-          onWhatsapp.push(new OnWhatsAppDto(result.jid, result.exists));
+          onWhatsapp.push(new OnWhatsAppDto(result.jid, result.exists, number));
         }
       }
     }


### PR DESCRIPTION
When requesting if the Whatsapp number is valid, if the number sent contains the 9 digit from Brazil, and the result comes without that digit, there's no way to identify the number sent inside the response array.

With this change the response DTO will become like this:
![image](https://github.com/EvolutionAPI/evolution-api/assets/44608323/bd9d62c7-ee7f-40b5-a826-554b8cf1caee)

With that when the API returns the list of valid numbers I can identify that exact number I sent