### PR TITLE
[v2] - Região no S3 e fix do size no uploadFile

### DIFF
--- a/src/api/integrations/s3/libs/minio.server.ts
+++ b/src/api/integrations/s3/libs/minio.server.ts
@@ -21,6 +21,7 @@ const minioClient = (() => {
       useSSL: BUCKET.USE_SSL,
       accessKey: BUCKET.ACCESS_KEY,
       secretKey: BUCKET.SECRET_KEY,
+      region: BUCKET.REGION
     });
   }
 })();

--- a/src/api/services/channels/whatsapp.baileys.service.ts
+++ b/src/api/services/channels/whatsapp.baileys.service.ts
@@ -1157,7 +1157,7 @@ export class BaileysStartupService extends ChannelStartupService {
 
                   const fullName = join(`${this.instance.id}`, received.key.remoteJid, mediaType, fileName);
 
-                  await s3Service.uploadFile(fullName, buffer, size.fileLength, {
+                  await s3Service.uploadFile(fullName, buffer, size.fileLength?.low, {
                     'Content-Type': mimetype,
                   });
 

--- a/src/config/env.config.ts
+++ b/src/config/env.config.ts
@@ -202,6 +202,7 @@ export type S3 = {
   ENABLE: boolean;
   PORT?: number;
   USE_SSL?: boolean;
+  REGION?: string;
 };
 
 export type CacheConf = { REDIS: CacheConfRedis; LOCAL: CacheConfLocal };
@@ -463,6 +464,7 @@ export class ConfigService {
         ENABLE: process.env?.S3_ENABLED === 'true',
         PORT: Number.parseInt(process.env?.S3_PORT || '9000'),
         USE_SSL: process.env?.S3_USE_SSL === 'true',
+        REGION: process.env?.S3_REGION
       },
       AUTHENTICATION: {
         API_KEY: {


### PR DESCRIPTION
### Bugs

1. O MinIO tem uma região padrão quando não informada a região ao criar o Client;
2. Ao fazer upload do arquivo foi notado que os metadados do arquivo setados (content-type e custom-header-application) não eram setados no arquivo no S3, inclusive o content-type era trocado pela detecção da AWS, ficando sempre como `binary/octet-stream`, então sempre quando acessa o link ele fazia download do arquivo, em vez de ter a preview.

### Soluções

1. Agora no S3 do .env tem pra colocar a região, caso não informada, pega o default normalmente do MinIO;
2. Isso estava acontecendo pois a função `uploadFile` recebia o size como parametro, mas em vez do número, chegava um objeto, se perdendo nos parametros da `putObject` que ignorava o metadata informado.


### Resultado
#### Antes
<img width="1136" alt="image" src="https://github.com/user-attachments/assets/4c967096-843d-49e5-b65b-75bc13ff37d0">

#### Depois
<img width="1103" alt="image" src="https://github.com/user-attachments/assets/39eaa853-c311-4725-926d-1ef96bd95a3b">
