### PR TITLE
refactor: Update content_attributes in ChatwootService

### DIFF
--- a/src/api/integrations/chatbot/chatwoot/services/chatwoot.service.ts
+++ b/src/api/integrations/chatbot/chatwoot/services/chatwoot.service.ts
@@ -954,9 +954,10 @@ export class ChatwootService {
       const replyToIds = await this.getReplyToIds(messageBody, instance);
 
       if (replyToIds.in_reply_to || replyToIds.in_reply_to_external_id) {
-        data.append('content_attributes', {
-          ...replyToIds,
-        });
+        const content = JSON.stringify({
+          ...replyToIds
+        })
+        data.append('content_attributes', content);
       }
     }
 


### PR DESCRIPTION
This commit refactors the code in ChatwootService to update the content_attributes when replyToIds are present. Instead of directly spreading the replyToIds object, the code now converts it to a JSON string and appends it to the data object.

Refactor the code to improve readability and maintainability.