### PR TITLE
V2 update contacts database

### DIFF
--- a/prisma/mysql-schema.prisma
+++ b/prisma/mysql-schema.prisma
@@ -130,6 +130,8 @@ model Contact {
   updatedAt     DateTime? @updatedAt @db.Timestamp
   Instance      Instance  @relation(fields: [instanceId], references: [id], onDelete: Cascade)
   instanceId    String
+
+  @@unique([remoteJid, instanceId])
 }
 
 model Message {

--- a/prisma/postgresql-migrations/20240811183328_add_unique_index_for_remoted_jid_and_instance_in_contacts/migration.sql
+++ b/prisma/postgresql-migrations/20240811183328_add_unique_index_for_remoted_jid_and_instance_in_contacts/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[remoteJid,instanceId]` on the table `Contact` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- CreateIndex
+CREATE UNIQUE INDEX "Contact_remoteJid_instanceId_key" ON "Contact"("remoteJid", "instanceId");

--- a/prisma/postgresql-schema.prisma
+++ b/prisma/postgresql-schema.prisma
@@ -130,6 +130,8 @@ model Contact {
   updatedAt     DateTime? @updatedAt @db.Timestamp
   Instance      Instance  @relation(fields: [instanceId], references: [id], onDelete: Cascade)
   instanceId    String
+
+  @@unique([remoteJid, instanceId])
 }
 
 model Message {


### PR DESCRIPTION
In this PR we made the contacts unique in the same instance to avoid duplicated records on the database.

Along with that the contact update section has been fixed, it was using `updateMany`, but since we're updating different values the updateMany won't work in this case, it has been implemented the `$transactions` from prisma.

See ref: https://stackoverflow.com/a/71509069