### PR TITLE
Correção de envio de áudio para OpenAI via Cloud API

### DIFF
--- a/src/api/integrations/channel/meta/whatsapp.business.service.ts
+++ b/src/api/integrations/channel/meta/whatsapp.business.service.ts
@@ -465,16 +465,23 @@ export class BusinessStartupService extends ChannelStartupService {
             },
           });
 
+          const audioMessage = received?.messages[0]?.audio;
+
           if (
             openAiDefaultSettings &&
             openAiDefaultSettings.openaiCredsId &&
             openAiDefaultSettings.speechToText &&
-            received?.message?.audioMessage
+            audioMessage
           ) {
             messageRaw.message.speechToText = await this.openaiService.speechToText(
               openAiDefaultSettings.OpenaiCreds,
-              received,
-              this.client.updateMediaMessage,
+              {
+                message: {
+                  mediaUrl: messageRaw.message.mediaUrl,
+                  ...messageRaw,
+                }
+              },
+              () => {},
             );
           }
         }


### PR DESCRIPTION
Foi corrigido o envio de áudio para transcrição pela OpenAI, com as `env`s `LANGUAGE=pt` e `OPENAI_ENABLED=true` configuradas, via Cloud API.