### PR TITLE
Changed labels to be unique on the same instance

### DIFF
--- a/prisma/postgresql-migrations/20240813003116_make_label_unique_for_instance/migration.sql
+++ b/prisma/postgresql-migrations/20240813003116_make_label_unique_for_instance/migration.sql
@@ -1,0 +1,11 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[labelId,instanceId]` on the table `Label` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- DropIndex
+DROP INDEX "Label_labelId_key";
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Label_labelId_instanceId_key" ON "Label"("labelId", "instanceId");

--- a/prisma/postgresql-schema.prisma
+++ b/prisma/postgresql-schema.prisma
@@ -216,7 +216,7 @@ model Chatwoot {
 
 model Label {
   id           String    @id @default(cuid())
-  labelId      String?   @unique @db.VarChar(100)
+  labelId      String?   @db.VarChar(100)
   name         String    @db.VarChar(100)
   color        String    @db.VarChar(100)
   predefinedId String?   @db.VarChar(100)
@@ -224,6 +224,8 @@ model Label {
   updatedAt    DateTime  @updatedAt @db.Timestamp
   Instance     Instance  @relation(fields: [instanceId], references: [id], onDelete: Cascade)
   instanceId   String
+
+  @@unique([labelId, instanceId])
 }
 
 model Proxy {


### PR DESCRIPTION
This is to prevent this kind of error:
![CleanShot 2024-08-12 at 21 28 56@2x](https://github.com/user-attachments/assets/ff438da4-b96b-4696-ab65-19aaa41704c8)

Since the label ID can be the same for different instances
![CleanShot 2024-08-12 at 21 37 19](https://github.com/user-attachments/assets/88b0cebd-7160-4a3c-a4e5-c59e1a82c7da)
