### PR TITLE
🐛 Fix: Add migration for missing wavoipToken column in MySQL build env (#1234)

### DIFF
--- a/prisma/mysql-migrations/1707735894523_add_wavoip_token_to_settings_table/migration.sql
+++ b/prisma/mysql-migrations/1707735894523_add_wavoip_token_to_settings_table/migration.sql
@@ -1,0 +1,9 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[remoteJid,instanceId]` on the table `Chat` will be added. If there are existing duplicate values, this will fail.
+*/
+
+-- AlterTable
+ALTER TABLE `Setting`
+  ADD COLUMN IF NOT EXISTS `wavoipToken` VARCHAR(100);


### PR DESCRIPTION
## Fixes Issue #1234
### Problema
A coluna `wavoipToken` estava ausente na tabela `Setting`, causando problemas na build do ambiente MySQL.
### O que foi alterado
Adicionei uma migration que cria a coluna `wavoipToken` na tabela `Setting`.
### Resolução
Esta alteração garante que a coluna `wavoipToken` seja criada automaticamente, corrigindo o problema reportado na **Issue #1234**.
