### PR TITLE
chore: update docker repository to EvolutionAPI/evolution-api

### DIFF
--- a/.github/workflows/publish_docker_image.yml
+++ b/.github/workflows/publish_docker_image.yml
@@ -29,12 +29,12 @@ jobs:
 
       - name: set docker tag
         run: |
-          echo "DOCKER_TAG=ghcr.io/atendai/evolution-api:$GIT_REF" >> $GITHUB_ENV
+          echo "DOCKER_TAG=ghcr.io/EvolutionAPI/evolution-api:$GIT_REF" >> $GITHUB_ENV
 
       - name: replace docker tag if main
         if: github.ref_name == 'main'
         run: |
-          echo "DOCKER_TAG=ghcr.io/atendai/evolution-api:latest" >> $GITHUB_ENV
+          echo "DOCKER_TAG=ghcr.io/EvolutionAPI/evolution-api:latest" >> $GITHUB_ENV
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3


### PR DESCRIPTION
Parece que o `atendai/evolution-api` não existe ou é privado. Essa alteração vai atrelar a imagem a ele repositório.