### PR TITLE
Improve reconnection logic for ban and block cases and add disconnection information to BaileysStartupService and Instance model

### DIFF
--- a/prisma/mysql-schema.prisma
+++ b/prisma/mysql-schema.prisma
@@ -47,34 +47,37 @@ enum TriggerOperator {
 }
 
 model Instance {
-  id               String                   @id @default(cuid())
-  name             String                   @unique @db.VarChar(255)
-  connectionStatus InstanceConnectionStatus @default(open)
-  ownerJid         String?                  @db.VarChar(100)
-  profileName      String?                  @db.VarChar(100)
-  profilePicUrl    String?                  @db.VarChar(500)
-  integration      String?                  @db.VarChar(100)
-  number           String?                  @db.VarChar(100)
-  token            String?                  @unique @db.VarChar(255)
-  clientName       String?                  @db.VarChar(100)
-  createdAt        DateTime?                @default(now()) @db.Timestamp
-  updatedAt        DateTime?                @updatedAt @db.Timestamp
-  Chat             Chat[]
-  Contact          Contact[]
-  Message          Message[]
-  Webhook          Webhook?
-  Chatwoot         Chatwoot?
-  Label            Label[]
-  Proxy            Proxy?
-  Setting          Setting?
-  Rabbitmq         Rabbitmq?
-  Sqs              Sqs?
-  Websocket        Websocket?
-  Typebot          Typebot[]
-  Session          Session?
-  MessageUpdate    MessageUpdate[]
-  TypebotSession   TypebotSession[]
-  TypebotSetting   TypebotSetting?
+  id                      String                   @id @default(cuid())
+  name                    String                   @unique @db.VarChar(255)
+  connectionStatus        InstanceConnectionStatus @default(open)
+  ownerJid                String?                  @db.VarChar(100)
+  profileName             String?                  @db.VarChar(100)
+  profilePicUrl           String?                  @db.VarChar(500)
+  integration             String?                  @db.VarChar(100)
+  number                  String?                  @db.VarChar(100)
+  token                   String?                  @unique @db.VarChar(255)
+  clientName              String?                  @db.VarChar(100)
+  disconnectionReasonCode Int?                     @db.Int
+  disconnectionObject     Json?                    @db.Json
+  disconnectionAt         DateTime?                @db.Timestamp
+  createdAt               DateTime?                @default(now()) @db.Timestamp
+  updatedAt               DateTime?                @updatedAt @db.Timestamp
+  Chat                    Chat[]
+  Contact                 Contact[]
+  Message                 Message[]
+  Webhook                 Webhook?
+  Chatwoot                Chatwoot?
+  Label                   Label[]
+  Proxy                   Proxy?
+  Setting                 Setting?
+  Rabbitmq                Rabbitmq?
+  Sqs                     Sqs?
+  Websocket               Websocket?
+  Typebot                 Typebot[]
+  Session                 Session?
+  MessageUpdate           MessageUpdate[]
+  TypebotSession          TypebotSession[]
+  TypebotSetting          TypebotSetting?
 }
 
 model Session {

--- a/prisma/postgresql-schema.prisma
+++ b/prisma/postgresql-schema.prisma
@@ -60,44 +60,47 @@ enum DifyBotType {
 }
 
 model Instance {
-  id               String                   @id @default(cuid())
-  name             String                   @unique @db.VarChar(255)
-  connectionStatus InstanceConnectionStatus @default(open)
-  ownerJid         String?                  @db.VarChar(100)
-  profileName      String?                  @db.VarChar(100)
-  profilePicUrl    String?                  @db.VarChar(500)
-  integration      String?                  @db.VarChar(100)
-  number           String?                  @db.VarChar(100)
-  businessId       String?                  @db.VarChar(100)
-  token            String?                  @db.VarChar(255)
-  clientName       String?                  @db.VarChar(100)
-  createdAt        DateTime?                @default(now()) @db.Timestamp
-  updatedAt        DateTime?                @updatedAt @db.Timestamp
-  Chat             Chat[]
-  Contact          Contact[]
-  Message          Message[]
-  Webhook          Webhook?
-  Chatwoot         Chatwoot?
-  Label            Label[]
-  Proxy            Proxy?
-  Setting          Setting?
-  Rabbitmq         Rabbitmq?
-  Sqs              Sqs?
-  Websocket        Websocket?
-  Typebot          Typebot[]
-  Session          Session?
-  MessageUpdate    MessageUpdate[]
-  TypebotSession   TypebotSession[]
-  TypebotSetting   TypebotSetting?
-  Media            Media[]
-  OpenaiCreds      OpenaiCreds[]
-  OpenaiBot        OpenaiBot[]
-  OpenaiSession    OpenaiSession[]
-  OpenaiSetting    OpenaiSetting?
-  Template         Template[]
-  Dify             Dify[]
-  DifySession      DifySession[]
-  DifySetting      DifySetting?
+  id                      String                   @id @default(cuid())
+  name                    String                   @unique @db.VarChar(255)
+  connectionStatus        InstanceConnectionStatus @default(open)
+  ownerJid                String?                  @db.VarChar(100)
+  profileName             String?                  @db.VarChar(100)
+  profilePicUrl           String?                  @db.VarChar(500)
+  integration             String?                  @db.VarChar(100)
+  number                  String?                  @db.VarChar(100)
+  businessId              String?                  @db.VarChar(100)
+  token                   String?                  @db.VarChar(255)
+  clientName              String?                  @db.VarChar(100)
+  disconnectionReasonCode Int?                     @db.Integer
+  disconnectionObject     Json?                    @db.JsonB
+  disconnectionAt         DateTime?                @db.Timestamp
+  createdAt               DateTime?                @default(now()) @db.Timestamp
+  updatedAt               DateTime?                @updatedAt @db.Timestamp
+  Chat                    Chat[]
+  Contact                 Contact[]
+  Message                 Message[]
+  Webhook                 Webhook?
+  Chatwoot                Chatwoot?
+  Label                   Label[]
+  Proxy                   Proxy?
+  Setting                 Setting?
+  Rabbitmq                Rabbitmq?
+  Sqs                     Sqs?
+  Websocket               Websocket?
+  Typebot                 Typebot[]
+  Session                 Session?
+  MessageUpdate           MessageUpdate[]
+  TypebotSession          TypebotSession[]
+  TypebotSetting          TypebotSetting?
+  Media                   Media[]
+  OpenaiCreds             OpenaiCreds[]
+  OpenaiBot               OpenaiBot[]
+  OpenaiSession           OpenaiSession[]
+  OpenaiSetting           OpenaiSetting?
+  Template                Template[]
+  Dify                    Dify[]
+  DifySession             DifySession[]
+  DifySetting             DifySetting?
 }
 
 model Session {

--- a/src/api/services/channels/whatsapp.baileys.service.ts
+++ b/src/api/services/channels/whatsapp.baileys.service.ts
@@ -388,7 +388,9 @@ export class BaileysStartupService extends ChannelStartupService {
     }
 
     if (connection === 'close') {
-      const shouldReconnect = (lastDisconnect.error as Boom)?.output?.statusCode !== DisconnectReason.loggedOut;
+      const statusCode = (lastDisconnect?.error as Boom)?.output?.statusCode;
+      const codesToNotReconnect = [DisconnectReason.loggedOut, DisconnectReason.forbidden, 402, 406];
+      const shouldReconnect = !codesToNotReconnect.includes(statusCode);
       if (shouldReconnect) {
         await this.connectToWhatsapp(this.phoneNumber);
       } else {

--- a/src/api/services/channels/whatsapp.baileys.service.ts
+++ b/src/api/services/channels/whatsapp.baileys.service.ts
@@ -397,6 +397,9 @@ export class BaileysStartupService extends ChannelStartupService {
         this.sendDataWebhook(Events.STATUS_INSTANCE, {
           instance: this.instance.name,
           status: 'closed',
+          disconnectionAt: new Date(),
+          disconnectionReasonCode: statusCode,
+          disconnectionObject: JSON.stringify(lastDisconnect),
         });
 
         if (this.configService.get<Database>('DATABASE').ENABLED) {
@@ -404,6 +407,9 @@ export class BaileysStartupService extends ChannelStartupService {
             where: { id: this.instanceId },
             data: {
               connectionStatus: 'close',
+              disconnectionAt: new Date(),
+              disconnectionReasonCode: statusCode,
+              disconnectionObject: JSON.stringify(lastDisconnect),
             },
           });
         }


### PR DESCRIPTION
- Updated BaileysStartupService to include disconnection handling logic.
- Enhanced Instance model to store disconnection status and details.
- Handled specific error codes to manage disconnection states:
  - 401: Triggered logout to handle unauthorized access.
  - 402: Recognized as temporary ban, reconnection attempts paused.
  - 403: Recognized as forbidden, reconnection attempts stopped.
  - 406: Recognized as permanent ban, reconnection attempts halted.