### PR TITLE
chore: improve instrumentSentry.ts import before another import

### DIFF
--- a/src/utils/instrumentSentry.ts
+++ b/src/utils/instrumentSentry.ts
@@ -1,0 +1,12 @@
+import * as Sentry from "@sentry/node";
+
+const dsn = process.env.SENTRY_DSN;
+
+if (dsn) {
+    Sentry.init({
+        dsn: dsn,
+        environment: process.env.NODE_ENV || 'development',
+        tracesSampleRate: 1.0,
+        profilesSampleRate: 1.0,
+    });
+}


### PR DESCRIPTION
O Sentry estava exibindo este alerta na instrumentação do pacote:
![Captura de tela 2024-12-08 151842](https://github.com/user-attachments/assets/93f14cec-156d-43ba-ae1f-801157811afe)

Com a atualização proposta segundo a documentação do Sentry não recebemos mais este aviso:
![Captura de tela 2024-12-08 152446](https://github.com/user-attachments/assets/0c1de685-cb76-4bc5-a186-6f318043b7d8)
