### PR TITLE
V2.0.0 contacts push name

### DIFF
--- a/src/api/integrations/channel/evolution/evolution.channel.service.ts
+++ b/src/api/integrations/channel/evolution/evolution.channel.service.ts
@@ -164,7 +164,7 @@ export class EvolutionStartupService extends ChannelStartupService {
 
         await this.updateContact({
           remoteJid: messageRaw.key.remoteJid,
-          pushName: messageRaw.pushName,
+          pushName:  messageRaw.key.fromMe ? '' : (messageRaw.key.fromMe == null ? '' : messageRaw.pushName),
           profilePicUrl: received.profilePicUrl,
         });
       }

--- a/src/api/integrations/channel/evolution/evolution.channel.service.ts
+++ b/src/api/integrations/channel/evolution/evolution.channel.service.ts
@@ -164,7 +164,7 @@ export class EvolutionStartupService extends ChannelStartupService {
 
         await this.updateContact({
           remoteJid: messageRaw.key.remoteJid,
-          pushName:  messageRaw.key.fromMe ? '' : (messageRaw.key.fromMe == null ? '' : messageRaw.pushName),
+          pushName:  messageRaw.key.fromMe ? '' : (messageRaw.key.fromMe == null ? '' : received.pushName),
           profilePicUrl: received.profilePicUrl,
         });
       }

--- a/src/api/integrations/channel/whatsapp/whatsapp.baileys.service.ts
+++ b/src/api/integrations/channel/whatsapp/whatsapp.baileys.service.ts
@@ -1179,7 +1179,7 @@ export class BaileysStartupService extends ChannelStartupService {
 
           const contactRaw: { remoteJid: string; pushName: string; profilePicUrl?: string; instanceId: string } = {
             remoteJid: received.key.remoteJid,
-            pushName: received.pushName,
+            pushName: received.key.fromMe ? '' : (received.key.fromMe == null ? '' : contact.pushName),
             profilePicUrl: (await this.profilePicture(received.key.remoteJid)).profilePictureUrl,
             instanceId: this.instanceId,
           };
@@ -1191,7 +1191,7 @@ export class BaileysStartupService extends ChannelStartupService {
           if (contact) {
             const contactRaw: { remoteJid: string; pushName: string; profilePicUrl?: string; instanceId: string } = {
               remoteJid: received.key.remoteJid,
-              pushName: contact.pushName,
+              pushName: received.key.fromMe ? '' : (received.key.fromMe == null ? '' : contact.pushName),
               profilePicUrl: (await this.profilePicture(received.key.remoteJid)).profilePictureUrl,
               instanceId: this.instanceId,
             };

--- a/src/api/integrations/channel/whatsapp/whatsapp.baileys.service.ts
+++ b/src/api/integrations/channel/whatsapp/whatsapp.baileys.service.ts
@@ -1179,7 +1179,7 @@ export class BaileysStartupService extends ChannelStartupService {
 
           const contactRaw: { remoteJid: string; pushName: string; profilePicUrl?: string; instanceId: string } = {
             remoteJid: received.key.remoteJid,
-            pushName: received.key.fromMe ? '' : (received.key.fromMe == null ? '' : contact.pushName),
+            pushName: received.key.fromMe ? '' : (received.key.fromMe == null ? '' : received.pushName),
             profilePicUrl: (await this.profilePicture(received.key.remoteJid)).profilePictureUrl,
             instanceId: this.instanceId,
           };
@@ -1189,13 +1189,6 @@ export class BaileysStartupService extends ChannelStartupService {
           }
 
           if (contact) {
-            const contactRaw: { remoteJid: string; pushName: string; profilePicUrl?: string; instanceId: string } = {
-              remoteJid: received.key.remoteJid,
-              pushName: received.key.fromMe ? '' : (received.key.fromMe == null ? '' : contact.pushName),
-              profilePicUrl: (await this.profilePicture(received.key.remoteJid)).profilePictureUrl,
-              instanceId: this.instanceId,
-            };
-
             this.sendDataWebhook(Events.CONTACTS_UPDATE, contactRaw);
 
             if (this.configService.get<Chatwoot>('CHATWOOT').ENABLED && this.localChatwoot?.enabled) {


### PR DESCRIPTION
Ao criar o contato pelo evento de message.upsert estamos considerando que o pushName sempre será o nome do contato e isso não é verdade. Um outro ponto, tem problema em atualizar o nome do contato sempre que uma nova mensagem é recebida?