### PR TITLE
refactor: Remove unnecessary code for handling contact not in WhatsApp and onSendMessageError

### DIFF
--- a/src/api/integrations/channel/whatsapp/whatsapp.baileys.service.ts
+++ b/src/api/integrations/channel/whatsapp/whatsapp.baileys.service.ts
@@ -1898,17 +1898,6 @@ export class BaileysStartupService extends ChannelStartupService {
     const isWA = (await this.whatsappNumber({ numbers: [number] }))?.shift();
 
     if (!isWA.exists && !isJidGroup(isWA.jid) && !isWA.jid.includes('@broadcast')) {
-      if (this.configService.get<Chatwoot>('CHATWOOT').ENABLED && this.localChatwoot?.enabled) {
-        const body = {
-          key: { remoteJid: isWA.jid },
-        };
-
-        this.chatwootService.eventWhatsapp(
-          'contact.is_not_in_wpp',
-          { instanceName: this.instance.name, instanceId: this.instance.id },
-          body,
-        );
-      }
       throw new BadRequestException(isWA);
     }
 

--- a/src/api/integrations/chatbot/chatwoot/services/chatwoot.service.ts
+++ b/src/api/integrations/chatbot/chatwoot/services/chatwoot.service.ts
@@ -1136,10 +1136,26 @@ export class ChatwootService {
     }
   }
 
-  public async onSendMessageError(instance: InstanceDto, conversation: number, error?: string) {
+  public async onSendMessageError(instance: InstanceDto, conversation: number, error?: any) {
+    this.logger.verbose(`onSendMessageError ${JSON.stringify(error)}`);
+
     const client = await this.clientCw(instance);
 
     if (!client) {
+      return;
+    }
+
+    if (error && error?.status === 400 && error?.message[0]?.exists === false) {
+      client.messages.create({
+        accountId: this.provider.accountId,
+        conversationId: conversation,
+        data: {
+          content: `${i18next.t('cw.message.numbernotinwhatsapp')}`,
+          message_type: 'outgoing',
+          private: true,
+        },
+      });
+
       return;
     }
 
@@ -1148,7 +1164,7 @@ export class ChatwootService {
       conversationId: conversation,
       data: {
         content: i18next.t('cw.message.notsent', {
-          error: error?.length > 0 ? `_${error}_` : '',
+          error: error ? `_${error.toString()}_` : '',
         }),
         message_type: 'outgoing',
         private: true,
@@ -1392,7 +1408,7 @@ export class ChatwootService {
               );
             } catch (error) {
               if (!messageSent && body.conversation?.id) {
-                this.onSendMessageError(instance, body.conversation?.id, error.toString());
+                this.onSendMessageError(instance, body.conversation?.id, error);
               }
               throw error;
             }
@@ -1850,27 +1866,6 @@ export class ChatwootService {
           this.logger.warn('Ignoring message from jid: ' + body?.key?.remoteJid);
           return;
         }
-      }
-
-      if (event === 'contact.is_not_in_wpp') {
-        const getConversation = await this.createConversation(instance, body);
-
-        if (!getConversation) {
-          this.logger.warn('conversation not found');
-          return;
-        }
-
-        client.messages.create({
-          accountId: this.provider.accountId,
-          conversationId: getConversation,
-          data: {
-            content: `🚨 ${i18next.t('numbernotinwhatsapp')}`,
-            message_type: 'outgoing',
-            private: true,
-          },
-        });
-
-        return;
       }
 
       if (event === 'messages.upsert' || event === 'send.message') {

--- a/src/utils/translations/en.json
+++ b/src/utils/translations/en.json
@@ -2,7 +2,6 @@
   "qrgeneratedsuccesfully": "QRCode successfully generated!",
   "scanqr": "Scan this QR code within the next 40 seconds.",
   "qrlimitreached": "QRCode generation limit reached, to generate a new QRCode, send the 'init' message again.",
-  "numbernotinwhatsapp": "The message was not sent as the contact is not a valid Whatsapp number.",
   "cw.inbox.connected": "🚀 Connection successfully established!",
   "cw.inbox.disconnect": "🚨 Disconnecting WhatsApp from inbox *{{inboxName}}*.",
   "cw.inbox.alreadyConnected": "🚨 {{inboxName}} instance is connected.",
@@ -23,5 +22,6 @@
   "cw.contactMessage.name": "Name",
   "cw.contactMessage.number": "Number",
   "cw.message.notsent": "🚨 The message could not be sent. Please check your connection. {{error}}",
+  "cw.message.numbernotinwhatsapp": "🚨 The message was not sent as the contact is not a valid Whatsapp number.",
   "cw.message.edited": "Edited Message"
 }

--- a/src/utils/translations/es.json
+++ b/src/utils/translations/es.json
@@ -2,7 +2,6 @@
   "qrgeneratedsuccesfully": "Código QR generado exitosamente!",
   "scanqr": "Escanea este código QR en los próximos 40 segundos.",
   "qrlimitreached": "🚨 Se alcanzó el límite de generación de QRCode. Para generar un nuevo QRCode, envíe el mensaje 'init' nuevamente.",
-  "numbernotinwhatsapp": "⚠️ El mensaje no fue enviado porque el contacto no es un número de Whatsapp válido..",
   "cw.inbox.connected": "🚀 ¡Conexión establecida exitosamente!",
   "cw.inbox.disconnect": "🚨 Instancia *{{inboxName}}* desconectado de Whatsapp.",
   "cw.inbox.alreadyConnected": "🚨 La instancia {{inboxName}} está conectada.",
@@ -23,5 +22,6 @@
   "cw.contactMessage.name": "Nombre",
   "cw.contactMessage.number": "Numero",
   "cw.message.notsent": "🚨 El mensaje no se pudo enviar. Comprueba tu conexión. {{error}}",
+  "cw.message.numbernotinwhatsapp": "🚨 El mensaje no fue enviado porque el contacto no es un número de Whatsapp válido.",
   "cw.message.edited": "Mensaje editado"
 }

--- a/src/utils/translations/pt-BR.json
+++ b/src/utils/translations/pt-BR.json
@@ -2,7 +2,6 @@
   "qrgeneratedsuccesfully": "QRCode gerado com sucesso!",
   "scanqr": "Escaneie o QRCode com o WhatsApp nos próximos 40 segundos.",
   "qrlimitreached": "Limite de geração de QRCode atingido! Para gerar um novo QRCode, envie o texto 'init' nesta conversa.",
-  "numbernotinwhatsapp": "A mensagem não foi enviada, pois o contato não é um número válido do WhatsApp.",
   "cw.inbox.connected": "🚀 Conectado com sucesso!",
   "cw.inbox.disconnect": "🚨 Instância *{{inboxName}}* desconectada do WhatsApp.",
   "cw.inbox.alreadyConnected": "🚨 Instância *{{inboxName}}* já está conectada.",
@@ -23,5 +22,6 @@
   "cw.contactMessage.name": "Nome",
   "cw.contactMessage.number": "Número",
   "cw.message.notsent": "🚨 Não foi possível enviar a mensagem. Verifique sua conexão. {{error}}",
+  "cw.message.numbernotinwhatsapp": "🚨 A mensagem não foi enviada, pois o contato não é um número válido do WhatsApp.",
   "cw.message.edited": "Mensagem editada"
 }


### PR DESCRIPTION
Aprimoramento no método _onSendMessageError_:

**Tratamento de erro de contato sem WhatsApp:**
Anteriormente, quando um contato não possuía uma conta de WhatsApp, o sistema enviava duas mensagens de erro ao Chatwoot. Esse comportamento foi corrigido, e agora, apenas uma mensagem de erro é enviada, informando que o contato não possui WhatsApp.

Antes:
![image](https://github.com/user-attachments/assets/b0bfac51-49ce-4793-96d1-3637086c507a)

Depois:

![image](https://github.com/user-attachments/assets/88b317ed-7a6b-4da2-9040-afe6190b726e)



**Exibição de erros retornando objetos:**
Em certos cenários, quando o método encontrava um erro e um objeto de erro era retornado, essa informação não era exibida no Chatwoot. A melhoria aplicada corrige essa situação, permitindo que erros que retornam objetos sejam devidamente apresentados na interface do Chatwoot, proporcionando maior clareza e rastreabilidade para os operadores.

Antes:
![image](https://github.com/user-attachments/assets/a8effbc0-b8e0-49ab-b1b0-b04d82c315d6)

Depois:
![image](https://github.com/user-attachments/assets/7b1ca4f4-e7f5-462d-a153-9c4a5d8e2d97)

**Outros**
Adicionado um log verbose do json retornado quando acontece algum erro no envio da mensagem.
Alterado a key da mensagem de erro de numbernotinwhatsapp no padrão das outras mensagens nas traduções