### PR TITLE
Fix: groups_ignore in create not works

### DIFF
--- a/src/api/controllers/instance.controller.ts
+++ b/src/api/controllers/instance.controller.ts
@@ -396,7 +396,7 @@ export class InstanceController {
       const settings: wa.LocalSettings = {
         reject_call: reject_call || false,
         msg_call: msg_call || '',
-        groups_ignore: groups_ignore || true,
+        groups_ignore: groups_ignore || false,
         always_online: always_online || false,
         read_messages: read_messages || false,
         read_status: read_status || false,


### PR DESCRIPTION
Rota /instance/create não estava respeitando o groups_ignore pois a comparação esta incorreta.