### PR TITLE
fix: Correction of media as attachments in chatwoot when using a Meta API Instance and not Baileys

### DIFF
--- a/src/api/integrations/chatwoot/services/chatwoot.service.ts
+++ b/src/api/integrations/chatwoot/services/chatwoot.service.ts
@@ -741,7 +741,6 @@ export class ChatwootService {
       findByName = inbox.payload.find((inbox) => inbox.name === this.getClientCwConfig().name_inbox.split('-cwId-')[0]);
     }
 
-
     if (!findByName) {
       this.logger.warn('inbox not found');
       return null;
@@ -1907,7 +1906,8 @@ export class ChatwootService {
 
           let nameFile: string;
           const messageBody = body?.message[body?.messageType];
-          const originalFilename = messageBody?.fileName || messageBody?.message?.documentMessage?.fileName;
+          const originalFilename =
+            messageBody?.fileName || messageBody?.filename || messageBody?.message?.documentMessage?.fileName;
           if (originalFilename) {
             const parsedFile = path.parse(originalFilename);
             if (parsedFile.name && parsedFile.ext) {

--- a/src/api/services/channels/whatsapp.business.service.ts
+++ b/src/api/services/channels/whatsapp.business.service.ts
@@ -743,6 +743,7 @@ export class BusinessStartupService extends ChannelStartupService {
               [message['type']]: message['id'],
               preview_url: linkPreview,
               caption: message['caption'],
+              filename: message['fileName'],
             },
           };
           quoted ? (content.context = { message_id: quoted.id }) : content;
@@ -1212,7 +1213,7 @@ export class BusinessStartupService extends ChannelStartupService {
     try {
       const msg = data.message;
       this.logger.verbose('Getting base64 from media message');
-      const messageType = msg.messageType + 'Message';
+      const messageType = msg.messageType.includes('Message') ? msg.messageType : msg.messageType + 'Message';
       const mediaMessage = msg.message[messageType];
 
       this.logger.verbose('Media message downloaded');


### PR DESCRIPTION
When using an Instance with the Cloud API (Meta) Integration, media files such as images, audio, and documents arrived in Chatwoot as attachments without file extensions, as shown in the image below:
![image](https://github.com/user-attachments/assets/eb9ae0fa-8571-4f6b-927f-fa600643d179)

Meta uses the "filename" property for files like documents that have a filename. The change below retrieves the filename with its extension and sends it correctly to Chatwoot.


[src/api/integrations/chatwoot/services/chatwoot.service.ts]
> const originalFilename = messageBody?.fileName || messageBody?.filename || messageBody?.message?.documentMessage?.fileName;


For files that do not have a filename, such as images, in chatwoot.service.ts, we use the mimetype property from the getBase64FromMediaMessage function and assign a name to it. However, the messageType property received from Meta was different from what was expected, as it already comes concatenated with the word "Message." The condition below addresses this and correctly finds the mimetype object. 


[src/api/services/channels/whatsapp.business.service.ts]
> const messageType = msg.messageType.includes('Message') ? msg.messageType : msg.messageType + 'Message';


Additionally, I noticed that when sending a file from Chatwoot to my WhatsApp number, the document appeared unattractive. Upon reviewing the evolutionApi, I realized the filename field was missing as per Meta's documentation. I made a simple adjustment, and as shown in the image below, we can see the before and after:
![image](https://github.com/user-attachments/assets/b76e73f0-c5db-4b7c-9213-aa6e1df3f37d)

Thank you.