### PR TITLE
feat: adiciona headers no cadastro de webhook da instância

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ lerna-debug.log*
 
 # Package
 /yarn.lock
+/pnpm-lock.yaml
 /package-lock.json
 
 # IDEs

--- a/prisma/mysql-schema.prisma
+++ b/prisma/mysql-schema.prisma
@@ -181,6 +181,7 @@ model MessageUpdate {
 model Webhook {
   id              String    @id @default(cuid())
   url             String    @db.VarChar(500)
+  headers         Json?     @db.Json
   enabled         Boolean?  @default(true)
   events          Json?     @db.Json
   webhookByEvents Boolean?  @default(false)

--- a/prisma/postgresql-migrations/20240906202019_add_headers_on_webhook_config/migration.sql
+++ b/prisma/postgresql-migrations/20240906202019_add_headers_on_webhook_config/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Webhook" ADD COLUMN     "headers" JSONB;

--- a/prisma/postgresql-schema.prisma
+++ b/prisma/postgresql-schema.prisma
@@ -180,6 +180,7 @@ model MessageUpdate {
 model Webhook {
   id              String    @id @default(cuid())
   url             String    @db.VarChar(500)
+  headers         Json?     @db.JsonB
   enabled         Boolean?  @default(true) @db.Boolean
   events          Json?     @db.JsonB
   webhookByEvents Boolean?  @default(false) @db.Boolean

--- a/src/api/controllers/instance.controller.ts
+++ b/src/api/controllers/instance.controller.ts
@@ -151,6 +151,7 @@ export class InstanceController {
           hash,
           webhook: {
             webhookUrl: instanceData?.webhook?.url,
+            webhookHeaders: instanceData?.webhook?.headers,
             webhookByEvents: instanceData?.webhook?.byEvents,
             webhookBase64: instanceData?.webhook?.base64,
           },
@@ -238,6 +239,7 @@ export class InstanceController {
         hash,
         webhook: {
           webhookUrl: instanceData?.webhook?.url,
+          webhookHeaders: instanceData?.webhook?.headers,
           webhookByEvents: instanceData?.webhook?.byEvents,
           webhookBase64: instanceData?.webhook?.base64,
         },

--- a/src/api/integrations/event/event.dto.ts
+++ b/src/api/integrations/event/event.dto.ts
@@ -1,10 +1,12 @@
 import { Constructor } from '@api/integrations/integration.dto';
+import { JsonValue } from '@prisma/client/runtime/library';
 
 export class EventDto {
   webhook?: {
     enabled?: boolean;
     events?: string[];
     url?: string;
+    headers?: JsonValue;
     byEvents?: boolean;
     base64?: boolean;
   };
@@ -30,6 +32,7 @@ export function EventInstanceMixin<TBase extends Constructor>(Base: TBase) {
     webhook?: {
       enabled?: boolean;
       events?: string[];
+      headers?: JsonValue;
       url?: string;
       byEvents?: boolean;
       base64?: boolean;

--- a/src/api/integrations/event/event.manager.ts
+++ b/src/api/integrations/event/event.manager.ts
@@ -126,6 +126,7 @@ export class EventManager {
           enabled: true,
           events: data.webhook?.events,
           url: data.webhook?.url,
+          headers: data.webhook?.headers,
           base64: data.webhook?.base64,
           byEvents: data.webhook?.byEvents,
         },

--- a/src/api/integrations/event/webhook/webhook.controller.ts
+++ b/src/api/integrations/event/webhook/webhook.controller.ts
@@ -38,6 +38,7 @@ export class WebhookController extends EventController implements EventControlle
         enabled: data.webhook?.enabled,
         events: data.webhook?.events,
         url: data.webhook?.url,
+        headers: data.webhook?.headers,
         webhookBase64: data.webhook.base64,
         webhookByEvents: data.webhook.byEvents,
       },
@@ -46,6 +47,7 @@ export class WebhookController extends EventController implements EventControlle
         events: data.webhook?.events,
         instanceId: this.monitor.waInstances[instanceName].instanceId,
         url: data.webhook?.url,
+        headers: data.webhook?.headers,
         webhookBase64: data.webhook.base64,
         webhookByEvents: data.webhook.byEvents,
       },
@@ -71,6 +73,7 @@ export class WebhookController extends EventController implements EventControlle
 
     const webhookConfig = configService.get<Webhook>('WEBHOOK');
     const webhookLocal = instance?.events;
+    const webhookHeaders = instance?.headers;
     const we = event.replace(/[.-]/gm, '_').toUpperCase();
     const transformedWe = we.replace(/_/gm, '-').toLowerCase();
     const enabledLog = configService.get<Log>('LOG').LEVEL.includes('WEBHOOKS');
@@ -108,7 +111,10 @@ export class WebhookController extends EventController implements EventControlle
 
         try {
           if (instance?.enabled && isURL(instance.url, { require_tld: false })) {
-            const httpService = axios.create({ baseURL });
+            const httpService = axios.create({
+              baseURL,
+              headers: webhookHeaders as Record<string, string> | undefined,
+            });
 
             await httpService.post('', webhookData);
           }

--- a/src/api/integrations/event/webhook/webhook.router.ts
+++ b/src/api/integrations/event/webhook/webhook.router.ts
@@ -3,7 +3,7 @@ import { InstanceDto } from '@api/dto/instance.dto';
 import { EventDto } from '@api/integrations/event/event.dto';
 import { HttpStatus } from '@api/routes/index.router';
 import { eventManager } from '@api/server.module';
-import { ConfigService, WaBusiness } from '@config/env.config';
+import { ConfigService } from '@config/env.config';
 import { instanceSchema, webhookSchema } from '@validate/validate.schema';
 import { RequestHandler, Router } from 'express';
 

--- a/src/api/integrations/event/webhook/webhook.schema.ts
+++ b/src/api/integrations/event/webhook/webhook.schema.ts
@@ -31,6 +31,7 @@ export const webhookSchema: JSONSchema7 = {
       properties: {
         enabled: { type: 'boolean' },
         url: { type: 'string' },
+        headers: { type: 'object' },
         byEvents: { type: 'boolean' },
         base64: { type: 'boolean' },
         events: {

--- a/src/api/types/wa.types.ts
+++ b/src/api/types/wa.types.ts
@@ -94,6 +94,7 @@ export declare namespace wa {
 
   export type LocalWebHook = LocalEvent & {
     url?: string;
+    headers?: JsonValue;
     webhookByEvents?: boolean;
     webhookBase64?: boolean;
   };


### PR DESCRIPTION
Foi adicionada a opção de cadastrar headers junto ao webhook, de forma que possibilite adicionar uma camada de segurança e autenticação para a aplicação/serviço que receberá a chamada vinda da API da Evolution.

Segue o exemplo de como cadastrar abaixo:

```json
{
    "webhook": {
        "url": "...",
        "headers": {
            "autorization": "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6Ik...",
            "Content-Type": "application/json"
        },
        "byEvents": true,
        "base64": false,
        "events": [...]
    }
}