### PR TITLE
Improve proxy error handling

### DIFF
--- a/src/whatsapp/controllers/proxy.controller.ts
+++ b/src/whatsapp/controllers/proxy.controller.ts
@@ -59,6 +59,9 @@ export class ProxyController {
     } catch (error) {
       if (axios.isAxiosError(error) && error.response?.data) {
         logger.error('testProxy error: ' + error.response.data);
+      } else if (axios.isAxiosError(error)) {
+        logger.error('testProxy error: ');
+        logger.verbose(error.cause ?? error.message);
       } else {
         logger.error('testProxy error: ');
         logger.verbose(error);

--- a/src/whatsapp/controllers/proxy.controller.ts
+++ b/src/whatsapp/controllers/proxy.controller.ts
@@ -57,11 +57,12 @@ export class ProxyController {
       logger.verbose('[testProxy] from IP: ' + response?.data + ' To IP: ' + serverIp?.data);
       return response?.data !== serverIp?.data;
     } catch (error) {
-      let errorMessage = error;
-      if (axios.isAxiosError(error) && error.response.data) {
-        errorMessage = error.response.data;
+      if (axios.isAxiosError(error) && error.response?.data) {
+        logger.error('testProxy error: ' + error.response.data);
+      } else {
+        logger.error('testProxy error: ');
+        logger.verbose(error);
       }
-      logger.error('testProxy error: ' + errorMessage);
       return false;
     }
   }

--- a/src/whatsapp/controllers/proxy.controller.ts
+++ b/src/whatsapp/controllers/proxy.controller.ts
@@ -26,11 +26,11 @@ export class ProxyController {
     }
 
     if (data.proxy) {
-      logger.verbose('proxy enabled');
       const testProxy = await this.testProxy(data.proxy);
       if (!testProxy) {
         throw new BadRequestException('Invalid proxy');
       }
+      logger.verbose('proxy enabled');
     }
 
     return this.proxyService.create(instance, data);
@@ -54,8 +54,8 @@ export class ProxyController {
         httpsAgent: makeProxyAgent(proxy),
       });
 
-      logger.verbose('testProxy response: ' + response.data);
-      return response.data !== serverIp.data;
+      logger.verbose('[testProxy] from IP: ' + response?.data + ' To IP: ' + serverIp?.data);
+      return response?.data !== serverIp?.data;
     } catch (error) {
       let errorMessage = error;
       if (axios.isAxiosError(error) && error.response.data) {


### PR DESCRIPTION
The application logs `proxy enabled` before conducting the proxy tests. In some cases, the request doesn't return any error, but the data is not accessible. An additional handler has been added for that.