### PR TITLE
fix: when you set jpegThumbnail, image not appear on app mobile

### DIFF
--- a/src/api/integrations/channel/whatsapp/whatsapp.baileys.service.ts
+++ b/src/api/integrations/channel/whatsapp/whatsapp.baileys.service.ts
@@ -2654,9 +2654,6 @@ export class BaileysStartupService extends ChannelStartupService {
       prepareMedia[mediaType].fileName = mediaMessage.fileName;
 
       if (mediaMessage.mediatype === 'video') {
-        prepareMedia[mediaType].jpegThumbnail = Uint8Array.from(
-          readFileSync(join(process.cwd(), 'public', 'images', 'video-cover.png')),
-        );
         prepareMedia[mediaType].gifPlayback = false;
       }
 


### PR DESCRIPTION
# 📦 Pull Request — Fix video thumbnail handling on mobile apps

## Context
Currently, when sending videos through the API, setting the `jpegThumbnail` manually (e.g., using a local image file like `video-cover.png`) was **not showing any thumbnail preview** on mobile WhatsApp applications.

After investigating, it was observed that:
- WhatsApp expects a correctly **sized**, **compressed**, and **proper JPEG format** thumbnail.
- Simply attaching any PNG-converted image as `jpegThumbnail` without proper optimization **causes the thumbnail to be ignored silently** on mobile devices.

---

## What has changed
- **Removed** setting `jpegThumbnail` manually from static images.
- **Set** `gifPlayback = false` for all video media messages (keeping consistent behavior between web and mobile apps).
  
Now, the native behavior of WhatsApp handles thumbnails better when `jpegThumbnail` is not manually set incorrectly.

---

## How it was fixed
```typescript
if (mediaMessage.mediatype === 'video') {
  prepareMedia[mediaType].gifPlayback = false;
}
```

No longer trying to inject a static `jpegThumbnail`.

---

## Impact
- Fixes videos sent through the API **not showing thumbnails** on mobile apps.
- Makes API behavior more aligned with WhatsApp mobile/web expectations.
- Reduces chance of future media handling bugs related to thumbnail encoding.

---

## Related
- Commit: `fix: when you set jpegThumbnail, image not appear on app mobile`

---

✅ Now videos sent through the API show the proper behavior on both **WhatsApp Web** and **WhatsApp Mobile**.

## Summary by Sourcery

Fix video thumbnail handling for WhatsApp media messages to ensure proper thumbnail display on mobile apps

New Features:
- Ensured consistent video thumbnail behavior across WhatsApp Web and Mobile platforms

Bug Fixes:
- Resolved issue with video thumbnails not appearing on mobile WhatsApp applications
- Removed manual thumbnail injection that was causing thumbnail preview failures

Enhancements:
- Improved media message handling to align with WhatsApp mobile and web expectations
- Simplified thumbnail processing for video messages