### PR TITLE
Update docker-compose and .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,7 +26,7 @@ DEL_INSTANCE=false
 
 # Provider: postgresql | mysql
 DATABASE_PROVIDER=postgresql
-DATABASE_CONNECTION_URI='postgresql://user:pass@localhost:5432/evolution?schema=public'
+DATABASE_CONNECTION_URI='postgresql://user:pass@postgres:5432/evolution?schema=public'
 # Client name for the database connection
 # It is used to separate an API installation from another that uses the same database.
 DATABASE_CONNECTION_CLIENT_NAME=evolution_exchange

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -34,12 +34,15 @@ services:
     image: postgres:15
     networks:
       - evolution-net
-    command: ["postgres", "-c", "max_connections=1000"]
+    command: ["postgres", "-c", "max_connections=1000", "-c", "listen_addresses=*"]
     restart: always
     ports:
       - 5432:5432
     environment:
-      - POSTGRES_PASSWORD=PASSWORD
+      - POSTGRES_USER=user
+      - POSTGRES_PASSWORD=pass
+      - POSTGRES_DB=evolution
+      - POSTGRES_HOST_AUTH_METHOD=trust
     volumes:
       - postgres_data:/var/lib/postgresql/data
     expose:


### PR DESCRIPTION
Error:

Database URL: 
Environment variables loaded from .env
Prisma schema loaded from prisma/postgresql-schema.prisma
Datasource "db": PostgreSQL database "evolution", schema "public" at "localhost:5432"
Error: P1001: Can't reach database server at localhost:5432

Fix:

Update `docker-compose.yaml` and `.env.example` files to configure PostgreSQL service and connection URI.

* **docker-compose.yaml**
  - Add `listen_addresses=*` command to the `postgres` service.
  - Add environment variables: `POSTGRES_USER=user`, `POSTGRES_PASSWORD=pass`, `POSTGRES_DB=evolution`, `POSTGRES_HOST_AUTH_METHOD=trust`.

* **.env.example**
  - Update `DATABASE_CONNECTION_URI` to `postgresql://user:pass@postgres:5432/evolution?schema=public`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/EvolutionAPI/evolution-api/pull/1073?shareId=0c4d71ca-a59b-40b2-bd3b-b7c4afb5efae).