### PR TITLE
Correção: Número de telefone apresentado no nome do contato (CW Service)

### DIFF
--- a/src/api/integrations/chatbot/chatwoot/services/chatwoot.service.ts
+++ b/src/api/integrations/chatbot/chatwoot/services/chatwoot.service.ts
@@ -1970,11 +1970,16 @@ export class ChatwootService {
 
           if (body.key.remoteJid.includes('@g.us')) {
             const participantName = body.pushName;
-            const rawPhoneNumber = body.key.remoteJid.split('@')[0];
-            const formattedPhoneNumber = `+${rawPhoneNumber.slice(0, 2)} (${rawPhoneNumber.slice(
-              2,
-              4,
-            )}) ${rawPhoneNumber.slice(4, 8)}-${rawPhoneNumber.slice(8)}`;
+            const rawPhoneNumber = body.key.participant.split('@')[0];
+            const phoneMatch = rawPhoneNumber.match(/^(\d{2})(\d{2})(\d{4})(\d{4})$/);
+
+            let formattedPhoneNumber: string;
+
+            if (phoneMatch) {
+              formattedPhoneNumber = `+${phoneMatch[1]} (${phoneMatch[2]}) ${phoneMatch[3]}-${phoneMatch[4]}`;
+            } else {
+              formattedPhoneNumber = `+${rawPhoneNumber}`;
+            }
 
             let content: string;
 
@@ -2104,11 +2109,16 @@ export class ChatwootService {
 
         if (body.key.remoteJid.includes('@g.us')) {
           const participantName = body.pushName;
-          const rawPhoneNumber = body.key.remoteJid.split('@')[0];
-          const formattedPhoneNumber = `+${rawPhoneNumber.slice(0, 2)} (${rawPhoneNumber.slice(
-            2,
-            4,
-          )}) ${rawPhoneNumber.slice(4, 8)}-${rawPhoneNumber.slice(8)}`;
+          const rawPhoneNumber = body.key.participant.split('@')[0];
+          const phoneMatch = rawPhoneNumber.match(/^(\d{2})(\d{2})(\d{4})(\d{4})$/);
+
+          let formattedPhoneNumber: string;
+
+          if (phoneMatch) {
+            formattedPhoneNumber = `+${phoneMatch[1]} (${phoneMatch[2]}) ${phoneMatch[3]}-${phoneMatch[4]}`;
+          } else {
+            formattedPhoneNumber = `+${rawPhoneNumber}`;
+          }
 
           let content: string;
 


### PR DESCRIPTION

# Correção da exibição do número do telefone do remetente nas mensagens recebidas do WhatsApp

## Descrição

Este PR corrige o problema na exibição do número de telefone do remetente nas mensagens recebidas do WhatsApp, que anteriormente incluía um ID incorreto. Agora, o número é extraído corretamente a partir do campo `participant` para garantir que apenas o número de telefone do remetente seja exibido antes do nome do contato.

### Motivação

A extração anterior do número de telefone estava utilizando o campo `remoteJid`, que incluía um identificador incorreto. Este ajuste melhora a clareza da informação e garante que o número exibido seja o correto para facilitar o atendimento.

### Alterações

1. **Correção na extração do número de telefone do remetente**:
   - Substitui a extração do número de `remoteJid` para o campo `participant`.
   - O número agora é formatado corretamente e precede o nome do contato na mensagem.

### Exemplo de mensagem antes da correção

```plaintext
**+12 (03) 6329-3577793308 - João Silva:** Olá! Gostaria de saber mais sobre os serviços.
```

### Exemplo de mensagem após a correção

```plaintext
**+55 (47) 9117-9003 - Gabriel Melo:** Olá! Gostaria de saber mais sobre os serviços.
```

## Testes

- [x] Testado manualmente com mensagens de grupo e contatos individuais.
- [x] Verificado com diferentes formatos de número para garantir a exibição correta.

## Checklist

- [x] Código testado localmente para garantir funcionamento esperado.
- [x] Revisão de código realizada.

## Observações

Essa correção assegura que o número de telefone correto seja exibido antes do nome do remetente, melhorando a clareza e a utilidade das informações para o atendimento.
