### PR TITLE
Add eventos referente a instancia que estavam faltando

### DIFF
--- a/src/api/integrations/event/event.controller.ts
+++ b/src/api/integrations/event/event.controller.ts
@@ -151,5 +151,8 @@ export class EventController {
     'TYPEBOT_CHANGE_STATUS',
     'REMOVE_INSTANCE',
     'LOGOUT_INSTANCE',
+    'INSTANCE_CREATE',
+    'INSTANCE_DELETE',
+    'STATUS_INSTANCE',
   ];
 }


### PR DESCRIPTION
Esses eventos estão faltando e se não estiverem nessa variável impossibilita de defini-los ao criar os webhooks, pois há uma validação do tipo enum

## Summary by Sourcery

Chores:
- Adds 'INSTANCE_CREATE', 'INSTANCE_DELETE', and 'STATUS_INSTANCE' events.