### PR TITLE
Improvement on whatsapp number validation

### DIFF
--- a/src/whatsapp/routers/chat.router.ts
+++ b/src/whatsapp/routers/chat.router.ts
@@ -60,7 +60,7 @@ export class ChatRouter extends RouterBroker {
           execute: (instance, data) => chatController.whatsappNumber(instance, data),
         });
 
-        return res.status(HttpStatus.CREATED).json(response);
+        return res.status(HttpStatus.OK).json(response);
       })
       .put(this.routerPath('markMessageAsRead'), ...guards, async (req, res) => {
         logger.verbose('request received in markMessageAsRead');


### PR DESCRIPTION
Currently, for every number checked, a database call is made to verify if the JID is saved and to return the name, but this can be improved to check everything only once.

In the current code, checking 92 numbers took 750ms, as shown here:
![CleanShot 2024-02-07 at 08 46 37@2x](https://github.com/EvolutionAPI/evolution-api/assets/44608323/228f293f-49b0-4c34-a353-99fb8b19bee2)

With the current improvement, checking the same 92 numbers results in a 321ms request:
![CleanShot 2024-02-07 at 08 51 06](https://github.com/EvolutionAPI/evolution-api/assets/44608323/1af58187-f2ff-4b4f-bb4e-86d9f24cdbb6)

The more numbers you send, the slower it becomes.