### PR TITLE
feat: add message location support whatsapp meta

### DIFF
--- a/src/api/integrations/channel/meta/whatsapp.business.service.ts
+++ b/src/api/integrations/channel/meta/whatsapp.business.service.ts
@@ -206,6 +206,20 @@ export class BusinessStartupService extends ChannelStartupService {
     return content;
   }
 
+  private messageLocationJson(received: any) {
+    const message = received.messages[0];
+    let content: any = {
+      locationMessage: {
+        degreesLatitude: message.location.latitude,
+        degreesLongitude: message.location.longitude,
+        name: message.location?.name,
+        address: message.location?.address,
+      },
+    };
+    message.context ? (content = { ...content, contextInfo: { stanzaId: message.context.id } }) : content;
+    return content;
+  }
+
   private messageContactsJson(received: any) {
     const message = received.messages[0];
     let content: any = {};
@@ -282,6 +296,9 @@ export class BusinessStartupService extends ChannelStartupService {
         break;
       case 'template':
         messageType = 'conversation';
+        break;
+      case 'location':
+        messageType = 'locationMessage';
         break;
       default:
         messageType = 'conversation';
@@ -434,6 +451,17 @@ export class BusinessStartupService extends ChannelStartupService {
             },
             contextInfo: this.messageContactsJson(received)?.contextInfo,
             messageType: 'contactMessage',
+            messageTimestamp: parseInt(received.messages[0].timestamp) as number,
+            source: 'unknown',
+            instanceId: this.instanceId,
+          };
+        } else if (received?.messages[0].location) {
+          messageRaw = {
+            key,
+            pushName,
+            message: this.messageLocationJson(received),
+            contextInfo: this.messageLocationJson(received)?.contextInfo,
+            messageType: this.renderMessageType(received.messages[0].type),
             messageTimestamp: parseInt(received.messages[0].timestamp) as number,
             source: 'unknown',
             instanceId: this.instanceId,


### PR DESCRIPTION
Greetings everyone, I encountered a problem while using Evolution API, when I received a location message from WhatsApp (Meta) the application did not resolve the message.
![image](https://github.com/user-attachments/assets/742ce27a-2adf-43df-865b-1dc114bb9ee9)

I noticed there was no integration with this type of messages yet so I hope this can help someone else.
