### PR TITLE
Escutar a configuração do webhook para midias recebidas

### DIFF
--- a/src/api/integrations/channel/whatsapp/whatsapp.baileys.service.ts
+++ b/src/api/integrations/channel/whatsapp/whatsapp.baileys.service.ts
@@ -598,6 +598,7 @@ export class BaileysStartupService extends ChannelStartupService {
     try {
       this.loadChatwoot();
       this.loadSettings();
+      this.loadWebhook();
       this.loadProxy();
 
       return await this.createClient(number);
@@ -1152,18 +1153,20 @@ export class BaileysStartupService extends ChannelStartupService {
             }
           }
 
-          if (isMedia && !this.configService.get<S3>('S3').ENABLE) {
-            const buffer = await downloadMediaMessage(
-              { key: received.key, message: received?.message },
-              'buffer',
-              {},
-              {
-                logger: P({ level: 'error' }) as any,
-                reuploadRequest: this.client.updateMediaMessage,
-              },
-            );
+          if (this.localWebhook.enabled) {
+            if (isMedia && this.localWebhook.webhookBase64) {
+              const buffer = await downloadMediaMessage(
+                { key: received.key, message: received?.message },
+                'buffer',
+                {},
+                {
+                  logger: P({ level: 'error' }) as any,
+                  reuploadRequest: this.client.updateMediaMessage,
+                },
+              );
 
-            messageRaw.message.base64 = buffer ? buffer.toString('base64') : undefined;
+              messageRaw.message.base64 = buffer ? buffer.toString('base64') : undefined;
+            }
           }
 
           this.logger.log(messageRaw);
@@ -2070,18 +2073,20 @@ export class BaileysStartupService extends ChannelStartupService {
         }
       }
 
-      if (isMedia && !this.configService.get<S3>('S3').ENABLE) {
-        const buffer = await downloadMediaMessage(
-          { key: messageRaw.key, message: messageRaw?.message },
-          'buffer',
-          {},
-          {
-            logger: P({ level: 'error' }) as any,
-            reuploadRequest: this.client.updateMediaMessage,
-          },
-        );
+      if (this.localWebhook.enabled) {
+        if (isMedia && this.localWebhook.webhookBase64) {
+          const buffer = await downloadMediaMessage(
+            { key: messageRaw.key, message: messageRaw?.message },
+            'buffer',
+            {},
+            {
+              logger: P({ level: 'error' }) as any,
+              reuploadRequest: this.client.updateMediaMessage,
+            },
+          );
 
-        messageRaw.message.base64 = buffer ? buffer.toString('base64') : undefined;
+          messageRaw.message.base64 = buffer ? buffer.toString('base64') : undefined;
+        }
       }
 
       this.logger.log(messageRaw);

--- a/src/api/services/channel.service.ts
+++ b/src/api/services/channel.service.ts
@@ -34,6 +34,7 @@ export class ChannelStartupService {
   public readonly localChatwoot: wa.LocalChatwoot = {};
   public readonly localProxy: wa.LocalProxy = {};
   public readonly localSettings: wa.LocalSettings = {};
+  public readonly localWebhook: wa.LocalWebHook = {};
 
   public chatwootService = new ChatwootService(
     waMonitor,
@@ -122,6 +123,17 @@ export class ChannelStartupService {
 
   public get wuid() {
     return this.instance.wuid;
+  }
+
+  public async loadWebhook() {
+    const data = await this.prismaRepository.webhook.findUnique({
+      where: {
+        instanceId: this.instanceId,
+      },
+    });
+
+    this.localWebhook.enabled = data?.enabled;
+    this.localWebhook.webhookBase64 = data?.webhookBase64;
   }
 
   public async loadSettings() {


### PR DESCRIPTION
Correção para que o webhook passe a respeitar se deve ou não enviar o anexo de midia em base64 no webhook

#956 