### PR TITLE
fix(audio): ensure full WhatsApp compatibility for audio conversion

### DIFF
--- a/src/api/integrations/channel/whatsapp/whatsapp.baileys.service.ts
+++ b/src/api/integrations/channel/whatsapp/whatsapp.baileys.service.ts
@@ -3005,15 +3005,24 @@ export class BaileysStartupService extends ChannelStartupService {
           .audioFrequency(48000)
           .audioChannels(1)
           .outputOptions([
-            '-write_xing', '0',
-            '-compression_level', '10',
-            '-application', 'voip',
-            '-fflags', '+bitexact',
-            '-flags', '+bitexact',
-            '-id3v2_version', '0',
-            '-map_metadata', '-1',
-            '-map_chapters', '-1',
-            '-write_bext', '0'
+            '-write_xing',
+            '0',
+            '-compression_level',
+            '10',
+            '-application',
+            'voip',
+            '-fflags',
+            '+bitexact',
+            '-flags',
+            '+bitexact',
+            '-id3v2_version',
+            '0',
+            '-map_metadata',
+            '-1',
+            '-map_chapters',
+            '-1',
+            '-write_bext',
+            '0',
           ])
           .pipe(outputAudioStream, { end: true })
           .on('error', function (error) {

--- a/src/api/integrations/channel/whatsapp/whatsapp.baileys.service.ts
+++ b/src/api/integrations/channel/whatsapp/whatsapp.baileys.service.ts
@@ -3001,7 +3001,20 @@ export class BaileysStartupService extends ChannelStartupService {
           .noVideo()
           .audioCodec('libopus')
           .addOutputOptions('-avoid_negative_ts make_zero')
+          .audioBitrate('128k')
+          .audioFrequency(48000)
           .audioChannels(1)
+          .outputOptions([
+            '-write_xing', '0',
+            '-compression_level', '10',
+            '-application', 'voip',
+            '-fflags', '+bitexact',
+            '-flags', '+bitexact',
+            '-id3v2_version', '0',
+            '-map_metadata', '-1',
+            '-map_chapters', '-1',
+            '-write_bext', '0'
+          ])
           .pipe(outputAudioStream, { end: true })
           .on('error', function (error) {
             console.log('error', error);


### PR DESCRIPTION
This update standardizes audio conversion to the `ogg` format using `libopus`, with a 48kHz sampling rate, 128kbps bitrate, and mono channel. 

It also removes unnecessary metadata and extended tags (such as ID3, BEXT, chapters, etc.) that previously caused the file to be flagged as invalid or unplayable by WhatsApp.

The resulting audio is fully compatible with WhatsApp Web, iOS and Android, regardless of the integration source (Chatwoot, N8N, Postman, etc.).

## Summary by Sourcery

Improve WhatsApp audio compatibility by standardizing audio conversion parameters and removing unnecessary metadata

Bug Fixes:
- Resolve audio file compatibility issues across WhatsApp platforms

Enhancements:
- Optimize audio conversion settings for maximum WhatsApp compatibility