### PR TITLE
Corrigindo um bug ao atualizar o push name no evento MESSAGES_UPSERT e MESSAGES_UPDATE

### DIFF
--- a/src/api/integrations/channel/whatsapp/whatsapp.baileys.service.ts
+++ b/src/api/integrations/channel/whatsapp/whatsapp.baileys.service.ts
@@ -382,7 +382,7 @@ export class BaileysStartupService extends ChannelStartupService {
       qrcodeTerminal.generate(qr, { small: true }, (qrcode) =>
         this.logger.log(
           `\n{ instance: ${this.instance.name} pairingCode: ${this.instance.qrcode.pairingCode}, qrcodeCount: ${this.instance.qrcode.count} }\n` +
-          qrcode,
+            qrcode,
         ),
       );
 
@@ -1023,18 +1023,18 @@ export class BaileysStartupService extends ChannelStartupService {
 
         const messagesRepository: Set<string> = new Set(
           chatwootImport.getRepositoryMessagesCache(instance) ??
-          (
-            await this.prismaRepository.message.findMany({
-              select: { key: true },
-              where: { instanceId: this.instanceId },
-            })
-          ).map((message) => {
-            const key = message.key as {
-              id: string;
-            };
+            (
+              await this.prismaRepository.message.findMany({
+                select: { key: true },
+                where: { instanceId: this.instanceId },
+              })
+            ).map((message) => {
+              const key = message.key as {
+                id: string;
+              };
 
-            return key.id;
-          }),
+              return key.id;
+            }),
         );
 
         if (chatwootImport.getRepositoryMessagesCache(instance) === null) {

--- a/src/api/integrations/channel/whatsapp/whatsapp.baileys.service.ts
+++ b/src/api/integrations/channel/whatsapp/whatsapp.baileys.service.ts
@@ -382,7 +382,7 @@ export class BaileysStartupService extends ChannelStartupService {
       qrcodeTerminal.generate(qr, { small: true }, (qrcode) =>
         this.logger.log(
           `\n{ instance: ${this.instance.name} pairingCode: ${this.instance.qrcode.pairingCode}, qrcodeCount: ${this.instance.qrcode.count} }\n` +
-            qrcode,
+          qrcode,
         ),
       );
 
@@ -1023,18 +1023,18 @@ export class BaileysStartupService extends ChannelStartupService {
 
         const messagesRepository: Set<string> = new Set(
           chatwootImport.getRepositoryMessagesCache(instance) ??
-            (
-              await this.prismaRepository.message.findMany({
-                select: { key: true },
-                where: { instanceId: this.instanceId },
-              })
-            ).map((message) => {
-              const key = message.key as {
-                id: string;
-              };
+          (
+            await this.prismaRepository.message.findMany({
+              select: { key: true },
+              where: { instanceId: this.instanceId },
+            })
+          ).map((message) => {
+            const key = message.key as {
+              id: string;
+            };
 
-              return key.id;
-            }),
+            return key.id;
+          }),
         );
 
         if (chatwootImport.getRepositoryMessagesCache(instance) === null) {
@@ -1226,6 +1226,7 @@ export class BaileysStartupService extends ChannelStartupService {
             received.pushName &&
             existingChat.name !== received.pushName &&
             received.pushName.trim().length > 0 &&
+            !received.key.fromMe &&
             !received.key.remoteJid.includes('@g.us')
           ) {
             this.sendDataWebhook(Events.CHATS_UPSERT, [{ ...existingChat, name: received.pushName }]);
@@ -1585,7 +1586,6 @@ export class BaileysStartupService extends ChannelStartupService {
             const chatToInsert = {
               remoteJid: message.remoteJid,
               instanceId: this.instanceId,
-              name: message.pushName || '',
               unreadMessages: 0,
             };
 


### PR DESCRIPTION
## Fix

### Problema

Ao enviar uma mensagem via dispositivo, dois comportamentos distintos ocorriam:

1. Inicialmente, o evento `MESSAGES_UPSERT` atualizava o campo `name` da tabela `Chat` com o `pushname` do remetente.
2. Em seguida, o evento `MESSAGES_UPDATE` sobrescrevia o campo `name` com uma string vazia de forma consistente, pois tentava fazer um `update` utilizando uma variável que sequer era definida — já que esse campo não era enviado pelo respectivo evento da *Baileys*.

### O que foi alterado?

- O campo `name` da tabela `Chat` **não é mais atualizado** durante o evento `MESSAGES_UPDATE`. Isto ocorre pois o campo `name` sequer é enviado no evento, causando ele sempre ser atualizado como uma string vazia.
- No evento `MESSAGES_UPSERT`, o campo `name` **só é atualizado quando `fromMe` for falso**, ou seja, apenas quando a mensagem for recebida (não enviada pelo próprio usuário).

### Resolução

Agora, ao chamar um endpoint que retorna o campo `name` da tabela `Chat` (como o `/chat/findChats/`), o valor retornado será o correto — evitando strings vazias ou o nome do próprio remetente. O campo continua sendo atualizado normalmente ao receber mensagens.

## Summary by Sourcery

Fix the behavior of updating chat names during message events to prevent incorrect name updates

Bug Fixes:
- Prevent overwriting chat names with empty strings during MESSAGES_UPDATE event
- Ensure chat names are only updated with push names for received messages

Enhancements:
- Improve chat name update logic to maintain accurate contact names