### PR TITLE
fix(chatwoot): error: invalid operator. The allowed operators for identifier are [equal_to,not_equal_to]

### DIFF
--- a/src/api/integrations/chatwoot/services/chatwoot.service.ts
+++ b/src/api/integrations/chatwoot/services/chatwoot.service.ts
@@ -461,7 +461,7 @@ export class ChatwootService {
         const queryOperator = fieldsToSearch.length - 1 === index1 && numbers.length - 1 === index2 ? null : 'OR';
         filterPayload.push({
           attribute_key: field,
-          filter_operator: field == 'phone_number' ? 'equal_to' : 'contains',
+          filter_operator: ['phone_number', 'identifier'].includes(field) ? 'equal_to' : 'contains',
           values: [number.replace('+', '')],
           query_operator: queryOperator,
         });


### PR DESCRIPTION
In chatwoot version 3.8 we can't use the filter operator 'contains' for the field 'identifier'