### PR TITLE
Update Dockerfile - Fix Prisma failed to detect the libssl/openssl

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM node:20-alpine AS builder
 
 RUN apk update && \
-    apk add git ffmpeg wget curl bash
+    apk add git ffmpeg wget curl bash openssl libc6-compat
 
 LABEL version="2.2.0" description="Api to control whatsapp features through http requests." 
 LABEL maintainer="Davidson Gomes" git="https://github.com/DavidsonGomes"
@@ -32,7 +32,7 @@ RUN npm run build
 FROM node:20-alpine AS final
 
 RUN apk update && \
-    apk add tzdata ffmpeg bash
+    apk add tzdata ffmpeg bash openssl libc6-compat
 
 ENV TZ=America/Sao_Paulo
 


### PR DESCRIPTION
When try create a image with docker build -t using a external database.