### PR TITLE
Adicionado message.status ao webhook MESSAGES_SET

### DIFF
--- a/src/api/models/message.model.ts
+++ b/src/api/models/message.model.ts
@@ -32,6 +32,7 @@ export class MessageRaw {
   source_reply_id?: string;
   chatwoot?: ChatwootMessage;
   contextInfo?: any;
+  status?: wa.StatusMessage | any;
 }
 
 type MessageRawBoolean<T> = {

--- a/src/api/services/whatsapp/whatsapp.baileys.service.ts
+++ b/src/api/services/whatsapp/whatsapp.baileys.service.ts
@@ -976,6 +976,15 @@ export class BaileysStartupService extends WAStartupService {
             continue;
           }
 
+          const status: Record<number, wa.StatusMessage> = {
+            0: 'ERROR',
+            1: 'PENDING',
+            2: 'SERVER_ACK',
+            3: 'DELIVERY_ACK',
+            4: 'READ',
+            5: 'PLAYED',
+          };
+
           messagesRaw.push({
             key: m.key,
             pushName: m.pushName || m.key.remoteJid.split('@')[0],
@@ -984,6 +993,7 @@ export class BaileysStartupService extends WAStartupService {
             messageType: getContentType(m.message),
             messageTimestamp: m.messageTimestamp as number,
             owner: this.instance.name,
+            status: m.status ? status[m.status] : null,
           });
         }
 


### PR DESCRIPTION
Ajuste para adicionar o status da mensagem junto ao webhook `MESSAGES_SET`, disparado com o evento `messaging-history.set` da baileys.

Ajuste visando facilitar a identificação do status da mensagem (pendente, entregue, lido, ...)  no momento da importação do histórico.

Estou utilizando esse ajuste no meu fork a algum tempo, tem funcionado sem problemas.

-----

**O que muda?**
Um novo campo `status` é enviado no conteudo do webhook MESSAGES_SET, possiveis valores são:
```javascript
 'ERROR' | 'PENDING' | 'SERVER_ACK' | 'DELIVERY_ACK' | 'READ' | 'PLAYED'
```

_(basicamente os valores disponiveis em wa.StatusMessage no formato de string.)_

Obs.: Não consegui testar com Chatwoot e Typebot, utilizo apenas a api "pura"