### PR TITLE
Adiciona o número de telefone do remetente nas mensagens recebidas do WhatsApp antes do nome do contato (GRUPOS)

### DIFF
--- a/src/api/integrations/chatbot/chatwoot/services/chatwoot.service.ts
+++ b/src/api/integrations/chatbot/chatwoot/services/chatwoot.service.ts
@@ -1970,11 +1970,16 @@ export class ChatwootService {
 
           if (body.key.remoteJid.includes('@g.us')) {
             const participantName = body.pushName;
+            const rawPhoneNumber = body.key.remoteJid.split('@')[0];
+            const formattedPhoneNumber = `+${rawPhoneNumber.slice(0, 2)} (${rawPhoneNumber.slice(
+              2,
+              4,
+            )}) ${rawPhoneNumber.slice(4, 8)}-${rawPhoneNumber.slice(8)}`;
 
             let content: string;
 
             if (!body.key.fromMe) {
-              content = `**${participantName}:**\n\n${bodyMessage}`;
+              content = `**${formattedPhoneNumber} - ${participantName}:**\n\n${bodyMessage}`;
             } else {
               content = `${bodyMessage}`;
             }
@@ -2099,11 +2104,16 @@ export class ChatwootService {
 
         if (body.key.remoteJid.includes('@g.us')) {
           const participantName = body.pushName;
+          const rawPhoneNumber = body.key.remoteJid.split('@')[0];
+          const formattedPhoneNumber = `+${rawPhoneNumber.slice(0, 2)} (${rawPhoneNumber.slice(
+            2,
+            4,
+          )}) ${rawPhoneNumber.slice(4, 8)}-${rawPhoneNumber.slice(8)}`;
 
           let content: string;
 
           if (!body.key.fromMe) {
-            content = `**${participantName}**\n\n${bodyMessage}`;
+            content = `**${formattedPhoneNumber} - ${participantName}:**\n\n${bodyMessage}`;
           } else {
             content = `${bodyMessage}`;
           }


### PR DESCRIPTION

# Adiciona o número de telefone do remetente nas mensagens recebidas do WhatsApp antes do nome do contato (EM GRUPOS)

## Descrição

Este PR realiza uma pequena melhoria no conteúdo das mensagens recebidas pelos grupos no WhatsApp, adicionando o número de telefone do remetente antes do nome do contato, facilitando a visualização do número diretamente na conversa.

### Motivação

Anteriormente, as mensagens enviadas para o Chatwoot continham apenas o nome do remetente no conteúdo da mensagem. Esta atualização adiciona o número de telefone do contato antes do nome, proporcionando melhor identificação do remetente sem a necessidade de procurar o número separadamente.

### Alterações

1. **Modificação no formato de exibição de mensagens recebidas**:
   - O número de telefone do remetente agora é exibido antes do nome do contato na mensagem formatada.

### Exemplo de mensagem antes da alteração

```plaintext
**João Silva:** Olá! Gostaria de saber mais sobre os serviços.
```

### Exemplo de mensagem após a alteração

```plaintext
**+55 (11) 91234-5678 - João Silva:** Olá! Gostaria de saber mais sobre os serviços.
```

## Observações

Essa atualização melhora a clareza das informações de contato e agiliza o atendimento, fornecendo o número de telefone em um formato visualmente destacado antes do nome do remetente.