### PR TITLE
bugfix: SQL query column quoting in ChannelStartupService

### DIFF
--- a/src/api/services/channel.service.ts
+++ b/src/api/services/channel.service.ts
@@ -732,7 +732,7 @@ export class ChannelStartupService {
             "Message"."messageTimestamp" DESC
         )
         SELECT * FROM rankedMessages
-        ORDER BY updatedAt DESC NULLS LAST;
+        ORDER BY "updatedAt" DESC NULLS LAST;
     `;
 
     if (results && isArray(results) && results.length > 0) {


### PR DESCRIPTION
Sending a POST request to `{{baseUrl}}/chat/findChats/{{instance}}` was returning an error `column \"updatedat\" does not exist"`.
