### PR TITLE
feat: Define a global proxy to be used if the instance does not have one

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -212,3 +212,10 @@ AUTHENTICATION_API_KEY=429683C4C977415CAAFCCE10F7D57E11
 # If you leave this option as true, the instances will be exposed in the fetch instances endpoint.
 AUTHENTICATION_EXPOSE_IN_FETCH_INSTANCES=true
 LANGUAGE=en
+
+# Define a global proxy to be used if the instance does not have one
+# PROXY_HOST=
+# PROXY_PORT=80
+# PROXY_PROTOCOL=http
+# PROXY_USERNAME=
+# PROXY_PASSWORD=

--- a/src/api/services/channel.service.ts
+++ b/src/api/services/channel.service.ts
@@ -338,18 +338,31 @@ export class ChannelStartupService {
   }
 
   public async loadProxy() {
+    this.localProxy.enabled = false;
+
+    if (process.env.PROXY_HOST) {
+      this.localProxy.enabled = true;
+      this.localProxy.host = process.env.PROXY_HOST;
+      this.localProxy.port = process.env.PROXY_PORT || '80';
+      this.localProxy.protocol = process.env.PROXY_PROTOCOL || 'http';
+      this.localProxy.username = process.env.PROXY_USERNAME;
+      this.localProxy.password = process.env.PROXY_PASSWORD;
+    }
+
     const data = await this.prismaRepository.proxy.findUnique({
       where: {
         instanceId: this.instanceId,
       },
     });
 
-    this.localProxy.enabled = data?.enabled;
-    this.localProxy.host = data?.host;
-    this.localProxy.port = data?.port;
-    this.localProxy.protocol = data?.protocol;
-    this.localProxy.username = data?.username;
-    this.localProxy.password = data?.password;
+    if (data?.enabled) {
+      this.localProxy.enabled = true;
+      this.localProxy.host = data?.host;
+      this.localProxy.port = data?.port;
+      this.localProxy.protocol = data?.protocol;
+      this.localProxy.username = data?.username;
+      this.localProxy.password = data?.password;
+    }
   }
 
   public async setProxy(data: ProxyDto) {


### PR DESCRIPTION
It gives us a chance to define a proxy to be used by all instances on deploy