### PR TITLE
Defininando TTL no userDivicesCache igual usado no Baileys

### DIFF
--- a/src/api/integrations/channel/whatsapp/whatsapp.baileys.service.ts
+++ b/src/api/integrations/channel/whatsapp/whatsapp.baileys.service.ts
@@ -226,7 +226,10 @@ export class BaileysStartupService extends ChannelStartupService {
 
   private authStateProvider: AuthStateProvider;
   private readonly msgRetryCounterCache: CacheStore = new NodeCache();
-  private readonly userDevicesCache: CacheStore = new NodeCache();
+    private readonly userDevicesCache: CacheStore = new NodeCache({
+        stdTTL: 300000,
+        useClones: false
+    });
   private endSession = false;
   private logBaileys = this.configService.get<Log>('LOG').BAILEYS;
 


### PR DESCRIPTION
No Canal de Comunição da Evolution com a Baileys, está definido como readonly e sem TTL o userDevicesCache, defini o TTL igual na Baileys.

Pois quando o Usuário reinstala o WhatsApp ( por diversos motivos ) ele refaz a criptografia do número e por esse cache não ter o TTL, para esses usuários fica "Aguardando mensagem. Essa ação pode levar alguns instantes"

Imagem do código no Baileys
![image](https://github.com/user-attachments/assets/df036653-3732-4f79-b7c1-53ce31a60d7d)

## Summary by Sourcery

Enhancements:
- Configures a Time-To-Live (TTL) for the userDevicesCache.