### PR TITLE
Temp instance deletion

### DIFF
--- a/src/utils/i18n.ts
+++ b/src/utils/i18n.ts
@@ -4,8 +4,6 @@ import path from 'path';
 
 import { ConfigService, Language } from '../config/env.config';
 
-// export class i18n {
-//   constructor(private readonly configService: ConfigService) {
 const languages = ['en', 'pt-BR'];
 const translationsPath = path.join(__dirname, 'translations');
 const configService: ConfigService = new ConfigService();
@@ -31,6 +29,4 @@ i18next.init({
     escapeValue: false,
   },
 });
-//   }
-// }
 export default i18next;

--- a/src/whatsapp/abstract/abstract.router.ts
+++ b/src/whatsapp/abstract/abstract.router.ts
@@ -21,7 +21,6 @@ const logger = new Logger('Validate');
 export abstract class RouterBroker {
   constructor() {}
   public routerPath(path: string, param = true) {
-    // const route = param ? '/:instanceName/' + path : '/' + path;
     let route = '/' + path;
     param ? (route += '/:instanceName') : null;
 
@@ -56,10 +55,6 @@ export abstract class RouterBroker {
           message = stack.replace('instance.', '');
         }
         return message;
-        // return {
-        //   property: property.replace('instance.', ''),
-        //   message,
-        // };
       });
       logger.error(message);
       throw new BadRequestException(message);

--- a/src/whatsapp/controllers/settings.controller.ts
+++ b/src/whatsapp/controllers/settings.controller.ts
@@ -1,7 +1,4 @@
-// import { isURL } from 'class-validator';
-
 import { Logger } from '../../config/logger.config';
-// import { BadRequestException } from '../../exceptions';
 import { InstanceDto } from '../dto/instance.dto';
 import { SettingsDto } from '../dto/settings.dto';
 import { SettingsService } from '../services/settings.service';

--- a/src/whatsapp/routers/chatwoot.router.ts
+++ b/src/whatsapp/routers/chatwoot.router.ts
@@ -5,7 +5,6 @@ import { chatwootSchema, instanceNameSchema } from '../../validate/validate.sche
 import { RouterBroker } from '../abstract/abstract.router';
 import { ChatwootDto } from '../dto/chatwoot.dto';
 import { InstanceDto } from '../dto/instance.dto';
-// import { ChatwootService } from '../services/chatwoot.service';
 import { chatwootController } from '../whatsapp.module';
 import { HttpStatus } from './index.router';
 

--- a/src/whatsapp/routers/settings.router.ts
+++ b/src/whatsapp/routers/settings.router.ts
@@ -5,7 +5,6 @@ import { instanceNameSchema, settingsSchema } from '../../validate/validate.sche
 import { RouterBroker } from '../abstract/abstract.router';
 import { InstanceDto } from '../dto/instance.dto';
 import { SettingsDto } from '../dto/settings.dto';
-// import { SettingsService } from '../services/settings.service';
 import { settingsController } from '../whatsapp.module';
 import { HttpStatus } from './index.router';
 

--- a/src/whatsapp/services/chatwoot.service.ts
+++ b/src/whatsapp/services/chatwoot.service.ts
@@ -51,11 +51,6 @@ export class ChatwootService {
     this.cache.set(cacheKey, provider);
 
     return provider;
-    // try {
-    // } catch (error) {
-    //   this.logger.error('provider not found');
-    //   return null;
-    // }
   }
 
   private async clientCw(instance: InstanceDto) {
@@ -389,10 +384,6 @@ export class ChatwootService {
         q: query,
       });
     } else {
-      // contact = await client.contacts.filter({
-      //   accountId: this.provider.account_id,
-      //   payload: this.getFilterPayload(query),
-      // });
       // hotfix for: https://github.com/EvolutionAPI/evolution-api/pull/382. waiting fix: https://github.com/figurolatam/chatwoot-sdk/pull/7
       contact = await chatwootRequest(this.getClientCwConfig(), {
         method: 'POST',
@@ -1194,7 +1185,6 @@ export class ChatwootService {
           if (state !== 'open') {
             if (state === 'close') {
               this.logger.verbose('request cleaning up instance: ' + instance.instanceName);
-              // await this.waMonitor.cleaningUp(instance.instanceName);
             }
             this.logger.verbose('connect to whatsapp');
             const number = command.split(':')[1];

--- a/src/whatsapp/services/monitor.service.ts
+++ b/src/whatsapp/services/monitor.service.ts
@@ -2,22 +2,19 @@ import { execSync } from 'child_process';
 import EventEmitter2 from 'eventemitter2';
 import { opendirSync, readdirSync, rmSync } from 'fs';
 import { Db } from 'mongodb';
+import { Collection } from 'mongoose';
 import { join } from 'path';
 
 import { Auth, ConfigService, Database, DelInstance, HttpServer, Redis } from '../../config/env.config';
 import { Logger } from '../../config/logger.config';
 import { INSTANCE_DIR, STORE_DIR } from '../../config/path.config';
 import { NotFoundException } from '../../exceptions';
-import { dbserver } from '../../libs/db.connect';
 import { RedisCache } from '../../libs/redis.client';
 import {
   AuthModel,
   ChamaaiModel,
-  // ChatModel,
   ChatwootModel,
-  // ContactModel,
-  // MessageModel,
-  // MessageUpModel,
+  ContactModel,
   ProxyModel,
   RabbitmqModel,
   SettingsModel,
@@ -41,7 +38,6 @@ export class WAMonitoringService {
 
     this.removeInstance();
     this.noConnection();
-    // this.delInstanceFiles();
 
     Object.assign(this.db, configService.get<Database>('DATABASE'));
     Object.assign(this.redis, configService.get<Redis>('REDIS'));
@@ -55,8 +51,6 @@ export class WAMonitoringService {
   private readonly redis: Partial<Redis> = {};
 
   private dbInstance: Db;
-
-  private dbStore = dbserver;
 
   private readonly logger = new Logger(WAMonitoringService.name);
   public readonly waInstances: Record<string, WAStartupService> = {};
@@ -326,11 +320,6 @@ export class WAMonitoringService {
 
     this.logger.verbose('cleaning store database instance: ' + instanceName);
 
-    // await ChatModel.deleteMany({ owner: instanceName });
-    // await ContactModel.deleteMany({ owner: instanceName });
-    // await MessageUpModel.deleteMany({ owner: instanceName });
-    // await MessageModel.deleteMany({ owner: instanceName });
-
     await AuthModel.deleteMany({ _id: instanceName });
     await WebhookModel.deleteMany({ _id: instanceName });
     await ChatwootModel.deleteMany({ _id: instanceName });
@@ -340,6 +329,7 @@ export class WAMonitoringService {
     await TypebotModel.deleteMany({ _id: instanceName });
     await WebsocketModel.deleteMany({ _id: instanceName });
     await SettingsModel.deleteMany({ _id: instanceName });
+    await ContactModel.deleteMany({ owner: instanceName });
 
     return;
   }
@@ -393,7 +383,7 @@ export class WAMonitoringService {
     this.logger.verbose('Database enabled');
     await this.repository.dbServer.connect();
     const collections: any[] = await this.dbInstance.collections();
-
+    await this.deleteTempInstances(collections);
     if (collections.length > 0) {
       this.logger.verbose('Reading collections and setting instances');
       await Promise.all(collections.map((coll) => this.setInstance(coll.namespace.replace(/^[\w-]+\./, ''))));
@@ -481,5 +471,23 @@ export class WAMonitoringService {
         this.logger.warn(`Instance "${instanceName}" - NOT CONNECTION`);
       }
     });
+  }
+
+  private async deleteTempInstances(collections: Collection<Document>[]) {
+    this.logger.verbose('Cleaning up temp instances');
+    const auths = await this.repository.auth.list();
+    if (auths.length === 0) {
+      this.logger.verbose('No temp instances found');
+      return;
+    }
+    let tempInstances = 0;
+    auths.forEach((auth) => {
+      if (collections.find((coll) => coll.namespace.replace(/^[\w-]+\./, '') === auth._id)) {
+        return;
+      }
+      tempInstances++;
+      this.eventEmitter.emit('remove.instance', auth._id, 'inner');
+    });
+    this.logger.verbose('Temp instances removed: ' + tempInstances);
   }
 }


### PR DESCRIPTION
When we create an instance and don't read the QR code, some documents are created in the database but not in the instance collection. As a result, after restarting the API, the instance disappears but the database still retains some leftover data.

![CleanShot 2024-02-07 at 16 41 24](https://github.com/EvolutionAPI/evolution-api/assets/44608323/509564c3-394a-4161-8347-ca8d9dd6204e)
![CleanShot 2024-02-07 at 16 42 08](https://github.com/EvolutionAPI/evolution-api/assets/44608323/02351c7c-71aa-466b-9950-5ff00c7741c6)
![CleanShot 2024-02-07 at 16 42 43](https://github.com/EvolutionAPI/evolution-api/assets/44608323/ffc75f1d-e05d-40d3-8e89-d1c2380d3b37)

And after we restart the API:
![CleanShot 2024-02-07 at 16 44 13](https://github.com/EvolutionAPI/evolution-api/assets/44608323/6ac53473-05c0-42b5-a053-d4765234f995)


---
With this change, when starting the API, it will check all documents from the 'auth' collection and compare if the instance exists.
![CleanShot 2024-02-07 at 16 45 27](https://github.com/EvolutionAPI/evolution-api/assets/44608323/08db6869-19f1-43fb-b1f8-c8cacc2518da)


Also, some commented sections have been cleaned.