### PR TITLE
v2.0.0-robsoncombr-fix-missing-autoCreate

### DIFF
--- a/src/api/controllers/instance.controller.ts
+++ b/src/api/controllers/instance.controller.ts
@@ -220,7 +220,7 @@ export class InstanceController {
           daysLimitImportMessages: instanceData.chatwootDaysLimitImportMessages ?? 60,
           organization: instanceData.chatwootOrganization,
           logo: instanceData.chatwootLogo,
-          autoCreate: true,
+          autoCreate: instanceData.chatwootAutoCreate !== false,
         });
       } catch (error) {
         this.logger.log(error);


### PR DESCRIPTION
Hello,

I have found a regression issue, that was working to me before, apparently a default static true value was left behind instead of assume from data as it does in Chatwoot Service itself.

Glad for assist.

Robson