### PR TITLE
Fix: Expiration being useless on awaitUser false

### DIFF
--- a/src/api/integrations/chatbot/typebot/controllers/typebot.controller.ts
+++ b/src/api/integrations/chatbot/typebot/controllers/typebot.controller.ts
@@ -1016,7 +1016,7 @@ export class TypebotController extends ChatbotController implements ChatbotContr
 
       if (!listeningFromMe && key.fromMe) {
         return;
-      }      
+      }
 
       if (debounceTime && debounceTime > 0) {
         this.processDebounce(this.userMessageDebounce, content, remoteJid, debounceTime, async (debouncedContent) => {

--- a/src/api/integrations/chatbot/typebot/controllers/typebot.controller.ts
+++ b/src/api/integrations/chatbot/typebot/controllers/typebot.controller.ts
@@ -1016,11 +1016,7 @@ export class TypebotController extends ChatbotController implements ChatbotContr
 
       if (!listeningFromMe && key.fromMe) {
         return;
-      }
-
-      if (session && !session.awaitUser) {
-        return;
-      }
+      }      
 
       if (debounceTime && debounceTime > 0) {
         this.processDebounce(this.userMessageDebounce, content, remoteJid, debounceTime, async (debouncedContent) => {

--- a/src/api/integrations/chatbot/typebot/services/typebot.service.ts
+++ b/src/api/integrations/chatbot/typebot/services/typebot.service.ts
@@ -741,6 +741,10 @@ export class TypebotService {
       }
     }
 
+    if (session && !session.awaitUser) {
+      return;
+    }
+
     if (session && session.status !== 'opened') {
       return;
     }


### PR DESCRIPTION
### **O que foi feito**
Removi uma validação de await user na função do controller do typebot e coloquei ela posteriomente dentro do service (processTypebot)

### **Por que isso é necessário**
Atualmente caso caia em uma situação onde a sessão está expirada, mas o awaitUser está false, não entra na função que efetua corretamente a reabertura da sessão expirada, ficando a sessão aberta até que seja manualmente deletada.

### Observação
Tive esse problema acontendo ocasionalmente, e após procurar, encontrei uma issue citando esse mesmo problema #1260 