### PR TITLE
chore: build docker image to platforms: linux/amd64, linux/arm64

### DIFF
--- a/.github/workflows/publish_docker_image.yml
+++ b/.github/workflows/publish_docker_image.yml
@@ -2,63 +2,52 @@ name: Build Docker image
 
 on:
   push:
-    tags: ['v*']
+    branches:
+      - develop
+      - main
+    tags:
+      - v*
+  workflow_dispatch:
 
 jobs:
-  build-amd:
+  build:
     runs-on: ubuntu-latest
+    env:
+      GIT_REF: ${{ github.head_ref || github.ref_name }} # ref_name to get tags/branches
+    permissions:
+      contents: read
+      packages: write
     steps:
-      - name: Check out the repo
-        uses: actions/checkout@v3
+      - name: Checkout
+        uses: actions/checkout@v4
 
-      - name: Extract existing image metadata
-        id: image-meta
-        uses: docker/metadata-action@v4
-        with:
-          images: atendai/evolution-api
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
 
-      - name: Log in to Docker Hub
-        uses: docker/login-action@v2
+      - name: set docker tag
+        run: |
+          echo "DOCKER_TAG=ghcr.io/stack-app-br/evolution-api:$GIT_REF" >> $GITHUB_ENV
+
+      - name: replace docker tag if main
+        if: github.ref_name == 'main'
+        run: |
+          echo "DOCKER_TAG=ghcr.io/stack-app-br/evolution-api:latest" >> $GITHUB_ENV
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build and push AMD image
-        uses: docker/build-push-action@v4
-        with:
-          context: .
-          labels: ${{ steps.image-meta.outputs.labels }}
-          platforms: linux/amd64
-          push: true
-
-  build-arm:
-    runs-on: buildjet-4vcpu-ubuntu-2204-arm
-    steps:
-      - name: Check out the repo
-        uses: actions/checkout@v3
-
-      - name: Extract existing image metadata
-        id: image-meta
-        uses: docker/metadata-action@v4
-        with:
-          images: atendai/evolution-api
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-
-      - name: Log in to Docker Hub
-        uses: docker/login-action@v2
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
-
-      - name: Build and push ARM image
-        uses: docker/build-push-action@v4
+      - name: Build and push
+        uses: docker/build-push-action@v2
         with:
           context: .
-          labels: ${{ steps.image-meta.outputs.labels }}
-          platforms: linux/arm64
+          file: ./Dockerfile
+          platforms: linux/amd64,linux/arm64
           push: true
+          tags: ${{ env.DOCKER_TAG }}


### PR DESCRIPTION
Sugestão de build automatizado das imagens amd64 e arm64.
Esse exemplo usa o próprio GitHub como register para as imagens.
Esse é o resultado final: https://github.com/stack-app-br/evolution-api/pkgs/container/evolution-api

PS: Precisa atualizar o DOCKER_TAG se vcs resolverem adotar essa abordagem.
Enviar para o docker hub também não é muito diferente.