### PR TITLE
Correção para quando enviar uma localização.

### DIFF
--- a/src/utils/getConversationMessage.ts
+++ b/src/utils/getConversationMessage.ts
@@ -10,7 +10,7 @@ const getTypeMessage = (msg: any) => {
     conversation: msg?.message?.conversation,
     extendedTextMessage: msg?.message?.extendedTextMessage?.text,
     contactMessage: msg?.message?.contactMessage?.displayName,
-    locationMessage: msg?.message?.locationMessage?.degreesLatitude,
+    locationMessage: msg?.message?.locationMessage?.degreesLatitude.toString(),
     viewOnceMessageV2:
       msg?.message?.viewOnceMessageV2?.message?.imageMessage?.url ||
       msg?.message?.viewOnceMessageV2?.message?.videoMessage?.url ||


### PR DESCRIPTION
Quando envia uma localização, faz a conversão de degreesLatitude para string, o parametro content é do tipo string nas chamadas de findBotByTrigger() em chatbot.controller e degreesLatitude é do tipo float causando erro de tipagem de dados.

## Summary by Sourcery

Bug Fixes:
- Fix type mismatch when processing location messages by converting degreesLatitude to a string