### PR TITLE
Advanced operators trigger for OpenAI/Dify/Typebot

### DIFF
--- a/prisma/mysql-schema.prisma
+++ b/prisma/mysql-schema.prisma
@@ -37,6 +37,7 @@ enum TriggerType {
   all
   keyword
   none
+  advanced
 }
 
 enum TriggerOperator {

--- a/prisma/postgresql-migrations/20240817110155_add_trigger_type_advanced/migration.sql
+++ b/prisma/postgresql-migrations/20240817110155_add_trigger_type_advanced/migration.sql
@@ -1,0 +1,2 @@
+-- AlterEnum
+ALTER TYPE "TriggerType" ADD VALUE 'advanced';

--- a/prisma/postgresql-schema.prisma
+++ b/prisma/postgresql-schema.prisma
@@ -37,6 +37,7 @@ enum TriggerType {
   all
   keyword
   none
+  advanced
 }
 
 enum TriggerOperator {

--- a/src/api/integrations/dify/validate/dify.schema.ts
+++ b/src/api/integrations/dify/validate/dify.schema.ts
@@ -29,7 +29,7 @@ export const difySchema: JSONSchema7 = {
     botType: { type: 'string', enum: ['chatBot', 'textGenerator', 'agent', 'workflow'] },
     apiUrl: { type: 'string' },
     apiKey: { type: 'string' },
-    triggerType: { type: 'string', enum: ['all', 'keyword', 'none'] },
+    triggerType: { type: 'string', enum: ['all', 'keyword', 'none', 'advanced'] },
     triggerOperator: { type: 'string', enum: ['equals', 'contains', 'startsWith', 'endsWith', 'regex'] },
     triggerValue: { type: 'string' },
     expire: { type: 'integer' },

--- a/src/api/integrations/openai/validate/openai.schema.ts
+++ b/src/api/integrations/openai/validate/openai.schema.ts
@@ -35,7 +35,7 @@ export const openaiSchema: JSONSchema7 = {
     assistantMessages: { type: 'array', items: { type: 'string' } },
     userMessages: { type: 'array', items: { type: 'string' } },
     maxTokens: { type: 'integer' },
-    triggerType: { type: 'string', enum: ['all', 'keyword', 'none'] },
+    triggerType: { type: 'string', enum: ['all', 'keyword', 'none', 'advanced'] },
     triggerOperator: { type: 'string', enum: ['equals', 'contains', 'startsWith', 'endsWith', 'regex'] },
     triggerValue: { type: 'string' },
     expire: { type: 'integer' },

--- a/src/api/integrations/typebot/validate/typebot.schema.ts
+++ b/src/api/integrations/typebot/validate/typebot.schema.ts
@@ -28,7 +28,7 @@ export const typebotSchema: JSONSchema7 = {
     description: { type: 'string' },
     url: { type: 'string' },
     typebot: { type: 'string' },
-    triggerType: { type: 'string', enum: ['all', 'keyword', 'none'] },
+    triggerType: { type: 'string', enum: ['all', 'keyword', 'none', 'advanced'] },
     triggerOperator: { type: 'string', enum: ['equals', 'contains', 'startsWith', 'endsWith', 'regex'] },
     triggerValue: { type: 'string' },
     expire: { type: 'integer' },

--- a/src/utils/advancedOperatorsSearch.ts
+++ b/src/utils/advancedOperatorsSearch.ts
@@ -1,0 +1,45 @@
+function normalizeString(str: string): string {
+  return str
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .toLowerCase();
+}
+
+export function advancedOperatorsSearch(data: string, query: string): boolean {
+  const filters = query.split(' ').reduce((acc: Record<string, string[]>, filter) => {
+    const [operator, ...values] = filter.split(':');
+    const value = values.join(':');
+
+    if (!acc[operator]) {
+      acc[operator] = [];
+    }
+    acc[operator].push(value);
+    return acc;
+  }, {});
+
+  const normalizedItem = normalizeString(data);
+
+  return Object.entries(filters).every(([operator, values]) => {
+    return values.some((val) => {
+      const subValues = val.split(',');
+      return subValues.every((subVal) => {
+        const normalizedSubVal = normalizeString(subVal);
+
+        switch (operator.toLowerCase()) {
+          case 'contains':
+            return normalizedItem.includes(normalizedSubVal);
+          case 'notcontains':
+            return !normalizedItem.includes(normalizedSubVal);
+          case 'startswith':
+            return normalizedItem.startsWith(normalizedSubVal);
+          case 'endswith':
+            return normalizedItem.endsWith(normalizedSubVal);
+          case 'exact':
+            return normalizedItem === normalizedSubVal;
+          default:
+            return false;
+        }
+      });
+    });
+  });
+}


### PR DESCRIPTION
> _Docs generate by AI_

### Development Documentation: Advanced Search with Operators

---

#### Introduction

This documentation describes the implementation of an advanced string search function using operators like `contains:`, `notContains:`, `startsWith:`, `endsWith:`, and `exact:`. The function allows for case-insensitive searches while ignoring accents. It supports both **AND** logic (when values are separated by a comma within the same operator) and **OR** logic (when multiple identical operators are used).

---

#### Supported Operators

- **`contains:`**
  - **Description**: Checks if the string contains the specified value.
  - **AND**: If a comma is present, all comma-separated values must be present.
  - **OR**: If multiple `contains:` operators are used, the string must satisfy at least one of the criteria.
  - **Example**:
    - `contains:Error,Access` (Searches for strings that contain **both** "Error" **and** "Access").
    - `contains:Error contains:Memory` (Searches for strings that contain "Error" **or** "Memory").

- **`notContains:`**
  - **Description**: Checks if the string **does not** contain the specified value.
  - **AND**: If a comma is present, the string must not contain any of the comma-separated values.
  - **OR**: If multiple `notContains:` operators are used, the string must satisfy at least one of the criteria.
  - **Example**:
    - `notContains:Warning,Error` (Searches for strings that **do not** contain "Warning" **and** "Error").
    - `notContains:Warning notContains:Memory` (Searches for strings that do not contain "Warning" **or** "Memory").

- **`startsWith:`**
  - **Description**: Checks if the string starts with the specified value.
  - **AND**: If a comma is present, the string must start with all comma-separated values.
  - **OR**: If multiple `startsWith:` operators are used, the string must start with at least one of the criteria.
  - **Example**:
    - `startsWith:Error,Warning` (Searches for strings that start with **both** "Error" **and** "Warning").
    - `startsWith:Error startsWith:Info` (Searches for strings that start with "Error" **or** "Info").

- **`endsWith:`**
  - **Description**: Checks if the string ends with the specified value.
  - **AND**: If a comma is present, the string must end with all comma-separated values.
  - **OR**: If multiple `endsWith:` operators are used, the string must end with at least one of the criteria.
  - **Example**:
    - `endsWith:found,authorized` (Searches for strings that end with **both** "found" **and** "authorized").
    - `endsWith:found endsWith:full` (Searches for strings that end with "found" **or** "full").

- **`exact:`**
  - **Description**: Checks if the string is exactly equal to the specified value.
  - **AND**: If a comma is present, the string must be exactly equal to all comma-separated values.
  - **OR**: If multiple `exact:` operators are used, the string must be exactly equal to at least one of the criteria.
  - **Example**:
    - `exact:Error,File` (Searches for strings that are exactly equal to **both** "Error" **and** "File").
    - `exact:Error exact:Warning` (Searches for strings that are exactly equal to "Error" **or** "Warning").

---

#### Practical Examples

1. **Simple search with `contains:` and `notContains:`**
   - **Query**: `"contains:Error contains:Memory notContains:Warning"`
   - **Description**: True if contain "Error" **or** "Memory" but do not contain "Warning."

2. **Combined search with `contains:` using AND**
   - **Query**: `"contains:Error,Access notContains:Warning"`
   - **Description**: True if contain **both** "Error" **and** "Access" but do not contain "Warning."

3. **Search with multiple `startsWith:` operators**
   - **Query**: `"startsWith:Error startsWith:Info"`
   - **Description**: True if start with "Error" **or** "Info."

4. **Exact search with `exact:` and `notContains:`**
   - **Query**: `"exact:Error notContains:File"`
   - **Description**: True if are exactly "Error" and do not contain "File."

---

#### API Examples

Trigger condition: `contains:Tudo,bem contains:como,vai notContains:oi`
![CleanShot 2024-08-17 at 08 37 57@2x](https://github.com/user-attachments/assets/8195ff25-408a-47cf-9439-2d94e0008453)