### PR TITLE
✨ Feat: Remover a reação de uma mensagem.

### DIFF
--- a/src/api/controllers/sendMessage.controller.ts
+++ b/src/api/controllers/sendMessage.controller.ts
@@ -18,6 +18,13 @@ import { WAMonitoringService } from '@api/services/monitor.service';
 import { BadRequestException } from '@exceptions';
 import { isBase64, isURL } from 'class-validator';
 
+function isEmoji(str: string) {
+  if (str === '') return true;
+  
+  const emojiRegex = /^[\u{1F300}-\u{1F9FF}\u{2600}-\u{26FF}\u{2700}-\u{27BF}\u{1F000}-\u{1F02F}\u{1F0A0}-\u{1F0FF}\u{1F100}-\u{1F64F}\u{1F680}-\u{1F6FF}]$/u;
+  return emojiRegex.test(str);
+}
+
 export class SendMessageController {
   constructor(private readonly waMonitor: WAMonitoringService) {}
 
@@ -81,8 +88,8 @@ export class SendMessageController {
   }
 
   public async sendReaction({ instanceName }: InstanceDto, data: SendReactionDto) {
-    if (!data.reaction.match(/[^()\w\sà-ú"-+]+/)) {
-      throw new BadRequestException('"reaction" must be an emoji');
+    if (!isEmoji(data.reaction)) {
+      throw new BadRequestException('Reaction must be a single emoji or empty string');
     }
     return await this.waMonitor.waInstances[instanceName].reactionMessage(data);
   }

--- a/src/api/controllers/sendMessage.controller.ts
+++ b/src/api/controllers/sendMessage.controller.ts
@@ -20,8 +20,9 @@ import { isBase64, isURL } from 'class-validator';
 
 function isEmoji(str: string) {
   if (str === '') return true;
-  
-  const emojiRegex = /^[\u{1F300}-\u{1F9FF}\u{2600}-\u{26FF}\u{2700}-\u{27BF}\u{1F000}-\u{1F02F}\u{1F0A0}-\u{1F0FF}\u{1F100}-\u{1F64F}\u{1F680}-\u{1F6FF}]$/u;
+
+  const emojiRegex =
+    /^[\u{1F300}-\u{1F9FF}\u{2600}-\u{26FF}\u{2700}-\u{27BF}\u{1F000}-\u{1F02F}\u{1F0A0}-\u{1F0FF}\u{1F100}-\u{1F64F}\u{1F680}-\u{1F6FF}]$/u;
   return emojiRegex.test(str);
 }
 


### PR DESCRIPTION
### O que foi feito  
Agora é possível remover uma reação de uma mensagem enviando a chave `"reaction"` com uma **string vazia** no corpo da requisição.  
Para isso, foi necessário modificar a validação no método `sendReaction()`, que agora utiliza **regex** para garantir que:  
- Apenas um único emoji seja enviado.  
- Qualquer outro valor inválido (incluindo uma string vazia) retorne um `BadRequestException()`.  

### Por que isso é necessário  
O WhatsApp já possui a funcionalidade de remover uma reação, então essa implementação garante compatibilidade com o comportamento original da plataforma.  

### Observação  
Seria interessante adicionar essa informação à **documentação** para que os usuários saibam como remover reações corretamente.  
Além disso, uma **nova rota exclusiva para remoção** poderia tornar essa funcionalidade mais intuitiva. Caso seja requisitado, posso implementá-la.  