### PR TITLE
Corrigir utilização do linkPreview no WhatsApp Business API

### DIFF
--- a/src/api/integrations/channel/meta/whatsapp.business.service.ts
+++ b/src/api/integrations/channel/meta/whatsapp.business.service.ts
@@ -752,7 +752,6 @@ export class BusinessStartupService extends ChannelStartupService {
     try {
       let quoted: any;
       let webhookUrl: any;
-      const linkPreview = options?.linkPreview != false ? undefined : false;
       if (options?.quoted) {
         const m = options?.quoted;
 
@@ -820,7 +819,7 @@ export class BusinessStartupService extends ChannelStartupService {
             to: number.replace(/\D/g, ''),
             text: {
               body: message['conversation'],
-              preview_url: linkPreview,
+              preview_url: Boolean(options?.linkPreview),
             },
           };
           quoted ? (content.context = { message_id: quoted.id }) : content;
@@ -837,7 +836,7 @@ export class BusinessStartupService extends ChannelStartupService {
             to: number.replace(/\D/g, ''),
             [message['mediaType']]: {
               [message['type']]: message['id'],
-              preview_url: linkPreview,
+              preview_url: Boolean(options?.linkPreview),
               ...(message['fileName'] && !isImage && !isVideo && { filename: message['fileName'] }),
               caption: message['caption'],
             },


### PR DESCRIPTION
**Descrição**
Ao utilizar a opção linkPreview no envio de mensagens via WhatsApp Business API não é feito o carregamento da pré-visualização  do link pois como true != false, é passado undefined no valor, no caso deveria passar true.

**Problemas Resolvidos**
- Corrigido utilização da opção linkPreview via WhatsApp Business API para que seja carregado as pré-visualizações dos links nas mensagens.

**Observações**
- Foi alterado apenas na Service do WhatsApp Business pois ele aceita apenas booleano, true e false.
- Na Service do Baileys, deve-se manter igual pois o mesmo trata o undefined como true.

## Summary by Sourcery

Bug Fixes:
- Corrected link preview option processing to ensure proper link preview generation in WhatsApp Business API messages