### PR TITLE
Add ContextInfo to return in FindMessages

### DIFF
--- a/src/api/services/channel.service.ts
+++ b/src/api/services/channel.service.ts
@@ -577,6 +577,7 @@ export class ChannelStartupService {
         messageTimestamp: true,
         instanceId: true,
         source: true,
+        contextInfo: true,
         MessageUpdate: {
           select: {
             status: true,


### PR DESCRIPTION
Adicionar ao retorno do endpoint findMessages(fetchMessages) o 'contextInfo' (essa info vem via websocket, mas não via API).