### PR TITLE
fix: chatwoot csat creating new conversation in another language

### DIFF
--- a/src/api/integrations/chatbot/chatwoot/services/chatwoot.service.ts
+++ b/src/api/integrations/chatbot/chatwoot/services/chatwoot.service.ts
@@ -1898,7 +1898,7 @@ export class ChatwootService {
               .replaceAll(/~((?!\s)([^\n~]+?)(?<!\s))~/g, '~~$1~~')
           : originalMessage;
 
-        if (bodyMessage && bodyMessage.includes('Por favor, classifique esta conversa, http')) {
+        if (bodyMessage && bodyMessage.includes('/survey/responses/') && bodyMessage.includes('http')) {
           return;
         }
 


### PR DESCRIPTION
### CHATWOOT CSAT BUG
Hello, when using another language in Chatwoot the CSAT message changes and skips validation, when the survey link is sent chatwoot creates a new conversation.
