### PR TITLE
Feat Chatwoot - Reject Message If is not a valid wpp number

### DIFF
--- a/src/utils/translations/en.json
+++ b/src/utils/translations/en.json
@@ -1,5 +1,6 @@
 {
   "qrgeneratedsuccesfully": "QRCode successfully generated!",
   "scanqr": "Scan this QR code within the next 40 seconds.",
-  "qrlimitreached": "QRCode generation limit reached, to generate a new QRCode, send the 'init' message again."
+  "qrlimitreached": "QRCode generation limit reached, to generate a new QRCode, send the 'init' message again.",
+  "numbernotinwhatsapp": "The message was not sent as the contact is not a valid Whatsapp number."
 }

--- a/src/utils/translations/pt-BR.json
+++ b/src/utils/translations/pt-BR.json
@@ -1,5 +1,6 @@
 {
   "qrgeneratedsuccesfully": "QRCode gerado com sucesso!",
   "scanqr": "Escanei o QRCode com o Whatsapp nos próximos 40 segundos.",
-  "qrlimitreached": "Limite de geração de QRCode atingido! Para gerar um novo QRCode, envie o texto 'init' nesta conversa."
+  "qrlimitreached": "Limite de geração de QRCode atingido! Para gerar um novo QRCode, envie o texto 'init' nesta conversa.",
+  "numbernotinwhatsapp": "A mensagem não foi enviada, pois o contato não é um número válido do Whatsapp."
 }

--- a/src/whatsapp/services/chatwoot.service.ts
+++ b/src/whatsapp/services/chatwoot.service.ts
@@ -1684,6 +1684,27 @@ export class ChatwootService {
         return null;
       }
 
+      if (event === 'contact.is_not_in_wpp') {
+        const getConversation = await this.createConversation(instance, body);
+
+        if (!getConversation) {
+          this.logger.warn('conversation not found');
+          return;
+        }
+
+        client.messages.create({
+          accountId: this.provider.account_id,
+          conversationId: getConversation,
+          data: {
+            content: `🚨 ${i18next.t('numbernotinwhatsapp')}`,
+            message_type: 'incoming',
+            private: true,
+          },
+        });
+
+        return;
+      }
+
       if (event === 'messages.upsert' || event === 'send.message') {
         this.logger.verbose('event messages.upsert');
 

--- a/src/whatsapp/services/chatwoot.service.ts
+++ b/src/whatsapp/services/chatwoot.service.ts
@@ -1697,7 +1697,7 @@ export class ChatwootService {
           conversationId: getConversation,
           data: {
             content: `🚨 ${i18next.t('numbernotinwhatsapp')}`,
-            message_type: 'incoming',
+            message_type: 'outgoing',
             private: true,
           },
         });

--- a/src/whatsapp/services/whatsapp.service.ts
+++ b/src/whatsapp/services/whatsapp.service.ts
@@ -2357,7 +2357,15 @@ export class WAStartupService {
     const isWA = (await this.whatsappNumber({ numbers: [number] }))?.shift();
 
     this.logger.verbose(`Exists: "${isWA.exists}" | jid: ${isWA.jid}`);
+
     if (!isWA.exists && !isJidGroup(isWA.jid) && !isWA.jid.includes('@broadcast')) {
+      if (this.localChatwoot.enabled) {
+        const body = {
+          key: { remoteJid: isWA.jid },
+        };
+
+        this.chatwootService.eventWhatsapp('contact.is_not_in_wpp', { instanceName: this.instance.name }, body);
+      }
       throw new BadRequestException(isWA);
     }
 


### PR DESCRIPTION
If a message is sent to a number that does not exist on WhatsApp, a private error message will be returned informing the user that the message was not delivered.

PT-BR

Caso seja enviado uma mensagem para um numero que não exite no whatsapp será devolvido uma mensagem privada de erro informando o usuário que aquela mensagem não foi entregue.

![image](https://github.com/EvolutionAPI/evolution-api/assets/1278305/2ef91e51-b65b-43d9-87b3-62332a997f2c)
