### PR TITLE
Fix [cacheService]: Resolve erros caso cacheService não esteja habilitado 

### DIFF
--- a/src/api/services/cache.service.ts
+++ b/src/api/services/cache.service.ts
@@ -17,10 +17,15 @@ export class CacheService {
     if (!this.cache) {
       return;
     }
+
     return this.cache.get(key);
   }
 
   public async hGet(key: string, field: string) {
+    if (!this.cache) {
+      return false;
+    }
+
     try {
       const data = await this.cache.hGet(key, field);
 
@@ -39,10 +44,15 @@ export class CacheService {
     if (!this.cache) {
       return;
     }
+
     this.cache.set(key, value);
   }
 
   public async hSet(key: string, field: string, value: any) {
+    if (!this.cache) {
+      return false;
+    }
+
     try {
       const json = JSON.stringify(value, BufferJSON.replacer);
 
@@ -56,6 +66,7 @@ export class CacheService {
     if (!this.cache) {
       return;
     }
+
     return this.cache.has(key);
   }
 
@@ -63,10 +74,15 @@ export class CacheService {
     if (!this.cache) {
       return;
     }
+
     return this.cache.delete(key);
   }
 
   async hDelete(key: string, field: string) {
+    if (!this.cache) {
+      return false;
+    }
+
     try {
       await this.cache.hDelete(key, field);
       return true;
@@ -80,6 +96,7 @@ export class CacheService {
     if (!this.cache) {
       return;
     }
+
     return this.cache.deleteAll(appendCriteria);
   }
 
@@ -87,6 +104,7 @@ export class CacheService {
     if (!this.cache) {
       return;
     }
+
     return this.cache.keys(appendCriteria);
   }
 }


### PR DESCRIPTION
Se o cache Redis não estiver habilitado, os erros anexados são exibidos no console. Esses erros ocorrem principalmente ao utilizar o Chatwoot, onde algumas funcionalidades ( Nao totalmente confirmados, ainda em testes), como a atualização de fotos de perfil e a função mergeBrazilContacts, não funcionam quando o cache está em uso.

Diante disso, o ideal é que erros sejam registrados no console apenas quando um erro real ocorre ao configurar o cache, o que não é o caso aqui, já que ele não está habilitado.



![Captura de tela 2024-08-27 112310](https://github.com/user-attachments/assets/0d033d98-e164-43af-a10e-fa6231161b38)
