### PR TITLE
feat(s3): add S3_SKIP_POLICY env variable to disable setBucketPolicy

### DIFF
--- a/src/api/integrations/storage/s3/libs/minio.server.ts
+++ b/src/api/integrations/storage/s3/libs/minio.server.ts
@@ -63,9 +63,9 @@ const createBucket = async () => {
       if (!exists) {
         await minioClient.makeBucket(bucketName);
       }
-
-      await setBucketPolicy();
-
+      if (!BUCKET.SKIP_POLICY) {
+        await setBucketPolicy();
+      }
       logger.info(`S3 Bucket ${bucketName} - ON`);
       return true;
     } catch (error) {

--- a/src/config/env.config.ts
+++ b/src/config/env.config.ts
@@ -251,6 +251,7 @@ export type S3 = {
   PORT?: number;
   USE_SSL?: boolean;
   REGION?: string;
+  SKIP_POLICY?: boolean;
 };
 
 export type CacheConf = { REDIS: CacheConfRedis; LOCAL: CacheConfLocal };
@@ -555,6 +556,7 @@ export class ConfigService {
         PORT: Number.parseInt(process.env?.S3_PORT || '9000'),
         USE_SSL: process.env?.S3_USE_SSL === 'true',
         REGION: process.env?.S3_REGION,
+        SKIP_POLICY: process.env?.S3_SKIP_POLICY === 'true',
       },
       AUTHENTICATION: {
         API_KEY: {


### PR DESCRIPTION
Some S3-compatible providers like DigitalOcean Spaces do not support setting bucket policies via the MinIO client. This PR adds a conditional to skip this step when the provider does not support it.
