### PR TITLE
[Proposta] Alterar level dos logs do cache para verbose

### DIFF
--- a/src/api/services/cache.service.ts
+++ b/src/api/services/cache.service.ts
@@ -7,9 +7,9 @@ export class CacheService {
 
   constructor(private readonly cache: ICache) {
     if (cache) {
-      this.logger.info(`cacheservice created using cache engine: ${cache.constructor?.name}`);
+      this.logger.verbose(`cacheservice created using cache engine: ${cache.constructor?.name}`);
     } else {
-      this.logger.info(`cacheservice disabled`);
+      this.logger.verbose(`cacheservice disabled`);
     }
   }
 

--- a/src/cache/cacheengine.ts
+++ b/src/cache/cacheengine.ts
@@ -5,7 +5,7 @@ import { Logger } from '@config/logger.config';
 import { LocalCache } from './localcache';
 import { RedisCache } from './rediscache';
 
-const logger = new Logger('Redis');
+const logger = new Logger('CacheEngine');
 
 export class CacheEngine {
   private engine: ICache;
@@ -14,12 +14,14 @@ export class CacheEngine {
     const cacheConf = configService.get<CacheConf>('CACHE');
 
     if (cacheConf?.REDIS?.ENABLED && cacheConf?.REDIS?.URI !== '') {
+      logger.verbose(`RedisCache initialized for ${module}`);
       this.engine = new RedisCache(configService, module);
     } else if (cacheConf?.LOCAL?.ENABLED) {
+      logger.verbose(`LocalCache initialized for ${module}`);
       this.engine = new LocalCache(configService, module);
     }
 
-    logger.info(`RedisCache initialized for ${module}`);
+    
   }
 
   public getEngine() {


### PR DESCRIPTION
"Minha proposta é alterar o nível dos logs do cache para 'verbose'. Acredito que isso ajudaria a manter os logs de info mais limpos, já que não é relevante gerar tantos logs sobre o uso do cache em cada operação."