### PR TITLE
Debounce message break

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,7 @@
 {
-  // "editor.fontSize": 13,
+  "editor.fontSize": 13,
   "editor.fontLigatures": true,
-  // "editor.letterSpacing": 0.5,
+  "editor.letterSpacing": 0.5,
   "editor.smoothScrolling": true,
   "editor.tabSize": 2,
   "editor.codeActionsOnSave": {

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -12,6 +12,5 @@
   "prisma-smart-formatter.prisma.defaultFormatter": "Prisma.prisma",
   "i18n-ally.localesPaths": [
     "store/messages"
-  ],
-  "deno.enable": false
+  ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,7 @@
 {
-  "editor.fontSize": 13,
+  // "editor.fontSize": 13,
   "editor.fontLigatures": true,
-  "editor.letterSpacing": 0.5,
+  // "editor.letterSpacing": 0.5,
   "editor.smoothScrolling": true,
   "editor.tabSize": 2,
   "editor.codeActionsOnSave": {
@@ -12,5 +12,6 @@
   "prisma-smart-formatter.prisma.defaultFormatter": "Prisma.prisma",
   "i18n-ally.localesPaths": [
     "store/messages"
-  ]
+  ],
+  "deno.enable": false
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Define a global proxy to be used if the instance does not have one
 * Save is on whatsapp on the database
 * Add headers to the instance's webhook registration
+* Debounce message break is now "\n" instead of white space
 
 ### Fixed
 
@@ -16,6 +17,7 @@
 * Use exchange name from .env on RabbitMQ
 * Fixed chatwoot screen
 * It is now possible to send images via the Evolution Channel
+* Removed "version" from docker-compose as it is obsolete (https://dev.to/ajeetraina/do-we-still-use-version-in-compose-3inp)
 
 # 2.1.0 (2024-08-26 15:33)
 

--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -1,5 +1,3 @@
-version: '3.3'
-
 services:
   api:
     container_name: evolution_api
@@ -19,6 +17,7 @@ services:
 
 volumes:
   evolution_instances:
+
 
 networks:
   evolution-net:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,5 +1,3 @@
-version: '3.3'
-
 services:
   api:
     container_name: evolution_api
@@ -18,6 +16,7 @@ services:
 
 volumes:
   evolution_instances:
+
 
 networks:
   evolution-net:

--- a/src/api/integrations/chatbot/chatbot.controller.ts
+++ b/src/api/integrations/chatbot/chatbot.controller.ts
@@ -108,7 +108,7 @@ export class ChatbotController {
     callback: any,
   ) {
     if (userMessageDebounce[remoteJid]) {
-      userMessageDebounce[remoteJid].message += ` ${content}`;
+      userMessageDebounce[remoteJid].message += `\n${content}`;
       this.logger.log('message debounced: ' + userMessageDebounce[remoteJid].message);
       clearTimeout(userMessageDebounce[remoteJid].timeoutId);
     } else {


### PR DESCRIPTION
Using debounce message break as "\n" instead of white spaces allow Bot API to treat better these messages.