### PR TITLE
Prevent server crash when SSL certificate is missing or invalid

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,6 +3,10 @@ SERVER_PORT=8080
 # Server URL - Set your application url
 SERVER_URL=http://localhost:8080
 
+# Paths to your SSL certificate files (used for HTTPS)
+SSL_CONF_PRIVKEY=/path/to/cert.key
+SSL_CONF_FULLCHAIN=/path/to/cert.crt
+
 SENTRY_DSN=
 
 # Cors - * for all or set separate by commas -  ex.: 'yourdomain1.com, yourdomain2.com'

--- a/src/main.ts
+++ b/src/main.ts
@@ -128,7 +128,15 @@ async function bootstrap() {
   const httpServer = configService.get<HttpServer>('SERVER');
 
   ServerUP.app = app;
-  const server = ServerUP[httpServer.TYPE];
+  let server = ServerUP[httpServer.TYPE];
+  
+  if (server === null) {
+    logger.warn("SSL cert load failed — falling back to HTTP.")
+    logger.info("Ensure 'SSL_CONF_PRIVKEY' and 'SSL_CONF_FULLCHAIN' env vars point to valid certificate files.");
+     
+    httpServer.TYPE = "http"
+    server = ServerUP[httpServer.TYPE]
+  }
 
   eventManager.init(server);
 

--- a/src/utils/server-up.ts
+++ b/src/utils/server-up.ts
@@ -12,14 +12,18 @@ export class ServerUP {
   }
 
   static get https() {
-    const { FULLCHAIN, PRIVKEY } = configService.get<SslConf>('SSL_CONF');
-    return https.createServer(
-      {
-        cert: readFileSync(FULLCHAIN),
-        key: readFileSync(PRIVKEY),
-      },
-      ServerUP.#app,
-    );
+    try {
+      const { FULLCHAIN, PRIVKEY } = configService.get<SslConf>('SSL_CONF');
+      return https.createServer(
+        {
+          cert: readFileSync(FULLCHAIN),
+          key: readFileSync(PRIVKEY),
+        },
+        ServerUP.#app,
+      );
+    } catch {
+      return null
+    }
   }
 
   static get http() {


### PR DESCRIPTION
**Problem Description:**

I was setting up my Evolution server for the first time. Everything went smoothly, and I was able to run it successfully. However, I ran into an issue when trying to configure the server to use HTTPS.

After changing the `SERVER_TYPE` environment variable to `https`, I encountered the following error in the console:

```
Error: ENOENT: no such file or directory, open ''
    at Object.openSync (node:fs:574:18)
    at readFileSync (node:fs:453:35)
    at get https [as https] (/opt/evolution-api/dist/main.js:286:131642)
    at el (/opt/evolution-api/dist/main.js:286:133569) {
  errno: -2,
  code: 'ENOENT',
  syscall: 'open',
  path: ''
}
```

After some research, I realized that the error was caused by a missing or invalid SSL certificate. I spent quite a bit of time trying to figure out which environment variables were required to define the certificate paths properly. I ended up digging into the source code to find out.

Once I set the correct variables, the HTTPS server worked as expected.

---

**Motivation for this pull request:**

I’m submitting this PR with a few improvements to make this process easier for future users:

1. If the SSL certificate is invalid or missing, the server no longer crashes — it gracefully falls back to HTTP.
2. A clear and friendly warning message is printed to the console, helping users quickly identify the issue.
3. I added the required SSL-related environment variables (`SSL_CONF_PRIVKEY` and `SSL_CONF_FULLCHAIN`) to the `.env.example` file, so users don’t need to search through the code or documentation to find them.

## Summary by Sourcery

Catch errors when loading SSL certificates to prevent server crashes, automatically fall back to HTTP with clear console warnings, and document required SSL environment variables.

Bug Fixes:
- Prevent server crash on missing or invalid SSL certificates by catching errors during HTTPS server creation

Enhancements:
- Fall back to an HTTP server and adjust server type when SSL loading fails
- Log a warning and guidance message to the console when SSL configuration is invalid

Documentation:
- Add SSL_CONF_PRIVKEY and SSL_CONF_FULLCHAIN entries to .env.example