### PR TITLE
Ajuste nos tipos de mensagem respondidas

### DIFF
--- a/src/api/integrations/channel/whatsapp/whatsapp.baileys.service.ts
+++ b/src/api/integrations/channel/whatsapp/whatsapp.baileys.service.ts
@@ -4259,6 +4259,19 @@ export class BaileysStartupService extends ChannelStartupService {
       delete messageRaw.message.documentWithCaptionMessage;
     }
 
+    const quotedMessage = messageRaw?.contextInfo?.quotedMessage;
+    if (quotedMessage) {
+      if (quotedMessage.extendedTextMessage) {
+        quotedMessage.conversation = quotedMessage.extendedTextMessage.text;
+        delete quotedMessage.extendedTextMessage;
+      }
+
+      if (quotedMessage.documentWithCaptionMessage) {
+        quotedMessage.documentMessage = quotedMessage.documentWithCaptionMessage.message.documentMessage;
+        delete quotedMessage.documentWithCaptionMessage;
+      }
+    }
+
     return messageRaw;
   }
 


### PR DESCRIPTION
Aplica o mesmo padrão dos tipos de mensagens dos quais foram aplicados nos playloads de envio e recebimento, transformando "extendedTextMessage" e "documentWithCaptionMessage" em "conversation" e "documentMessage".