### PR TITLE
Add or update the Azure App Service build and deployment workflow config

### DIFF
--- a/.github/workflows/main_whatsappsupplyanalytics.yml
+++ b/.github/workflows/main_whatsappsupplyanalytics.yml
@@ -1,0 +1,64 @@
+# Docs for the Azure Web Apps Deploy action: https://github.com/Azure/webapps-deploy
+# More GitHub Actions for Azure: https://github.com/Azure/actions
+
+name: Build and deploy Node.js app to Azure Web App - whatsappsupplyanalytics
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read #This is required for actions/checkout
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node.js version
+        uses: actions/setup-node@v3
+        with:
+          node-version: '20.x'
+
+      - name: npm install, build, and test
+        run: |
+          npm install
+          npm run build --if-present
+          npm run test --if-present
+
+      - name: Zip artifact for deployment
+        run: zip release.zip ./* -r
+
+      - name: Upload artifact for deployment job
+        uses: actions/upload-artifact@v4
+        with:
+          name: node-app
+          path: release.zip
+
+  deploy:
+    runs-on: ubuntu-latest
+    needs: build
+    environment:
+      name: 'Production'
+      url: ${{ steps.deploy-to-webapp.outputs.webapp-url }}
+    
+    steps:
+      - name: Download artifact from build job
+        uses: actions/download-artifact@v4
+        with:
+          name: node-app
+
+      - name: Unzip artifact for deployment
+        run: unzip release.zip
+      
+      - name: 'Deploy to Azure Web App'
+        id: deploy-to-webapp
+        uses: azure/webapps-deploy@v3
+        with:
+          app-name: 'whatsappsupplyanalytics'
+          slot-name: 'Production'
+          package: .
+          publish-profile: ${{ secrets.AZUREAPPSERVICE_PUBLISHPROFILE_801655C9AA76417B9840818D43188742 }}


### PR DESCRIPTION
## Summary by Sourcery

Add a GitHub Actions workflow to automate the build and deployment of the Node.js application to Azure App Service.

CI:
- Add a CI job triggered on pushes to main or manually, which builds, tests, and packages the Node.js application using Node.js 20.x.
- Upload the packaged application as a build artifact named 'node-app' for the deployment job.
- Grant read permissions for contents to the build job for checkout action compatibility

Deployment:
- Add a deployment job that downloads the build artifact.
- Deploy the packaged application to the 'whatsappsupplyanalytics' Azure App Service production slot using the Azure Web Apps Deploy action.