### PR TITLE
Corrigindo variável inexistente do arquivo env.config.ts e substituindo pela correta CLEAN_STORE_CLEANING_INTERVAL 

### DIFF
--- a/src/config/env.config.ts
+++ b/src/config/env.config.ts
@@ -251,8 +251,8 @@ export class ConfigService {
         LABELS: process.env?.STORE_LABELS === 'true',
       },
       CLEAN_STORE: {
-        CLEANING_INTERVAL: Number.isInteger(process.env?.CLEAN_STORE_CLEANING_TERMINAL)
-          ? Number.parseInt(process.env.CLEAN_STORE_CLEANING_TERMINAL)
+        CLEANING_INTERVAL: Number.isInteger(process.env?.CLEAN_STORE_CLEANING_INTERVAL)
+          ? Number.parseInt(process.env.CLEAN_STORE_CLEANING_INTERVAL)
           : 7200,
         MESSAGES: process.env?.CLEAN_STORE_MESSAGES === 'true',
         MESSAGE_UP: process.env?.CLEAN_STORE_MESSAGE_UP === 'true',


### PR DESCRIPTION
Este PR tem como objetivo resolver esta issue: 
- https://github.com/EvolutionAPI/evolution-api/issues/589

Nela eu deixei melhor descrito que a variável de ambiente CLEAN_STORE_CLEANING_INTERVAL não está sendo utilizada, mas sim sendo substituída por uma que não existe. Também adicionei exemplos e algumas evidências.

Fico a disposição para qualquer correção necessária!