### PR TITLE
fix(chatwoot): fix when receiving/sending messages from whatsapp desktop with ephemeral messages enabled

### DIFF
--- a/src/whatsapp/services/chatwoot.service.ts
+++ b/src/whatsapp/services/chatwoot.service.ts
@@ -1774,6 +1774,13 @@ export class ChatwootService {
           return;
         }
 
+        // fix when receiving/sending messages from whatsapp desktop with ephemeral messages enabled
+        if (body.message?.ephemeralMessage?.message) {
+          body.message = {
+            ...body.message?.ephemeralMessage?.message,
+          };
+        }
+
         this.logger.verbose('get conversation message');
 
         // Whatsapp to Chatwoot


### PR DESCRIPTION
Acredito que isso deve ser um bug na própria baileys mas pelo que verifiquei, usando o WhatsApp desktop com mensagens temporárias habilitadas, o padrão de mensagem que recebemos é diferente.

Este ajuste apenas contorna este formato fora do padrão. Um pouco gambiarra mas faz parte rs