### PR TITLE
fix: added validation when sending gif image

### DIFF
--- a/src/api/integrations/chatwoot/services/chatwoot.service.ts
+++ b/src/api/integrations/chatwoot/services/chatwoot.service.ts
@@ -1092,6 +1092,10 @@ export class ChatwootService {
         return messageSent;
       }
 
+      if (type === 'image' && parsedMedia && parsedMedia?.ext === '.gif') {
+        type = 'document';
+      }
+
       this.logger.verbose('send media to instance: ' + waInstance.instanceName);
       const data: SendMediaDto = {
         number: number,


### PR DESCRIPTION
Quando uma mensagem com imagens GIF é enviada, ela não é recebida pelo WhatsApp no telefone. A mensagem é recebida no WhatsApp Web e no WhatsApp Desktop, mas não no WhatsApp Mobile.

Tentei enviar o GIF como vídeo, mas não deu certo. Enviar como imagem também parece não ser suportado.

A solução é enviar como documento, que é a mesma abordagem usada pelo WhatsApp Web e Desktop para o tratamento de imagens GIF.

Apenas GIFs enviados diretamente pelo celular são lidos corretamente.