### PR TITLE
Hotfix - shell injection vulnerability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 2.2.4 (hotfix)
+
+### Fixed
+
+* Shell injection vulnerability
+
 # 2.2.3 (2025-02-03 11:52)
 
 ### Fixed

--- a/src/api/provider/sessions.ts
+++ b/src/api/provider/sessions.ts
@@ -1,7 +1,7 @@
 import { Auth, ConfigService, ProviderSession } from '@config/env.config';
 import { Logger } from '@config/logger.config';
 import axios from 'axios';
-import { execSync } from 'child_process';
+import { execFileSync } from 'child_process';
 
 type ResponseSuccess = { status: number; data?: any };
 type ResponseProvider = Promise<[ResponseSuccess?, Error?]>;
@@ -36,7 +36,7 @@ export class ProviderFiles {
       } catch (error) {
         this.logger.error(['Failed to connect to the file server', error?.message, error?.stack]);
         const pid = process.pid;
-        execSync(`kill -9 ${pid}`);
+        execFileSync('kill', ['-9', `${pid}`]);
       }
     }
   }

--- a/src/api/services/monitor.service.ts
+++ b/src/api/services/monitor.service.ts
@@ -168,7 +168,7 @@ export class WAMonitoringService {
 
   public async cleaningStoreData(instanceName: string) {
     if (this.configService.get<Chatwoot>('CHATWOOT').ENABLED) {
-      const instancePath = join(STORE_DIR, 'chatwoot', `${instanceName}*`);
+      const instancePath = join(STORE_DIR, 'chatwoot', instanceName);
       execFileSync('rm', ['-rf', instancePath]);
     }
 

--- a/src/api/services/monitor.service.ts
+++ b/src/api/services/monitor.service.ts
@@ -7,7 +7,7 @@ import { CacheConf, Chatwoot, ConfigService, Database, DelInstance, ProviderSess
 import { Logger } from '@config/logger.config';
 import { INSTANCE_DIR, STORE_DIR } from '@config/path.config';
 import { NotFoundException } from '@exceptions';
-import { execSync } from 'child_process';
+import { execFileSync } from 'child_process';
 import EventEmitter2 from 'eventemitter2';
 import { rmSync } from 'fs';
 import { join } from 'path';
@@ -168,7 +168,8 @@ export class WAMonitoringService {
 
   public async cleaningStoreData(instanceName: string) {
     if (this.configService.get<Chatwoot>('CHATWOOT').ENABLED) {
-      execSync(`rm -rf ${join(STORE_DIR, 'chatwoot', instanceName + '*')}`);
+      const instancePath = join(STORE_DIR, 'chatwoot', `${instanceName}*`);
+      execFileSync('rm', ['-rf', instancePath]);
     }
 
     const instance = await this.prismaRepository.instance.findFirst({


### PR DESCRIPTION
This Pull request change execSync to execFileSync, to avoid shell injection vulnerability.

@DavidsonGomes please priorize this hotfix to production

This closes #1348

## Summary by Sourcery

Implement security fix to prevent shell injection vulnerability by replacing execSync with execFileSync

Bug Fixes:
- Replace potentially dangerous execSync calls with execFileSync to mitigate shell injection risks in multiple files

Chores:
- Update CHANGELOG.md to document the security hotfix