### PR TITLE
fix: adjusting cloud api send audio and video

### DIFF
--- a/src/api/integrations/channel/meta/whatsapp.business.service.ts
+++ b/src/api/integrations/channel/meta/whatsapp.business.service.ts
@@ -800,6 +800,7 @@ export class BusinessStartupService extends ChannelStartupService {
         }
         if (message['media']) {
           const isImage = message['mimetype']?.startsWith('image/');
+          const isVideo = message['mimetype']?.startsWith('video/');
 
           content = {
             messaging_product: 'whatsapp',
@@ -809,7 +810,7 @@ export class BusinessStartupService extends ChannelStartupService {
             [message['mediaType']]: {
               [message['type']]: message['id'],
               preview_url: linkPreview,
-              ...(message['fileName'] && !isImage && { filename: message['fileName'] }),
+              ...(message['fileName'] && !isImage && !isVideo && { filename: message['fileName'] }),
               caption: message['caption'],
             },
           };
@@ -977,8 +978,9 @@ export class BusinessStartupService extends ChannelStartupService {
 
   private async getIdMedia(mediaMessage: any) {
     const formData = new FormData();
+    const media = mediaMessage.media || mediaMessage.audio;
 
-    const fileStream = createReadStream(mediaMessage.media);
+    const fileStream = createReadStream(media);
 
     formData.append('file', fileStream, { filename: 'media', contentType: mediaMessage.mimetype });
     formData.append('typeFile', mediaMessage.mimetype);
@@ -1079,7 +1081,7 @@ export class BusinessStartupService extends ChannelStartupService {
     const prepareMedia: any = {
       fileName: `${hash}.mp3`,
       mediaType: 'audio',
-      media: audio,
+      audio,
     };
 
     if (isURL(audio)) {
@@ -1101,15 +1103,7 @@ export class BusinessStartupService extends ChannelStartupService {
   public async audioWhatsapp(data: SendAudioDto, file?: any, isIntegration = false) {
     const mediaData: SendAudioDto = { ...data };
 
-    if (file?.buffer) {
-      mediaData.audio = file.buffer.toString('base64');
-    } else if (isURL(mediaData.audio)) {
-      // DO NOTHING
-      // mediaData.audio = mediaData.audio;
-    } else {
-      console.error('El archivo no tiene buffer o file es undefined');
-      throw new Error('File or buffer is undefined');
-    }
+    if (file) mediaData.audio = file.buffer.toString('base64');
 
     const message = await this.processAudio(mediaData.audio, data.number);
 


### PR DESCRIPTION
This commit fix sending video and audio in cloud api service:
- Send video should not send fileName.
- Send audio was sending as media with incorrect params.