### PR TITLE
fix(chatwoot): add merge_brazil_contacts flag to ChannelStartupService and add logs

### DIFF
--- a/src/api/services/channel.service.ts
+++ b/src/api/services/channel.service.ts
@@ -332,6 +332,7 @@ export class ChannelStartupService {
     this.logger.verbose(`Chatwoot sign delimiter: ${data.sign_delimiter}`);
     this.logger.verbose(`Chatwoot reopen conversation: ${data.reopen_conversation}`);
     this.logger.verbose(`Chatwoot conversation pending: ${data.conversation_pending}`);
+    this.logger.verbose(`Chatwoot merge brazil contacts: ${data.merge_brazil_contacts}`);
     this.logger.verbose(`Chatwoot import contacts: ${data.import_contacts}`);
     this.logger.verbose(`Chatwoot import messages: ${data.import_messages}`);
     this.logger.verbose(`Chatwoot days limit import messages: ${data.days_limit_import_messages}`);
@@ -360,7 +361,7 @@ export class ChannelStartupService {
     this.logger.verbose(`Chatwoot sign delimiter: ${data.sign_delimiter}`);
     this.logger.verbose(`Chatwoot reopen conversation: ${data.reopen_conversation}`);
     this.logger.verbose(`Chatwoot conversation pending: ${data.conversation_pending}`);
-    this.logger.verbose(`Chatwoot merge brazilian contacts: ${data.import_contacts}`);
+    this.logger.verbose(`Chatwoot merge brazilian contacts: ${data.merge_brazil_contacts}`);
     this.logger.verbose(`Chatwoot import contacts: ${data.import_contacts}`);
     this.logger.verbose(`Chatwoot import messages: ${data.import_messages}`);
     this.logger.verbose(`Chatwoot days limit import messages: ${data.days_limit_import_messages}`);

--- a/src/api/services/channel.service.ts
+++ b/src/api/services/channel.service.ts
@@ -306,6 +306,9 @@ export class ChannelStartupService {
     this.localChatwoot.conversation_pending = data?.conversation_pending;
     this.logger.verbose(`Chatwoot conversation pending: ${this.localChatwoot.conversation_pending}`);
 
+    this.localChatwoot.merge_brazil_contacts = data?.merge_brazil_contacts;
+    this.logger.verbose(`Chatwoot merge brazil contacts: ${this.localChatwoot.merge_brazil_contacts}`);
+
     this.localChatwoot.import_contacts = data?.import_contacts;
     this.logger.verbose(`Chatwoot import contacts: ${this.localChatwoot.import_contacts}`);
 

--- a/src/api/types/wa.types.ts
+++ b/src/api/types/wa.types.ts
@@ -69,6 +69,7 @@ export declare namespace wa {
     number?: string;
     reopen_conversation?: boolean;
     conversation_pending?: boolean;
+    merge_brazil_contacts?: boolean;
     import_contacts?: boolean;
     import_messages?: boolean;
     days_limit_import_messages?: number;


### PR DESCRIPTION
Foi adicionado o parâmetro 'merge_brazil_contacts' ao channel.service.ts e wa.types.ts também alguns logs foram acionados para manter a consistência e o padrão de logs e tipagem. 
A funcionalidade não foi afetada, portanto, trata-se de um minor fix.