### PR TITLE
fix: include filename in media message payload for WhatsApp Business

### DIFF
--- a/src/api/integrations/channel/meta/whatsapp.business.service.ts
+++ b/src/api/integrations/channel/meta/whatsapp.business.service.ts
@@ -809,7 +809,7 @@ export class BusinessStartupService extends ChannelStartupService {
             [message['mediaType']]: {
               [message['type']]: message['id'],
               preview_url: linkPreview,
-              ...(message['fileName'] && !isImage && { filename: message['fileName'] }), // Adiciona filename apenas se não for imagem
+              ...(message['fileName'] && !isImage && { filename: message['fileName'] }),
               caption: message['caption'],
             },
           };

--- a/src/api/integrations/channel/meta/whatsapp.business.service.ts
+++ b/src/api/integrations/channel/meta/whatsapp.business.service.ts
@@ -807,6 +807,7 @@ export class BusinessStartupService extends ChannelStartupService {
             [message['mediaType']]: {
               [message['type']]: message['id'],
               preview_url: linkPreview,
+              filename: message['fileName'],
               caption: message['caption'],
             },
           };

--- a/src/api/integrations/channel/meta/whatsapp.business.service.ts
+++ b/src/api/integrations/channel/meta/whatsapp.business.service.ts
@@ -799,6 +799,8 @@ export class BusinessStartupService extends ChannelStartupService {
           return await this.post(content, 'messages');
         }
         if (message['media']) {
+          const isImage = message['mimetype']?.startsWith('image/');
+          
           content = {
             messaging_product: 'whatsapp',
             recipient_type: 'individual',
@@ -807,13 +809,13 @@ export class BusinessStartupService extends ChannelStartupService {
             [message['mediaType']]: {
               [message['type']]: message['id'],
               preview_url: linkPreview,
-              filename: message['fileName'],
+              ...(message['fileName'] && !isImage && { filename: message['fileName'] }), // Adiciona filename apenas se não for imagem
               caption: message['caption'],
             },
           };
           quoted ? (content.context = { message_id: quoted.id }) : content;
           return await this.post(content, 'messages');
-        }
+        }          
         if (message['audio']) {
           content = {
             messaging_product: 'whatsapp',


### PR DESCRIPTION
Adicionado suporte para o campo **filename** na payload de mensagens de mídia enviadas pela API do WhatsApp Business.