### PR TITLE
Refactor fetching participants for group in WhatsApp service

### DIFF
--- a/src/whatsapp/services/whatsapp.service.ts
+++ b/src/whatsapp/services/whatsapp.service.ts
@@ -4077,7 +4077,19 @@ export class WAStartupService {
     this.logger.verbose('Fetching participants for group: ' + id.groupJid);
     try {
       const participants = (await this.client.groupMetadata(id.groupJid)).participants;
-      return { participants };
+      const contacts = await this.repository.contact.findManyById({
+        owner: this.instance.name,
+        ids: participants.map((p) => p.id),
+      });
+      const parsedParticipants = participants.map((participant) => {
+        const contact = contacts.find((c) => c.id === participant.id);
+        return {
+          ...participant,
+          name: participant.name ?? contact?.pushName,
+          imgUrl: participant.imgUrl ?? contact?.profilePictureUrl,
+        };
+      });
+      return { participants: parsedParticipants };
     } catch (error) {
       throw new NotFoundException('No participants', error.toString());
     }


### PR DESCRIPTION
Currently, the return of the group participants list exactly mirrors what is returned from WhatsApp. In this pull request, we have added a function to check the database for saved contacts. If the participant's name or profile picture doesn't exist but is present in the database, we will use the saved data instead of returning null or empty.