### PR TITLE
Fix groups_ignore when sending property with false

### DIFF
--- a/src/whatsapp/controllers/instance.controller.ts
+++ b/src/whatsapp/controllers/instance.controller.ts
@@ -338,7 +338,7 @@ export class InstanceController {
       const settings: wa.LocalSettings = {
         reject_call: reject_call || false,
         msg_call: msg_call || '',
-        groups_ignore: groups_ignore || true,
+        groups_ignore: groups_ignore || false,
         always_online: always_online || false,
         read_messages: read_messages || false,
         read_status: read_status || false,


### PR DESCRIPTION
When creating instance, when groups_ignore is not provided or when it is provided with a value equal to false, the persisted value must be equal to false.