### PR TITLE
Correção do Markdown na integração N8N e tratamento de mensagens do EvolutionBot

### DIFF
--- a/src/api/integrations/chatbot/evolutionBot/services/evolutionBot.service.ts
+++ b/src/api/integrations/chatbot/evolutionBot/services/evolutionBot.service.ts
@@ -101,7 +101,17 @@ export class EvolutionBotService {
     if (instance.integration === Integration.WHATSAPP_BAILEYS)
       await instance.client.sendPresenceUpdate('paused', remoteJid);
 
-    const message = response?.data?.message;
+    let message = response?.data?.message;
+    
+    if (message && typeof message === 'string') {
+
+      if (message.startsWith("'") && message.endsWith("'")) {
+        const innerContent = message.slice(1, -1);
+        if (!innerContent.includes("'")) {
+          message = innerContent;
+        }
+      }
+    }
 
     return message;
   }

--- a/src/api/integrations/chatbot/evolutionBot/services/evolutionBot.service.ts
+++ b/src/api/integrations/chatbot/evolutionBot/services/evolutionBot.service.ts
@@ -103,15 +103,13 @@ export class EvolutionBotService {
 
     let message = response?.data?.message;
     
-    if (message && typeof message === 'string') {
-
-      if (message.startsWith("'") && message.endsWith("'")) {
-        const innerContent = message.slice(1, -1);
-        if (!innerContent.includes("'")) {
-          message = innerContent;
-        }
-      }
+    if (message && typeof message === 'string' && (message.startsWith("'") && message.endsWith("'"))) {
+          const innerContent = message.slice(1, -1);
+          if (!innerContent.includes("'")) {
+            message = innerContent;
+          }
     }
+
 
     return message;
   }

--- a/src/api/integrations/chatbot/evolutionBot/services/evolutionBot.service.ts
+++ b/src/api/integrations/chatbot/evolutionBot/services/evolutionBot.service.ts
@@ -103,13 +103,12 @@ export class EvolutionBotService {
 
     let message = response?.data?.message;
     
-    if (message && typeof message === 'string' && (message.startsWith("'") && message.endsWith("'"))) {
-          const innerContent = message.slice(1, -1);
-          if (!innerContent.includes("'")) {
-            message = innerContent;
-          }
+    if (message && typeof message === 'string' && message.startsWith("'") && message.endsWith("'")) {
+      const innerContent = message.slice(1, -1);
+      if (!innerContent.includes("'")) {
+        message = innerContent;
+      }
     }
-
 
     return message;
   }

--- a/src/api/integrations/chatbot/n8n/services/n8n.service.ts
+++ b/src/api/integrations/chatbot/n8n/services/n8n.service.ts
@@ -194,7 +194,7 @@ export class N8nService {
   }
 
   private async sendMessageWhatsApp(instance: any, remoteJid: string, message: string, settings: N8nSetting) {
-    const linkRegex = /(!?)\[(.*?)\]\((.*?)\)/g;
+    const linkRegex = /!?\[(.*?)\]\((.*?)\)/g;
     let textBuffer = '';
     let lastIndex = 0;
     let match: RegExpExecArray | null;
@@ -211,7 +211,7 @@ export class N8nService {
       return null;
     };
     while ((match = linkRegex.exec(message)) !== null) {
-      const [altText, url] = match;
+      const [fullMatch, altText, url] = match;
       const mediaType = getMediaType(url);
       const beforeText = message.slice(lastIndex, match.index);
       if (beforeText) {
@@ -282,7 +282,7 @@ export class N8nService {
           );
         }
       } else {
-        textBuffer += `[${altText}](${url})`;
+        textBuffer += fullMatch;
       }
       lastIndex = linkRegex.lastIndex;
     }


### PR DESCRIPTION
## Descrição
Esta PR implementa melhorias no processamento de mensagens do serviço N8N e corrige um problema no tratamento de mensagens retornadas na integração do EvolutionBot. As alterações visam melhorar o tratamento de links e formatação markdown nas mensagens, além de resolver a questão de aspas extras que estavam sendo incluídas no início e fim das mensagens.

## Mudanças
- Ajustada a desestruturação do objeto `match` para capturar corretamente o texto completo do link markdown.
- Modificado o tratamento de links que não são mídia para preservar a formatação original.
- Mantida a expressão regular para detecção de links markdown.
- Implementada uma lógica inteligente para tratar as aspas nas mensagens do EvolutionBot:
  - Verifica se a mensagem inteira está entre aspas simples.
  - Se estiver, verifica se há aspas simples dentro do conteúdo.
  - Remove as aspas externas apenas se não houver aspas/apóstrofos dentro do conteúdo.

## Impacto
- Mensagens com links markdown agora são processadas de forma mais consistente.
- A formatação original dos links é preservada quando não são tratados como mídia.
- Melhor tratamento de casos onde o link não corresponde a um tipo de mídia suportado.
- Mensagens com aspas extras são corrigidas: `'texto'` -> `texto`.
- Mensagens com aspas/apóstrofos legítimos são preservadas: `'texto com "aspas" e don't'` -> `'texto com "aspas" e don't'`.
- Melhora a formatação das mensagens enviadas pelo bot.
- Mantém a compatibilidade com o formato de mensagens do n8n.

<hr>

## Prints Antes:
Tentativa de envio de imagem com markdown na integração do N8N:
![image](https://github.com/user-attachments/assets/583d28d7-44b3-4b69-8946-68f6aac48868)

Tentativa de envio de imagem com markdown na integração Evolution Bot:
![image](https://github.com/user-attachments/assets/1c8cbe34-0c2e-4c8a-9038-62616df927dc)

## Prints Depois:
Tentativa de envio de imagem com markdown na integração do N8N:
![image](https://github.com/user-attachments/assets/e5ac1dc8-cfd8-451b-a335-74c766078d6d)

Tentativa de envio de imagem com markdown na integração Evolution Bot:
![image](https://github.com/user-attachments/assets/c28b26c9-ec1e-416e-80a1-abf43c791c94)

## Summary by Sourcery

Improve markdown link handling in N8N integration and strip extraneous quotes in EvolutionBot message responses.

Bug Fixes:
- Remove unnecessary surrounding single quotes from EvolutionBot responses without affecting valid apostrophes.

Enhancements:
- Refine N8N markdown link regex and destructuring to capture full matches and preserve original formatting for non-media links.