### PR TITLE
Typebot: Remove quebra de linha no index final do array | Obtem a resposta de um sendList (Lista)

### DIFF
--- a/src/whatsapp/services/typebot.service.ts
+++ b/src/whatsapp/services/typebot.service.ts
@@ -274,6 +274,7 @@ export class TypebotService {
     const types = {
       conversation: msg.conversation,
       extendedTextMessage: msg.extendedTextMessage?.text,
+      responseRowId: msg.listResponseMessage.singleSelectReply?.selectedRowId,
     };
 
     this.logger.verbose('type message: ' + types);

--- a/src/whatsapp/services/typebot.service.ts
+++ b/src/whatsapp/services/typebot.service.ts
@@ -412,7 +412,7 @@ export class TypebotService {
         text += element.text;
       }
 
-      if (element.type === 'p' || element.type === 'inline-variable' || element.type === 'a') {
+      if (element.children && (element.type === 'p' || element.type === 'a' || element.type === 'inline-variable' || element.type === 'variable')) {
         for (const child of element.children) {
           text += applyFormatting(child);
         }


### PR DESCRIPTION
- Remove quebra de linha no index final do array

Foi realizada alteração para permitir a quebra de linha correta, quando usada em um array dentro de um script, como na imagem abaixo:

![image](https://github.com/EvolutionAPI/evolution-api/assets/135462452/427c65bb-02c1-458d-93fd-90bffd316ae7)

Quanto existe um \n no final da última linha do array **(1)**, o Typebot acabou criando um novo nó só com a quebra, mas sem a informação do nó children **(2)**. Isso alterou a estrutura que foi criada na Evo, que interpretou como não iterável, já que está fora do array.

- Obtem a resposta de um sendList (Lista)

Este é um recurso bastante pedido pelos usuários do Typebot e foi solicitado na Issue https://github.com/EvolutionAPI/evolution-api/issues/329, onde consta uma descrição mais detalhada da forma de uso.

