### PR TITLE
Fix/chatwoot validate 9 digit

### DIFF
--- a/src/whatsapp/services/chatwoot.service.ts
+++ b/src/whatsapp/services/chatwoot.service.ts
@@ -455,19 +455,22 @@ export class ChatwootService {
     const values = this.getNumbers(query);
 
     const fields = this.getSearchableFields();
-    fields.forEach((key, index) => {
-      const queryOperator = fields.length - 1 === index ? null : 'OR';
-      payload.push({
-        attribute_key: key,
-        filter_operator: 'contains',
-        values: values,
-        query_operator: queryOperator,
+
+    fields.forEach((field, index1) => {
+      values.forEach((number, index2) => {
+        const queryOperator = fields.length - 1 === index1 && values.length - 1 === index2 ? null : 'OR';
+        payload.push({
+          attribute_key: field,
+          filter_operator: 'contains',
+          values: [number],
+          query_operator: queryOperator,
+        });
       });
     });
 
+    this.logger.verbose('Payload: ' + JSON.stringify(payload));
     return payload;
   }
-
   public async createConversation(instance: InstanceDto, body: any) {
     this.logger.verbose('create conversation to instance: ' + instance.instanceName);
     try {

--- a/src/whatsapp/services/chatwoot.service.ts
+++ b/src/whatsapp/services/chatwoot.service.ts
@@ -447,29 +447,28 @@ export class ChatwootService {
   }
 
   private getSearchableFields() {
-    return ['identifier', 'phone_number', 'name', 'email'];
+    return ['phone_number'];
   }
 
   private getFilterPayload(query: string) {
-    const payload = [];
-    const values = this.getNumbers(query);
+    const filterPayload = [];
 
-    const fields = this.getSearchableFields();
+    const numbers = this.getNumbers(query);
+    const fieldsToSearch = this.getSearchableFields();
 
-    fields.forEach((field, index1) => {
-      values.forEach((number, index2) => {
-        const queryOperator = fields.length - 1 === index1 && values.length - 1 === index2 ? null : 'OR';
-        payload.push({
+    fieldsToSearch.forEach((field, index1) => {
+      numbers.forEach((number, index2) => {
+        const queryOperator = fieldsToSearch.length - 1 === index1 && numbers.length - 1 === index2 ? null : 'OR';
+        filterPayload.push({
           attribute_key: field,
-          filter_operator: 'contains',
-          values: [number],
+          filter_operator: 'equal_to',
+          values: [number.replace('+', '')],
           query_operator: queryOperator,
         });
       });
     });
 
-    this.logger.verbose('Payload: ' + JSON.stringify(payload));
-    return payload;
+    return filterPayload;
   }
   public async createConversation(instance: InstanceDto, body: any) {
     this.logger.verbose('create conversation to instance: ' + instance.instanceName);


### PR DESCRIPTION
Changed the search fields to only consider the phone_number, there is no need to search in all fields.
Changed payload format for the filter, each phone number must have its own payload, if you place it within the values array, chatwoot only searches for the first number disregarding the second, occasionally causing duplication of the contact.
Changed the filter_operator to equal_to, this will optimize the query as it will no longer use LIKE in the database query.
In the values array you must remove the + from the number as it is not stored in the DB.

PT-BR

Alterado os campos de procura para considerar somente o phone_number não há necessidade de procurar em todos os campos. 
Alterado formato do payload para o filtro, cada numero de telefone deve ter seu proprio payload, caso coloque dentro do array values o chatwoot só busca o primeiro numero desconsiderando o segundo, causando duplicação do contato ocasionalmente.
Alterado o filter_operator para equal_to, isso irá otimizar a consulta já que deixará de usar LIKE na query do banco.
No array values deve-se retirar o + do numero já que ele não é armazenado no DB.


Créditos:  [@yvescleuder](https://github.com/yvescleuder) 

Fix https://github.com/EvolutionAPI/evolution-api/pull/382 