### PR TITLE
fix(chatwoot): avoid "undefined" caption on group audio messages

### DIFF
--- a/src/api/integrations/chatbot/chatwoot/services/chatwoot.service.ts
+++ b/src/api/integrations/chatbot/chatwoot/services/chatwoot.service.ts
@@ -1652,7 +1652,7 @@ export class ChatwootService {
       stickerMessage: undefined,
       documentMessage: msg.documentMessage?.caption,
       documentWithCaptionMessage: msg.documentWithCaptionMessage?.message?.documentMessage?.caption,
-      audioMessage: msg.audioMessage?.caption,
+      audioMessage: msg.audioMessage?.caption || '',
       contactMessage: msg.contactMessage?.vcard,
       contactsArrayMessage: msg.contactsArrayMessage,
       locationMessage: msg.locationMessage,


### PR DESCRIPTION
This PR fixes an issue where incoming audio messages in WhatsApp groups were displaying the text "undefined" as a caption in Chatwoot.

The change ensures that if no caption is present in the `audioMessage`, an empty string is sent instead — preventing the literal string "undefined" from appearing in the UI.

**Before:**
🟥 The word "undefined" was shown above the audio player when no caption existed.
![image](https://github.com/user-attachments/assets/f2954633-a5b4-4be1-91f7-efe159d7f91d)

**After:**
✅ No caption is displayed, keeping the interface clean.
![image](https://github.com/user-attachments/assets/fa4cb8d9-d544-4a6a-bb18-7b71e5818c37)

## Summary by Sourcery

Fix an issue with audio message captions in WhatsApp group messages by ensuring an empty string is used when no caption is present

Bug Fixes:
- Resolved an issue where 'undefined' was displayed as a caption for audio messages in WhatsApp groups

Enhancements:
- Updated caption handling for audio messages to prevent 'undefined' text from appearing in the UI