### PR TITLE
Fix on whatsapp number return

### DIFF
--- a/src/api/integrations/channel/whatsapp/whatsapp.baileys.service.ts
+++ b/src/api/integrations/channel/whatsapp/whatsapp.baileys.service.ts
@@ -2732,7 +2732,7 @@ export class BaileysStartupService extends ChannelStartupService {
             exists: true,
             jid: cached.remoteJid,
             name: contacts.find((c) => c.remoteJid === cached.remoteJid)?.pushName,
-            number: cached.number,
+            number: user.number,
           };
         }
 


### PR DESCRIPTION
The return must be what the user informed and not the number result.

The number can be obtained from the JID, this is the same behavior that we had previously in v1