### PR TITLE
fix: esvazia textBuffer dos chatbots no sendMessageWhatsapp quando splitMessages é true

### DIFF
--- a/src/api/integrations/chatbot/dify/services/dify.service.ts
+++ b/src/api/integrations/chatbot/dify/services/dify.service.ts
@@ -428,8 +428,8 @@ export class DifyService {
               },
               false,
             );
-            textBuffer = '';
           }
+          textBuffer = '';
         }
 
         if (mediaType === 'audio') {

--- a/src/api/integrations/chatbot/evolutionBot/services/evolutionBot.service.ts
+++ b/src/api/integrations/chatbot/evolutionBot/services/evolutionBot.service.ts
@@ -190,8 +190,8 @@ export class EvolutionBotService {
               },
               false,
             );
-            textBuffer = '';
           }
+          textBuffer = '';
         }
 
         if (mediaType === 'audio') {
@@ -274,8 +274,8 @@ export class EvolutionBotService {
           },
           false,
         );
-        textBuffer = '';
       }
+      textBuffer = '';
     }
 
     sendTelemetry('/message/sendText');

--- a/src/api/integrations/chatbot/flowise/services/flowise.service.ts
+++ b/src/api/integrations/chatbot/flowise/services/flowise.service.ts
@@ -189,8 +189,8 @@ export class FlowiseService {
               },
               false,
             );
-            textBuffer = '';
           }
+          textBuffer = '';
         }
 
         if (mediaType === 'audio') {
@@ -273,8 +273,8 @@ export class FlowiseService {
           },
           false,
         );
-        textBuffer = '';
       }
+      textBuffer = '';
     }
 
     sendTelemetry('/message/sendText');

--- a/src/api/integrations/chatbot/openai/services/openai.service.ts
+++ b/src/api/integrations/chatbot/openai/services/openai.service.ts
@@ -234,8 +234,8 @@ export class OpenaiService {
               },
               false,
             );
-            textBuffer = '';
           }
+          textBuffer = '';
         }
 
         if (mediaType === 'audio') {
@@ -318,8 +318,8 @@ export class OpenaiService {
           },
           false,
         );
-        textBuffer = '';
       }
+      textBuffer = '';
     }
 
     sendTelemetry('/message/sendText');


### PR DESCRIPTION
Este PR resolve um problema onde o text buffer não é esvaziado corretamente quando splitMessages está configurado como true. Esse comportamento causa o envio incorreto das mensagens, pois a última mensagem enviada pelo chatbot no WhatsApp inclui também mensagens anteriores.