### PR TITLE
Fix: groups_ignore in /instance/create and maintaining compatibility

### DIFF
--- a/src/api/controllers/instance.controller.ts
+++ b/src/api/controllers/instance.controller.ts
@@ -396,7 +396,7 @@ export class InstanceController {
       const settings: wa.LocalSettings = {
         reject_call: reject_call || false,
         msg_call: msg_call || '',
-        groups_ignore: groups_ignore || true,
+        groups_ignore: groups_ignore === undefined ? true : groups_ignore || false,
         always_online: always_online || false,
         read_messages: read_messages || false,
         read_status: read_status || false,


### PR DESCRIPTION
A rota /instance/create não estava sempre definindo o groups_ignore mesmo marcado como false pois avia um comparador false || true que sempre retornaria true, então adicionei uma solução que mantem a compatibilidade anterior caso o valor não seja definido o groups_ignore sera true.