### PR TITLE
Implement contact upsert in messaging-history.set

### DIFF
--- a/src/whatsapp/services/whatsapp.service.ts
+++ b/src/whatsapp/services/whatsapp.service.ts
@@ -1734,6 +1734,7 @@ export class WAStartupService {
       {
         messages,
         chats,
+        contacts,
       }: {
         chats: Chat[];
         contacts: Contact[];
@@ -1846,6 +1847,17 @@ export class WAStartupService {
           );
         }
 
+        await this.contactHandle['contacts.upsert'](
+          contacts
+            .filter((c) => !!c.notify ?? !!c.name)
+            .map((c) => ({
+              id: c.id,
+              name: c.name ?? c.notify,
+            })),
+          database,
+        );
+
+        contacts = undefined;
         messages = undefined;
         chats = undefined;
       } catch (error) {


### PR DESCRIPTION
In some connections, the event `contacts.upsert` is not called, and the contacts are not saved in the database.

With this change, we call the `contacts.upsert` with the contacts received in the message history (`messaging-history.set`). This is only called if the contact received has a name, to avoid replacing preexisting contacts with a name.

To make it work properly, the setting `sync_full_history` must be enabled (check this issue from Baileys: [Baileys Issue #470](https://github.com/WhiskeySockets/Baileys/issues/470)).

Also, with this change, it will save all contacts that you have messaged with, and not only your saved contacts.

Check some issues with this error from the Baileys repo:
[Baileys Issue #522](https://github.com/WhiskeySockets/Baileys/issues/522)
[Baileys Issue #121](https://github.com/WhiskeySockets/Baileys/issues/121)