### PR TITLE
Remove instance from redis even if using database

### DIFF
--- a/src/api/services/monitor.service.ts
+++ b/src/api/services/monitor.service.ts
@@ -120,6 +120,7 @@ export class WAMonitoringService {
   }
 
   public async cleaningUp(instanceName: string) {
+    let instanceDbId: string;
     if (this.db.ENABLED && this.db.SAVE_DATA.INSTANCE) {
       const instance = await this.prismaRepository.instance.update({
         where: { name: instanceName },
@@ -130,13 +131,16 @@ export class WAMonitoringService {
 
       rmSync(join(INSTANCE_DIR, instance.id), { recursive: true, force: true });
 
+      instanceDbId = instance.id;
       await this.prismaRepository.session.deleteMany({ where: { sessionId: instance.id } });
-      return;
     }
 
     if (this.redis.REDIS.ENABLED && this.redis.REDIS.SAVE_INSTANCES) {
+      console.log({ instanceName, instanceDbId });
       await this.cache.delete(instanceName);
-      return;
+      if (instanceDbId) {
+        await this.cache.delete(instanceDbId);
+      }
     }
 
     if (this.providerSession?.ENABLED) {

--- a/src/api/services/monitor.service.ts
+++ b/src/api/services/monitor.service.ts
@@ -136,7 +136,6 @@ export class WAMonitoringService {
     }
 
     if (this.redis.REDIS.ENABLED && this.redis.REDIS.SAVE_INSTANCES) {
-      console.log({ instanceName, instanceDbId });
       await this.cache.delete(instanceName);
       if (instanceDbId) {
         await this.cache.delete(instanceDbId);


### PR DESCRIPTION
Without this change, if I have instance saved on redis and using database, it will clear from the database on logout but not from redis