### PR TITLE
Solução para erro ao adicionar um label

### DIFF
--- a/prisma/postgresql-migrations/20250314220553_add_unique_chat/migration.sql
+++ b/prisma/postgresql-migrations/20250314220553_add_unique_chat/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[instanceId,remoteJid]` on the table `Chat` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- CreateIndex
+CREATE UNIQUE INDEX "Chat_instanceId_remoteJid_key" ON "Chat"("instanceId", "remoteJid");

--- a/prisma/postgresql-schema.prisma
+++ b/prisma/postgresql-schema.prisma
@@ -127,6 +127,7 @@ model Chat {
   instanceId     String
   unreadMessages Int       @default(0)
 
+  @@unique([instanceId, remoteJid])
   @@index([instanceId])
   @@index([remoteJid])
 }

--- a/src/api/services/channel.service.ts
+++ b/src/api/services/channel.service.ts
@@ -702,6 +702,7 @@ export class ChannelStartupService {
             ) as "updatedAt",
             "Chat"."createdAt" as "windowStart",
             "Chat"."createdAt" + INTERVAL '24 hours' as "windowExpires",
+            "Chat"."labels" as "labels",
             CASE 
               WHEN "Chat"."createdAt" + INTERVAL '24 hours' > NOW() THEN true 
               ELSE false 
@@ -764,6 +765,7 @@ export class ChannelStartupService {
           windowExpires: contact.windowExpires,
           windowActive: contact.windowActive,
           lastMessage: lastMessage ? this.cleanMessageData(lastMessage) : undefined,
+          labels: contact.labels,
         };
       });
 


### PR DESCRIPTION
Estou criando essa pull request depois de ver que a pull request https://github.com/EvolutionAPI/evolution-api/pull/1277 estava vindo da branch errada.

Criei a issue https://github.com/EvolutionAPI/evolution-api/issues/1276

Ao analisar o código percebi que o problema e que no schema prisma do postgresql não temos um index único usando instanceId, remoteJid porem no schema do mysql ele existe, com isso adicionei esse index.

@@unique([instanceId, remoteJid])

Também aproveitei para adicionar a lista de labels no chat ao chamar o endpoint {{baseUrl}}/chat/findChats/{{instance}}

## Summary by Sourcery

Fixes an error when adding a label by adding a unique index to the Chat table in the PostgreSQL schema. Also includes the list of labels in the chat when calling the endpoint /chat/findChats/{instance}.

Bug Fixes:
- Fixes an error when adding a label due to a missing unique index in the PostgreSQL schema.
- Includes the list of labels in the chat when calling the endpoint /chat/findChats/{instance}.