### PR TITLE
fix: change mediaId optional chaining and list response message text obtain

### DIFF
--- a/src/utils/getConversationMessage.ts
+++ b/src/utils/getConversationMessage.ts
@@ -4,7 +4,7 @@ const getTypeMessage = (msg: any) => {
   let mediaId: string;
 
   if (configService.get<S3>('S3').ENABLE) mediaId = msg.message.mediaUrl;
-  else mediaId = msg.key.id;
+  else mediaId = msg.key?.id;
 
   const types = {
     conversation: msg?.message?.conversation,
@@ -15,7 +15,8 @@ const getTypeMessage = (msg: any) => {
       msg?.message?.viewOnceMessageV2?.message?.imageMessage?.url ||
       msg?.message?.viewOnceMessageV2?.message?.videoMessage?.url ||
       msg?.message?.viewOnceMessageV2?.message?.audioMessage?.url,
-    listResponseMessage: msg?.message?.listResponseMessage?.title,
+    listResponseMessage: msg?.message?.listResponseMessage?.title ||
+      msg?.listResponseMessage?.title,
     responseRowId: msg?.message?.listResponseMessage?.singleSelectReply?.selectedRowId,
     templateButtonReplyMessage:
       msg?.message?.templateButtonReplyMessage?.selectedId || msg?.message?.buttonsResponseMessage?.selectedButtonId,

--- a/src/utils/getConversationMessage.ts
+++ b/src/utils/getConversationMessage.ts
@@ -15,8 +15,7 @@ const getTypeMessage = (msg: any) => {
       msg?.message?.viewOnceMessageV2?.message?.imageMessage?.url ||
       msg?.message?.viewOnceMessageV2?.message?.videoMessage?.url ||
       msg?.message?.viewOnceMessageV2?.message?.audioMessage?.url,
-    listResponseMessage: msg?.message?.listResponseMessage?.title ||
-      msg?.listResponseMessage?.title,
+    listResponseMessage: msg?.message?.listResponseMessage?.title || msg?.listResponseMessage?.title,
     responseRowId: msg?.message?.listResponseMessage?.singleSelectReply?.selectedRowId,
     templateButtonReplyMessage:
       msg?.message?.templateButtonReplyMessage?.selectedId || msg?.message?.buttonsResponseMessage?.selectedButtonId,

--- a/src/utils/getConversationMessage.ts
+++ b/src/utils/getConversationMessage.ts
@@ -3,7 +3,7 @@ import { configService, S3 } from '@config/env.config';
 const getTypeMessage = (msg: any) => {
   let mediaId: string;
 
-  if (configService.get<S3>('S3').ENABLE) mediaId = msg.message.mediaUrl;
+  if (configService.get<S3>('S3').ENABLE) mediaId = msg.message?.mediaUrl;
   else mediaId = msg.key?.id;
 
   const types = {


### PR DESCRIPTION
Essa falha para obter o .id causa a sessão em entrar no modo `awaitUser: false`, com isso, as interações acabam não chegando mais no typebot (e possivelmente em outros lugares que possuem essa mesma lógica)

![Imagem do WhatsApp de 2025-02-13 à(s) 20 46 06_9be2bb1d](https://github.com/user-attachments/assets/512b2dda-5e7c-4420-b7e7-b2265a0c9b99)

Fiz o ajuste de optional chaining na hora de obter o mediaId, para evitar esse erro, e ajustei também o modo como o listResponseMessage é acesso (provavelmente alguma diferença relacionada a versão do baileys)