### PR TITLE
feat: add support for fetching multiple instances by key

### DIFF
--- a/src/api/controllers/instance.controller.ts
+++ b/src/api/controllers/instance.controller.ts
@@ -360,27 +360,25 @@ export class InstanceController {
   public async fetchInstances({ instanceName, instanceId, number }: InstanceDto, key: string) {
     const env = this.configService.get<Auth>('AUTHENTICATION').API_KEY;
 
-    let name = instanceName;
-    // let arrayReturn = false;
-
     if (env.KEY !== key) {
-      const instanceByKey = await this.prismaRepository.instance.findMany({
+      const instancesByKey = await this.prismaRepository.instance.findMany({
         where: {
           token: key,
+          name: instanceName || undefined,
+          id: instanceId || undefined,
         },
       });
 
-      if (instanceByKey) {
-        name = instanceByKey[0].name;
-        // arrayReturn = true;
+      if (instancesByKey.length > 0) {
+        const names = instancesByKey.map((instance) => instance.name);
+
+        return this.waMonitor.instanceInfo(names);
       } else {
         throw new UnauthorizedException();
       }
     }
 
-    if (name) {
-      return this.waMonitor.instanceInfo(name);
-    } else if (instanceId || number) {
+    if (instanceId || number) {
       return this.waMonitor.instanceInfoById(instanceId, number);
     }
 

--- a/src/api/integrations/channel/whatsapp/whatsapp.baileys.service.ts
+++ b/src/api/integrations/channel/whatsapp/whatsapp.baileys.service.ts
@@ -1699,7 +1699,7 @@ export class BaileysStartupService extends ChannelStartupService {
           website: business?.website?.shift(),
         };
       } else {
-        const info: Instance = await waMonitor.instanceInfo(instanceName);
+        const info: Instance = await waMonitor.instanceInfo([instanceName]);
         const business = await this.fetchBusinessProfile(jid);
 
         return {


### PR DESCRIPTION
This commit adds a new feature to fetch instances by key in the InstanceController. If the provided key does not match the environment key, the controller will search for instances with the matching token. If instances are found, the names are extracted and passed to the waMonitor to retrieve instance information.

Also, update the waMonitor's instanceInfo method to accept an array of instance names instead of a single name.

Fixes #990