### PR TITLE
fix: preserve animation in GIF and WebP stickers

### DIFF
--- a/src/api/integrations/channel/whatsapp/whatsapp.baileys.service.ts
+++ b/src/api/integrations/channel/whatsapp/whatsapp.baileys.service.ts
@@ -2703,8 +2703,7 @@ export class BaileysStartupService extends ChannelStartupService {
         imageBuffer = Buffer.from(response.data, 'binary');
       }
 
-      const isAnimated = image.includes('.gif') || 
-                         (image.includes('.webp') && this.isAnimatedWebp(imageBuffer));
+      const isAnimated = this.isAnimated(image, imageBuffer);
       
       if (isAnimated) {
         return await sharp(imageBuffer, { animated: true })
@@ -2722,14 +2721,14 @@ export class BaileysStartupService extends ChannelStartupService {
   private isAnimatedWebp(buffer: Buffer): boolean {
     if (buffer.length < 12) return false;
     
-    for (let i = 0; i < buffer.length - 4; i++) {
-      if (buffer[i] === 0x41 && // 'A'
-          buffer[i + 1] === 0x4E && // 'N'
-          buffer[i + 2] === 0x49 && // 'I'
-          buffer[i + 3] === 0x4D) { // 'M'
-        return true;
-      }
-    }
+    return buffer.indexOf(Buffer.from('ANIM')) !== -1;
+  }
+
+  private isAnimated(image: string, buffer: Buffer): boolean {
+    if (image.includes('.gif')) return true;
+    
+    if (image.includes('.webp')) return this.isAnimatedWebp(buffer);
+    
     return false;
   }
 


### PR DESCRIPTION
# WebP Animation Preservation Enhancement

## Problem Statement
When sending .gif or animated .webp files as stickers, the animation is lost in the conversion process.

## Solution
Modified the `convertToWebP` method to detect animated content and preserve animations during conversion using Sharp's animation support.

## Technical Details
- Added detection for animated GIFs and WebPs
- Implemented Sharp's `animated: true` option for animation preservation
- Added a helper method to inspect WebP headers for animation chunks

## Benefits
- Users can now send animated stickers properly
- Maintains full backward compatibility with existing code
- No changes to method signatures or calling code required

This enhancement addresses a specific functional gap without disrupting existing workflows.

## Summary by Sourcery

Bug Fixes:
- Fixes a bug where animations were lost when sending .gif or animated .webp files as stickers.