### PR TITLE
fix: Erro na criação de conversation quando já existe uma conversation de outro inbox para o mesmo usuário

### DIFF
--- a/src/api/integrations/chatbot/chatwoot/services/chatwoot.service.ts
+++ b/src/api/integrations/chatbot/chatwoot/services/chatwoot.service.ts
@@ -698,34 +698,33 @@ export class ChatwootService {
         return null;
       }
 
-      if (contactConversations.payload.length) {
-        let conversation: any;
+      let inboxConversation = contactConversations.payload.find(
+        (conversation) => conversation.inbox_id == filterInbox.id,
+      );
+      if (inboxConversation) {
         if (this.provider.reopenConversation) {
-          conversation = contactConversations.payload.find((conversation) => conversation.inbox_id == filterInbox.id);
-          this.logger.verbose(`Found conversation in reopenConversation mode: ${JSON.stringify(conversation)}`);
+          this.logger.verbose(`Found conversation in reopenConversation mode: ${JSON.stringify(inboxConversation)}`);
 
-          if (this.provider.conversationPending && conversation.status !== 'open') {
-            if (conversation) {
-              await client.conversations.toggleStatus({
-                accountId: this.provider.accountId,
-                conversationId: conversation.id,
-                data: {
-                  status: 'pending',
-                },
-              });
-            }
+          if (this.provider.conversationPending && inboxConversation.status !== 'open') {
+            await client.conversations.toggleStatus({
+              accountId: this.provider.accountId,
+              conversationId: inboxConversation.id,
+              data: {
+                status: 'pending',
+              },
+            });
           }
         } else {
-          conversation = contactConversations.payload.find(
+          inboxConversation = contactConversations.payload.find(
             (conversation) => conversation.status !== 'resolved' && conversation.inbox_id == filterInbox.id,
           );
-          this.logger.verbose(`Found conversation: ${JSON.stringify(conversation)}`);
+          this.logger.verbose(`Found conversation: ${JSON.stringify(inboxConversation)}`);
         }
 
-        if (conversation) {
-          this.logger.verbose(`Returning existing conversation ID: ${conversation.id}`);
-          this.cache.set(cacheKey, conversation.id);
-          return conversation.id;
+        if (inboxConversation) {
+          this.logger.verbose(`Returning existing conversation ID: ${inboxConversation.id}`);
+          this.cache.set(cacheKey, inboxConversation.id);
+          return inboxConversation.id;
         }
       }
 


### PR DESCRIPTION
### Objetivo:
Ao buscar pela conversa do contato, é retornado todas as conversas de todos os inbox (o endpoint não permite filtrar pelo inbox), retornando conversas de outro inbox. O problema ocorre quando há uma conversa para o Usuario1 no InboxA, e um novo canal é adicionado no CW (inbox) onde o mesmo contato (Usuario1) também existe.

Com isso, `contactConversations.payload` existe e há um registro (porém do inbox errado). Ao filtrar pelo inbox na linha 704, não há conversation, gerando um erro. A conversation que existe no payload é de outro inbox.

Assim, é preciso filtrar o `contactConversations.payload` antes de realizar a operação, garantindo que, caso não exista, a conversation será criada, como esperado. 

### Mudanças:
- Define `inboxConversation` a partir das conversas do usuário e filtrando por inbox.
- Move `inboxConversation` (anteriormente dentro do condicional) para fora, verificando se o inbox correto realmente existe, ao invés de verificar TODOS os inboxes retornados.

## Summary by Sourcery

Fix conversation retrieval logic in Chatwoot service to correctly handle conversations across different inboxes for the same contact

Bug Fixes:
- Correctly filter conversations by specific inbox to prevent errors when multiple conversations exist for the same contact
- Ensure conversation retrieval works correctly when a contact exists in multiple inboxes

Enhancements:
- Improved conversation filtering logic to find the correct conversation in the specific inbox
- Simplified conversation lookup and status handling