### PR TITLE
Changed label update to chat instead of contacts

### DIFF
--- a/src/whatsapp/models/chat.model.ts
+++ b/src/whatsapp/models/chat.model.ts
@@ -7,6 +7,7 @@ export class ChatRaw {
   id?: string;
   owner: string;
   lastMsgTimestamp?: number;
+  labels?: string[];
 }
 
 type ChatRawBoolean<T> = {
@@ -18,6 +19,7 @@ const chatSchema = new Schema<ChatRaw>({
   _id: { type: String, _id: true },
   id: { type: String, required: true, minlength: 1 },
   owner: { type: String, required: true, minlength: 1 },
+  labels: { type: [String], default: [] },
 });
 
 export const ChatModel = dbserver?.model(ChatRaw.name, chatSchema, 'chats');

--- a/src/whatsapp/models/contact.model.ts
+++ b/src/whatsapp/models/contact.model.ts
@@ -8,7 +8,6 @@ export class ContactRaw {
   id?: string;
   profilePictureUrl?: string;
   owner: string;
-  labels?: string[];
 }
 
 type ContactRawBoolean<T> = {
@@ -22,7 +21,6 @@ const contactSchema = new Schema<ContactRaw>({
   id: { type: String, required: true, minlength: 1 },
   profilePictureUrl: { type: String, minlength: 1 },
   owner: { type: String, required: true, minlength: 1 },
-  labels: { type: [String], default: [] },
 });
 
 export const ContactModel = dbserver?.model(ContactRaw.name, contactSchema, 'contacts');


### PR DESCRIPTION
This is a hotfix for this PR: https://github.com/EvolutionAPI/evolution-api/pull/409

In this change we removed the label save to contact, since the return is chat and not contact and added the label list to chat fetch (if save chat is enabled)

Change on the `/chat/findChats/{instance}` endpoint:
Added labels associated array
![CleanShot 2024-02-08 at 15 41 17](https://github.com/EvolutionAPI/evolution-api/assets/44608323/96d4a60e-d319-4129-9ee4-d9fe44d282e6)


Also, the webhook **labels.association** changed the `jid` to `chatId` for better understanding.