### PR TITLE
fix: Correction to Postgres connection string in environment files

### DIFF
--- a/Docker/.env.example
+++ b/Docker/.env.example
@@ -125,7 +125,7 @@ CHATWOOT_MESSAGE_DELETE=false # false | true
 # If you leave this option as true, when sending a message in Chatwoot, the client's last message will be marked as read on WhatsApp.
 CHATWOOT_MESSAGE_READ=false # false | true
 # This db connection is used to import messages from whatsapp to chatwoot database
-CHATWOOT_IMPORT_DATABASE_CONNECTION_URI=postgres://user:password@hostname:port/dbname
+CHATWOOT_IMPORT_DATABASE_CONNECTION_URI=postgres://user:password@hostname:port/dbname?sslmode=disable
 CHATWOOT_IMPORT_DATABASE_PLACEHOLDER_MEDIA_MESSAGE=true
 
 # Defines an authentication type for the api

--- a/src/dev-env.yml
+++ b/src/dev-env.yml
@@ -172,7 +172,7 @@ CHATWOOT:
     # This db connection is used to import messages from whatsapp to chatwoot database
     DATABASE:
       CONNECTION:
-        URI: "postgres://user:password@hostname:port/dbname"
+        URI: "postgres://user:password@hostname:port/dbname?sslmode=disable"
     PLACEHOLDER_MEDIA_MESSAGE: true
 
 # Cache to optimize application performance


### PR DESCRIPTION
As initially mentioned in Issue https://github.com/EvolutionAPI/evolution-api/issues/480, there was a need to pass an SSL configuration parameter in the Postgres connection string, to enable contact synchronization.

If this parameter is not informed, the following message will be displayed:

`[ChatwootImport] [string] Error on import history contacts: Error: The server does not support SSL connections`

To prevent new users from wasting time, if they are not aware of this need, include the parameter in the files 

- scr/dev-env.yml
- Docker/.env.example

So, just adjust the rest of the string with the Postgres connection data and the synchronization will work automatically.

Hugs and let's go! 🚀