### PR TITLE
[FIX] Fixando label handler e chats

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "class-validator": "^0.14.1",
     "compression": "^1.7.4",
     "cors": "^2.8.5",
+    "cuid": "^3.0.0",
     "dayjs": "^1.11.7",
     "dotenv": "^16.4.5",
     "eventemitter2": "^6.4.9",

--- a/prisma/mysql-schema.prisma
+++ b/prisma/mysql-schema.prisma
@@ -127,6 +127,7 @@ model Chat {
   unreadMessages Int       @default(0)
   @@index([instanceId])
   @@index([remoteJid])
+  @@unique([remoteJid, instanceId])
 }
 
 model Contact {

--- a/prisma/postgresql-schema.prisma
+++ b/prisma/postgresql-schema.prisma
@@ -127,6 +127,7 @@ model Chat {
   unreadMessages Int       @default(0)
   @@index([instanceId])
   @@index([remoteJid])
+  @@unique([remoteJid, instanceId])
 }
 
 model Contact {

--- a/src/api/integrations/channel/whatsapp/whatsapp.baileys.service.ts
+++ b/src/api/integrations/channel/whatsapp/whatsapp.baileys.service.ts
@@ -1147,7 +1147,10 @@ export class BaileysStartupService extends ChannelStartupService {
 
             this.sendDataWebhook(Events.CHATS_UPSERT, [chatToInsert]);
             if (this.configService.get<Database>('DATABASE').SAVE_DATA.CHATS) {
-              await this.prismaRepository.chat.create({
+              await this.prismaRepository.chat.update({
+                where: {
+                  id: existingChat.id,
+                },
                 data: chatToInsert,
               });
             }
@@ -1483,7 +1486,10 @@ export class BaileysStartupService extends ChannelStartupService {
 
             this.sendDataWebhook(Events.CHATS_UPSERT, [chatToInsert]);
             if (this.configService.get<Database>('DATABASE').SAVE_DATA.CHATS) {
-              await this.prismaRepository.chat.create({
+              await this.prismaRepository.chat.update({
+                where: {
+                  id: existingChat.id,
+                },
                 data: chatToInsert,
               });
             }

--- a/src/api/integrations/channel/whatsapp/whatsapp.baileys.service.ts
+++ b/src/api/integrations/channel/whatsapp/whatsapp.baileys.service.ts
@@ -3861,7 +3861,7 @@ export class BaileysStartupService extends ChannelStartupService {
     }));
   }
 
-  public async handleLabel(data: HandleLabelDto, instanceId: string) {
+  public async handleLabel(data: HandleLabelDto) {
     const whatsappContact = await this.whatsappNumber({ numbers: [data.number] });
     if (whatsappContact.length === 0) {
       throw new NotFoundException('Number not found');
@@ -3874,13 +3874,13 @@ export class BaileysStartupService extends ChannelStartupService {
     try {
       if (data.action === 'add') {
         await this.client.addChatLabel(contact.jid, data.labelId);
-        await this.addLabel(data.labelId, instanceId, contact.jid);
+        await this.addLabel(data.labelId, this.instanceId, contact.jid);
 
         return { numberJid: contact.jid, labelId: data.labelId, add: true };
       }
       if (data.action === 'remove') {
         await this.client.removeChatLabel(contact.jid, data.labelId);
-        await this.removeLabel(data.labelId, instanceId, contact.jid);
+        await this.removeLabel(data.labelId, this.instanceId, contact.jid);
 
         return { numberJid: contact.jid, labelId: data.labelId, remove: true };
       }

--- a/src/api/services/channel.service.ts
+++ b/src/api/services/channel.service.ts
@@ -655,8 +655,8 @@ export class ChannelStartupService {
             (ARRAY_AGG("Message"."sessionId" ORDER BY "Message"."messageTimestamp" DESC))[1] AS last_message_session_id,
             (ARRAY_AGG("Message"."status" ORDER BY "Message"."messageTimestamp" DESC))[1] AS last_message_status
           FROM "Chat"
-          LEFT JOIN "Message" ON "Message"."messageType" != 'reactionMessage' and "Message"."key"->>'remoteJid' = "Chat"."remoteJid"
-          LEFT JOIN "Contact" ON "Chat"."remoteJid" = "Contact"."remoteJid"
+          LEFT JOIN "Message" ON "Message"."messageType" != 'reactionMessage' and "Message"."key"->>'remoteJid' = "Chat"."remoteJid"  AND "Chat"."instanceId" = "Message"."instanceId"
+          LEFT JOIN "Contact" ON "Chat"."remoteJid" = "Contact"."remoteJid" AND "Chat"."instanceId" = "Contact"."instanceId"
           WHERE 
             "Chat"."instanceId" = ${this.instanceId}
           GROUP BY
@@ -690,8 +690,8 @@ export class ChannelStartupService {
             (ARRAY_AGG("Message"."sessionId" ORDER BY "Message"."messageTimestamp" DESC))[1] AS last_message_session_id,
             (ARRAY_AGG("Message"."status" ORDER BY "Message"."messageTimestamp" DESC))[1] AS last_message_status
           FROM "Chat"
-          LEFT JOIN "Message" ON "Message"."messageType" != 'reactionMessage' and "Message"."key"->>'remoteJid' = "Chat"."remoteJid"
-          LEFT JOIN "Contact" ON "Chat"."remoteJid" = "Contact"."remoteJid"
+          LEFT JOIN "Message" ON "Message"."messageType" != 'reactionMessage' and "Message"."key"->>'remoteJid' = "Chat"."remoteJid" AND "Chat"."instanceId" = "Message"."instanceId"
+          LEFT JOIN "Contact" ON "Chat"."remoteJid" = "Contact"."remoteJid" AND "Chat"."instanceId" = "Contact"."instanceId"
           WHERE 
             "Chat"."instanceId" = ${this.instanceId} AND "Chat"."remoteJid" = ${remoteJid} and "Message"."messageType" != 'reactionMessage'
           GROUP BY


### PR DESCRIPTION
## Problemas
Encontrei alguns problemas de concorrencia no Handle Label e principalmente duplicação de chats.

1. Ele primeiro fazia um get de todos os chats da instancia para depois realizar o update, caso o usuario adicionasse ou removesse labels ao mesmo tempo existia uma chance muito alta de sobrescrita de labels.
2. Como os chats não eram unicos isso quebrava a lógica das labels e várias outras.
3. Para o caso de duas instancias diferentes salvarem o mesmo numero o findChats retornava como se os numeros fossem da mesma instanceID.
4. No startup da aplicação as labels não eram carregadas adequadamente pois os chats não tinha sido salvos ainda.


## Soluções
1. Realizei as operações diretamente no banco de dados para um risco menor de racing.
2. Defini uma migration para que não hajam problemas com chats duplicados.
3. Adicionei a instanceId na query de join.
4. Agora as labels são tratadas como upsert, no startup, quem chegar primeiro (label ou chat) ele já cria direto.


### Ressalvas
~1. A migration com a unicidade do chat não está sendo realizada corretamente (por isso o PR está em draft)~
~2. No startup da aplicação o handle labels sempre vai ser falho já que os chats não são criados até que o whatsapp esteja sync.~
3. ~Por algum motivo o baileys não funciona em 100% das vezes, muitas vezes ele não chama o evento de labels association. (Sempre após o reinicio da aplicação os eventos de labels.association param de funcionar).~ Erro meu, o redis precisa estar configurado para que esse comportamento não ocorra.
4. Por algum motivo, se eu já tiver conectado em outra instancia do whatsapp web e conectar uma nova instancia na evolution, os eventos de labels ficam inconsistentes, identifiquei o mesmo problema usando o baileys diretamente.

Edit: Este pr usa uma das ideias já feita em outro PR (https://github.com/EvolutionAPI/evolution-api/pull/1012) recomendo mergiar ele primeiro.
