### PR TITLE
refactor(chatwoot): optimize ChatwootService method for updating contact inform…

### DIFF
--- a/src/api/integrations/chatwoot/services/chatwoot.service.ts
+++ b/src/api/integrations/chatwoot/services/chatwoot.service.ts
@@ -564,25 +564,29 @@ export class ChatwootService {
       let contact = await this.findContact(instance, chatId);
 
       if (contact) {
-        const waProfilePictureFile = picture_url.profilePictureUrl.split('#')[0].split('?')[0].split('/').pop();
-        const chatwootProfilePictureFile = contact?.thumbnail?.split('#')[0].split('?')[0].split('/').pop();
-        const pictureNeedsUpdate = waProfilePictureFile !== chatwootProfilePictureFile;
-        const nameNeedsUpdate =
-          !contact.name ||
-          contact.name === chatId ||
-          (`+${chatId}`.startsWith('+55')
-            ? this.getNumbers(`+${chatId}`).some(
-                (v) => contact.name === v || contact.name === v.substring(3) || contact.name === v.substring(1),
-              )
-            : false);
+        if (!body.key.fromMe) {
+          const waProfilePictureFile =
+            picture_url?.profilePictureUrl?.split('#')[0].split('?')[0].split('/').pop() || '';
+          const chatwootProfilePictureFile = contact?.thumbnail?.split('#')[0].split('?')[0].split('/').pop() || '';
+          const pictureNeedsUpdate = waProfilePictureFile !== chatwootProfilePictureFile;
+          const nameNeedsUpdate =
+            !contact.name ||
+            contact.name === chatId ||
+            (`+${chatId}`.startsWith('+55')
+              ? this.getNumbers(`+${chatId}`).some(
+                  (v) => contact.name === v || contact.name === v.substring(3) || contact.name === v.substring(1),
+                )
+              : false);
 
-        const contactNeedsUpdate = pictureNeedsUpdate || nameNeedsUpdate;
-        if (contactNeedsUpdate) {
-          this.logger.verbose('update contact in chatwoot');
-          contact = await this.updateContact(instance, contact.id, {
-            ...(nameNeedsUpdate && { name: nameContact }),
-            ...(pictureNeedsUpdate && { avatar_url: picture_url.profilePictureUrl || null }),
-          });
+          const contactNeedsUpdate = pictureNeedsUpdate || nameNeedsUpdate;
+          if (contactNeedsUpdate) {
+            this.logger.verbose('update contact in chatwoot');
+            contact = await this.updateContact(instance, contact.id, {
+              ...(nameNeedsUpdate && { name: nameContact }),
+              ...(waProfilePictureFile === '' && { avatar: null }),
+              ...(pictureNeedsUpdate && { avatar_url: picture_url?.profilePictureUrl }),
+            });
+          }
         }
       } else {
         const jid = isGroup ? null : body.key.remoteJid;


### PR DESCRIPTION
Aprimorado a função de atualização dos dados do cliente (nome e foto) no Chatwoot.

Anteriormente, o sistema tentava atualizar a foto do cliente a cada mensagem recebida.

Com a nova alteração, a foto só será atualizada se o nome da foto armazenada no Chatwoot for diferente do nome da foto recebida do WhatsApp. (O Chatwoot salva o nome original da foto. Se houver alguma particularidade na instalação que altere o nome, a função continuará a operar como antes sem prejudicar a sua funcionalidade.)

Quanto à alteração do nome, se não houver um nome no Chatwoot ou se o nome contiver o número de telefone, ele será alterado para o nome do WhatsApp como antes. Para números brasileiros, foi implementada uma verificação adicional: o nome pode conter variações, como a presença ou ausência do 9 e o número não ter o código +55.

Exemplos de nomes que serão atualizados:

+5534999999999
+553499999999
5534999999999
553499999999
34999999999
3499999999
Apenas os parâmetros que necessitarem de atualização serão modificados.

Quando, a foto de perfil for removida do whatsapp também será removida do chatwoot.