### PR TITLE
Fix with nine number brazil

### DIFF
--- a/src/whatsapp/services/chatwoot.service.ts
+++ b/src/whatsapp/services/chatwoot.service.ts
@@ -391,17 +391,17 @@ export class ChatwootService {
     }
 
     this.logger.verbose('find contact in chatwoot');
-    let contact: any = await client.contacts.search({
-      accountId: this.provider.account_id,
-      q: query,
-    });
+    let contact: any;
 
-    if (!contact && !isGroup && query.startsWith('+55') && query.length > 13) {
-      this.logger.verbose('trying without the 9th digit');
-      query = query.slice(0, 5) + query.slice(6);
+    if(isGroup) {
       contact = await client.contacts.search({
         accountId: this.provider.account_id,
         q: query,
+      });
+    } else {
+      contact = await client.contacts.filter({
+        accountId: this.provider.account_id,
+        payload: this.getFilterPayload(query),
       });
     }
 
@@ -410,13 +410,65 @@ export class ChatwootService {
       return null;
     }
 
-    if (!phoneNumber.includes('@g.us')) {
+    if (!isGroup) {
       this.logger.verbose('return contact');
-      return contact.payload.find((contact) => contact.phone_number === query);
+      return this.findContactInContactList(contact.payload, query);
     } else {
       this.logger.verbose('return group');
       return contact.payload.find((contact) => contact.identifier === query);
     }
+  }
+
+  private findContactInContactList(contacts: any[], query: string) {
+    const phoneNumbers = this.getNumbers(query);
+    const searchableFields = this.getSearchableFields();
+
+    for (const contact of contacts) {
+      for (const field of searchableFields) {
+        if (contact[field] && phoneNumbers.includes(contact[field])) {
+          return contact;
+        }
+      }
+    }
+
+    return null;
+  }
+
+  private getNumbers(query: string) {
+    const numbers = [];
+    numbers.push(query);
+
+    if (query.startsWith('+55') && query.length === 14) {
+      const withoutNine = query.slice(0, 5) + query.slice(6);
+      numbers.push(withoutNine);
+    } else if (query.startsWith('+55') && query.length === 13) {
+      const withNine = query.slice(0, 5) + '9' + query.slice(5);
+      numbers.push(withNine);
+    }
+
+    return numbers;
+  }
+
+  private getSearchableFields() {
+    return ['identifier', 'phone_number', 'name', 'email'];
+  }
+
+  private getFilterPayload(query: string) {
+    const payload = [];
+    const values = this.getNumbers(query)
+
+    const fields = this.getSearchableFields();
+    fields.forEach((key, index) => {
+      const queryOperator = fields.length - 1 === index ? null : 'OR';
+      payload.push({
+        "attribute_key": key,
+        "filter_operator": "contains",
+        "values": values,
+        "query_operator": queryOperator
+      });
+    });
+
+    return payload;
   }
 
   public async createConversation(instance: InstanceDto, body: any) {

--- a/src/whatsapp/services/chatwoot.service.ts
+++ b/src/whatsapp/services/chatwoot.service.ts
@@ -398,7 +398,7 @@ export class ChatwootService {
 
     if (!contact && !isGroup && query.startsWith('+55') && query.length > 13) {
       this.logger.verbose('trying without the 9th digit');
-      query = query.slice(0, 3) + query.slice(4);
+      query = query.slice(0, 5) + query.slice(6);
       contact = await client.contacts.search({
         accountId: this.provider.account_id,
         q: query,


### PR DESCRIPTION
Existe cenários onde é utilizado no ChatWoot com numeros que não são providos pela EvolutionAPI.
Por exemplo, na Cloud API, os numeros utilizados estão com 9.
Quando envia uma nova mensagem para esses números utilizando a EvolutionAPI, a mensagem é enviada normalmente, mas quando recebe, é criado um novo contato, pois o número está sem o 9.
Com isso, fiz a implementação para buscar novamente o número caso for DDI do Brasil, não pode ser grupo e que tenha mais de 13 caracteres.
+55 XX X XXXXXXXX

Será feito a remoção do 9 e feito uma nova busca no Chatwoot.