### PR TITLE
Fix: getOpenConversationByContact and init queries error

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "amqplib": "^0.10.3",
     "aws-sdk": "^2.1499.0",
     "axios": "^1.6.5",
-    "baileys": "^6.7.1",
+    "baileys": "^6.7.2",
     "class-validator": "^0.14.1",
     "compression": "^1.7.4",
     "cors": "^2.8.5",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "amqplib": "^0.10.3",
     "aws-sdk": "^2.1499.0",
     "axios": "^1.6.5",
-    "baileys": "^6.7.0",
+    "baileys": "^6.7.1",
     "class-validator": "^0.14.1",
     "compression": "^1.7.4",
     "cors": "^2.8.5",

--- a/src/api/integrations/chatwoot/services/chatwoot.service.ts
+++ b/src/api/integrations/chatwoot/services/chatwoot.service.ts
@@ -789,26 +789,15 @@ export class ChatwootService {
       return null;
     }
 
-    const payload = [
-      ['inbox_id', inbox.id.toString()],
-      ['contact_id', contact.id.toString()],
-      ['status', 'open'],
-    ];
+    const conversations = (await client.contacts.listConversations({
+      accountId: this.provider.account_id,
+      id: contact.id,
+    })) as any;
 
     return (
-      (
-        (await client.conversations.filter({
-          accountId: this.provider.account_id,
-          payload: payload.map((item, i, payload) => {
-            return {
-              attribute_key: item[0],
-              filter_operator: 'equal_to',
-              values: [item[1]],
-              query_operator: i < payload.length - 1 ? 'AND' : null,
-            };
-          }),
-        })) as { payload: conversation[] }
-      ).payload[0] || undefined
+      conversations.payload.find(
+        (conversation) => conversation.inbox_id === inbox.id && conversation.status === 'open',
+      ) || undefined
     );
   }
 


### PR DESCRIPTION
Atualizado Baileys para corrigir o erro de 'init queries' https://github.com/WhiskeySockets/Baileys/issues/764

Refatorado o método getOpenConversationByContact, o chatwoot alterou sua api de filtro de conversas e não aceita mais o parâmetro contact_id, com isso não é mais possível buscar conversas abertas para o contato especifico, portanto, foi alterado para a api de contacts para buscar as conversas do contato e filtrar a conversa aberta.
Esse erro impacta a geração e envio do QR Code para o chatwoot e mensagens do 'Bot' +123456.


![image](https://github.com/EvolutionAPI/evolution-api/assets/1278305/b06d78e1-0f7b-4b7c-8324-a65c6dbd3706)
