### PR TITLE
feat(evoai): add Evoai and EvoaiSetting tables with foreign key const…

### DIFF
--- a/prisma/postgresql-migrations/20250515211815_add_evoai_table/migration.sql
+++ b/prisma/postgresql-migrations/20250515211815_add_evoai_table/migration.sql
@@ -1,0 +1,61 @@
+-- CreateTable
+CREATE TABLE "Evoai" (
+    "id" TEXT NOT NULL,
+    "enabled" BOOLEAN NOT NULL DEFAULT true,
+    "description" VARCHAR(255),
+    "agentUrl" VARCHAR(255),
+    "apiKey" VARCHAR(255),
+    "expire" INTEGER DEFAULT 0,
+    "keywordFinish" VARCHAR(100),
+    "delayMessage" INTEGER,
+    "unknownMessage" VARCHAR(100),
+    "listeningFromMe" BOOLEAN DEFAULT false,
+    "stopBotFromMe" BOOLEAN DEFAULT false,
+    "keepOpen" BOOLEAN DEFAULT false,
+    "debounceTime" INTEGER,
+    "ignoreJids" JSONB,
+    "splitMessages" BOOLEAN DEFAULT false,
+    "timePerChar" INTEGER DEFAULT 50,
+    "triggerType" "TriggerType",
+    "triggerOperator" "TriggerOperator",
+    "triggerValue" TEXT,
+    "createdAt" TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP NOT NULL,
+    "instanceId" TEXT NOT NULL,
+
+    CONSTRAINT "Evoai_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "EvoaiSetting" (
+    "id" TEXT NOT NULL,
+    "expire" INTEGER DEFAULT 0,
+    "keywordFinish" VARCHAR(100),
+    "delayMessage" INTEGER,
+    "unknownMessage" VARCHAR(100),
+    "listeningFromMe" BOOLEAN DEFAULT false,
+    "stopBotFromMe" BOOLEAN DEFAULT false,
+    "keepOpen" BOOLEAN DEFAULT false,
+    "debounceTime" INTEGER,
+    "ignoreJids" JSONB,
+    "splitMessages" BOOLEAN DEFAULT false,
+    "timePerChar" INTEGER DEFAULT 50,
+    "createdAt" TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP NOT NULL,
+    "evoaiIdFallback" VARCHAR(100),
+    "instanceId" TEXT NOT NULL,
+
+    CONSTRAINT "EvoaiSetting_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "EvoaiSetting_instanceId_key" ON "EvoaiSetting"("instanceId");
+
+-- AddForeignKey
+ALTER TABLE "Evoai" ADD CONSTRAINT "Evoai_instanceId_fkey" FOREIGN KEY ("instanceId") REFERENCES "Instance"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "EvoaiSetting" ADD CONSTRAINT "EvoaiSetting_evoaiIdFallback_fkey" FOREIGN KEY ("evoaiIdFallback") REFERENCES "Evoai"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "EvoaiSetting" ADD CONSTRAINT "EvoaiSetting_instanceId_fkey" FOREIGN KEY ("instanceId") REFERENCES "Instance"("id") ON DELETE CASCADE ON UPDATE CASCADE;


### PR DESCRIPTION
…raints

- Created the Evoai and EvoaiSetting tables in the PostgreSQL migration.
- Defined primary keys and added foreign key constraints to link with the Instance table.
- Included unique index on instanceId for EvoaiSetting to ensure data integrity.

## Summary by Sourcery

Add Evoai and EvoaiSetting tables with primary keys, foreign key constraints, and a uniqueness requirement for settings per instance

New Features:
- Create Evoai table with AI configuration fields
- Create EvoaiSetting table for per-instance settings

Enhancements:
- Enforce unique instanceId on EvoaiSetting
- Add foreign key constraints linking Evoai and EvoaiSetting to Instance
- Add foreign key constraint from EvoaiSetting.evoaiIdFallback to Evoai