### PR TITLE
(whatsapp.baileys.service.ts): adiciona novos campos de grupo na integração do WhatsApp

### DIFF
--- a/src/api/integrations/channel/whatsapp/whatsapp.baileys.service.ts
+++ b/src/api/integrations/channel/whatsapp/whatsapp.baileys.service.ts
@@ -3552,6 +3552,9 @@ export class BaileysStartupService extends ChannelStartupService {
         restrict: group.restrict,
         announce: group.announce,
         participants: group.participants,
+        isCommunity: group.isCommunity,
+        isCommunityAnnounce: group.isCommunityAnnounce,
+        linkedParent: group.linkedParent,
       };
     } catch (error) {
       if (reply === 'inner') {
@@ -3581,6 +3584,9 @@ export class BaileysStartupService extends ChannelStartupService {
         descId: group.descId,
         restrict: group.restrict,
         announce: group.announce,
+        isCommunity: group.isCommunity,
+        isCommunityAnnounce: group.isCommunityAnnounce,
+        linkedParent: group.linkedParent,
       };
 
       if (getParticipants.getParticipants == 'true') {


### PR DESCRIPTION
A inclusão dos campos isCommunity, isCommunityAnnounce e linkedParent na integração do WhatsApp permite que o serviço manipule informações adicionais sobre grupos. Isso melhora a funcionalidade e a flexibilidade do serviço, possibilitando um melhor gerenciamento e interação com grupos comunitários no WhatsApp.