### PR TITLE
Fix/animated stickers

### DIFF
--- a/src/api/integrations/channel/whatsapp/whatsapp.baileys.service.ts
+++ b/src/api/integrations/channel/whatsapp/whatsapp.baileys.service.ts
@@ -2725,9 +2725,11 @@ export class BaileysStartupService extends ChannelStartupService {
   }
 
   private isAnimated(image: string, buffer: Buffer): boolean {
-    if (image.includes('.gif')) return true;
+    const lowerCaseImage = image.toLowerCase();
     
-    if (image.includes('.webp')) return this.isAnimatedWebp(buffer);
+    if (lowerCaseImage.includes('.gif')) return true;
+    
+    if (lowerCaseImage.includes('.webp')) return this.isAnimatedWebp(buffer);
     
     return false;
   }

--- a/src/api/integrations/channel/whatsapp/whatsapp.baileys.service.ts
+++ b/src/api/integrations/channel/whatsapp/whatsapp.baileys.service.ts
@@ -2703,8 +2703,7 @@ export class BaileysStartupService extends ChannelStartupService {
         imageBuffer = Buffer.from(response.data, 'binary');
       }
 
-      const isAnimated = image.includes('.gif') || 
-                         (image.includes('.webp') && this.isAnimatedWebp(imageBuffer));
+      const isAnimated = this.isAnimated(image, imageBuffer);
       
       if (isAnimated) {
         return await sharp(imageBuffer, { animated: true })
@@ -2722,14 +2721,14 @@ export class BaileysStartupService extends ChannelStartupService {
   private isAnimatedWebp(buffer: Buffer): boolean {
     if (buffer.length < 12) return false;
     
-    for (let i = 0; i < buffer.length - 4; i++) {
-      if (buffer[i] === 0x41 && // 'A'
-          buffer[i + 1] === 0x4E && // 'N'
-          buffer[i + 2] === 0x49 && // 'I'
-          buffer[i + 3] === 0x4D) { // 'M'
-        return true;
-      }
-    }
+    return buffer.indexOf(Buffer.from('ANIM')) !== -1;
+  }
+
+  private isAnimated(image: string, buffer: Buffer): boolean {
+    if (image.includes('.gif')) return true;
+    
+    if (image.includes('.webp')) return this.isAnimatedWebp(buffer);
+    
     return false;
   }
 

--- a/src/api/integrations/channel/whatsapp/whatsapp.baileys.service.ts
+++ b/src/api/integrations/channel/whatsapp/whatsapp.baileys.service.ts
@@ -2706,7 +2706,7 @@ export class BaileysStartupService extends ChannelStartupService {
       const isAnimated = this.isAnimated(image, imageBuffer);
 
       if (isAnimated) {
-        return await sharp(imageBuffer, { animated: true }).webp({ quality: 80, animated: true }).toBuffer();
+        return await sharp(imageBuffer, { animated: true }).webp({ quality: 80 }).toBuffer();
       } else {
         return await sharp(imageBuffer).webp().toBuffer();
       }

--- a/src/api/integrations/channel/whatsapp/whatsapp.baileys.service.ts
+++ b/src/api/integrations/channel/whatsapp/whatsapp.baileys.service.ts
@@ -2704,11 +2704,9 @@ export class BaileysStartupService extends ChannelStartupService {
       }
 
       const isAnimated = this.isAnimated(image, imageBuffer);
-      
+
       if (isAnimated) {
-        return await sharp(imageBuffer, { animated: true })
-          .webp({ quality: 80, animated: true })
-          .toBuffer();
+        return await sharp(imageBuffer, { animated: true }).webp({ quality: 80, animated: true }).toBuffer();
       } else {
         return await sharp(imageBuffer).webp().toBuffer();
       }
@@ -2720,17 +2718,17 @@ export class BaileysStartupService extends ChannelStartupService {
 
   private isAnimatedWebp(buffer: Buffer): boolean {
     if (buffer.length < 12) return false;
-    
+
     return buffer.indexOf(Buffer.from('ANIM')) !== -1;
   }
 
   private isAnimated(image: string, buffer: Buffer): boolean {
     const lowerCaseImage = image.toLowerCase();
-    
+
     if (lowerCaseImage.includes('.gif')) return true;
-    
+
     if (lowerCaseImage.includes('.webp')) return this.isAnimatedWebp(buffer);
-    
+
     return false;
   }
 


### PR DESCRIPTION
# WebP Animation Preservation Enhancement

## Problem Statement
When sending .gif or animated .webp files as stickers, the animation is lost in the conversion process.

## Solution
Modified the `convertToWebP` method to detect animated content and preserve animations during conversion using Sharp's animation support.

## Technical Details
- Added detection for animated GIFs and WebPs
- Implemented Sharp's `animated: true` option for animation preservation
- Added a helper method to inspect WebP headers for animation chunks

## Benefits
- Users can now send animated stickers properly
- Maintains full backward compatibility with existing code
- No changes to method signatures or calling code required

This enhancement addresses a specific functional gap without disrupting existing workflows.

## Summary by Sourcery

Bug Fixes:
- Fixes a bug where animations were lost when sending .gif or animated .webp files as stickers.