### PR TITLE
fix mysql wavoip token

### DIFF
--- a/prisma/mysql-migrations/20250510035200_add_wavoip_token_to_settings_table/migration.sql
+++ b/prisma/mysql-migrations/20250510035200_add_wavoip_token_to_settings_table/migration.sql
@@ -1,0 +1,26 @@
+/*
+Warnings:
+
+- A unique constraint covering the columns `[remoteJid,instanceId]` on the table `Chat` will be added. If there are existing duplicate values, this will fail.
+
+*/
+
+-- AlterTable
+SET @column_exists := (
+  SELECT COUNT(*) 
+  FROM information_schema.columns 
+  WHERE table_schema = DATABASE() 
+    AND table_name = 'Setting' 
+    AND column_name = 'wavoipToken'
+);
+
+SET @sql := IF(@column_exists = 0, 
+  'ALTER TABLE Setting ADD COLUMN wavoipToken VARCHAR(100);', 
+  'SELECT "Column already exists";'
+);
+
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+ALTER TABLE Chat ADD CONSTRAINT unique_remote_instance UNIQUE (remoteJid, instanceId);


### PR DESCRIPTION
## Summary by Sourcery

Add a wavoip token column to the Settings table and create a unique constraint on Chat table

New Features:
- Add wavoipToken column to Setting table

Enhancements:
- Create a unique constraint on Chat table for remoteJid and instanceId