### PR TITLE
fix: Deadlock errors and undefined arguments

### DIFF
--- a/src/api/integrations/channel/whatsapp/whatsapp.baileys.service.ts
+++ b/src/api/integrations/channel/whatsapp/whatsapp.baileys.service.ts
@@ -1311,7 +1311,7 @@ export class BaileysStartupService extends ChannelStartupService {
               data: messageRaw,
             });
 
-            const remoteJid = received.key.remoteJid;
+            const {remoteJid} = received.key;
             const timestamp = msg.messageTimestamp;
             const fromMe = received.key.fromMe.toString();
             const messageKey = `${remoteJid}_${timestamp}_${fromMe}`;
@@ -1567,7 +1567,7 @@ export class BaileysStartupService extends ChannelStartupService {
             if (!key.fromMe && key.remoteJid) {
               readChatToUpdate[key.remoteJid] = true;
 
-              const remoteJid = key.remoteJid;
+              const {remoteJid} = key; 
               const timestamp = findMessage.messageTimestamp;
               const fromMe = key.fromMe.toString();
               const messageKey = `${remoteJid}_${timestamp}_${fromMe}`;
@@ -3828,8 +3828,8 @@ export class BaileysStartupService extends ChannelStartupService {
         buffer: getBuffer ? buffer : null,
       };
     } catch (error) {
-      this.logger.info('Error processing media message:');
-      this.logger.info(error);
+      this.logger.error('Error processing media message:');  
+      this.logger.error(error);
       throw new BadRequestException(error.toString());
     }
   }

--- a/src/api/integrations/channel/whatsapp/whatsapp.baileys.service.ts
+++ b/src/api/integrations/channel/whatsapp/whatsapp.baileys.service.ts
@@ -3749,6 +3749,10 @@ export class BaileysStartupService extends ChannelStartupService {
         }
       }
 
+      if ('messageContextInfo' in msg.message && Object.keys(msg.message).length === 1) {
+        throw 'The message is messageContextInfo';
+      }
+
       let mediaMessage: any;
       let mediaType: string;
 
@@ -3824,8 +3828,8 @@ export class BaileysStartupService extends ChannelStartupService {
         buffer: getBuffer ? buffer : null,
       };
     } catch (error) {
-      this.logger.error('Error processing media message:');
-      this.logger.error(error);
+      this.logger.info('Error processing media message:');
+      this.logger.info(error);
       throw new BadRequestException(error.toString());
     }
   }

--- a/src/api/integrations/channel/whatsapp/whatsapp.baileys.service.ts
+++ b/src/api/integrations/channel/whatsapp/whatsapp.baileys.service.ts
@@ -1173,8 +1173,8 @@ export class BaileysStartupService extends ChannelStartupService {
             const oldMessage = await this.getMessage(editedMessage.key, true);
             if ((oldMessage as any)?.id) {
               const editedMessageTimestamp = Long.isLong(editedMessage?.timestampMs)
-                ? editedMessage.timestampMs?.toNumber()
-                : (editedMessage.timestampMs as number);
+                ? Math.floor(editedMessage.timestampMs.toNumber() / 1000) // Convert to int32 by dividing by 1000 to get seconds
+                : Math.floor((editedMessage.timestampMs as number) / 1000); // Convert to int32 by dividing by 1000 to get seconds
 
               await this.prismaRepository.message.update({
                 where: { id: (oldMessage as any).id },

--- a/src/api/integrations/channel/whatsapp/whatsapp.baileys.service.ts
+++ b/src/api/integrations/channel/whatsapp/whatsapp.baileys.service.ts
@@ -1173,8 +1173,8 @@ export class BaileysStartupService extends ChannelStartupService {
             const oldMessage = await this.getMessage(editedMessage.key, true);
             if ((oldMessage as any)?.id) {
               const editedMessageTimestamp = Long.isLong(editedMessage?.timestampMs)
-                ? Math.floor(editedMessage.timestampMs.toNumber() / 1000) // Convert to int32 by dividing by 1000 to get seconds
-                : Math.floor((editedMessage.timestampMs as number) / 1000); // Convert to int32 by dividing by 1000 to get seconds
+                ? Math.floor(editedMessage.timestampMs.toNumber() / 1000)
+                : Math.floor((editedMessage.timestampMs as number) / 1000);
 
               await this.prismaRepository.message.update({
                 where: { id: (oldMessage as any).id },
@@ -1205,7 +1205,7 @@ export class BaileysStartupService extends ChannelStartupService {
             continue;
           }
 
-          await this.baileysCache.set(messageKey, true, 30 * 60);
+          await this.baileysCache.set(messageKey, true, 5 * 60);
 
           if (
             (type !== 'notify' && type !== 'append') ||
@@ -1311,21 +1311,31 @@ export class BaileysStartupService extends ChannelStartupService {
               data: messageRaw,
             });
 
-            if (received.key.fromMe === false) {
-              if (msg.status === status[3]) {
-                this.logger.log(`Update not read messages ${received.key.remoteJid}`);
+            const remoteJid = received.key.remoteJid;
+            const timestamp = msg.messageTimestamp;
+            const fromMe = received.key.fromMe.toString();
+            const messageKey = `${remoteJid}_${timestamp}_${fromMe}`;
 
-                await this.updateChatUnreadMessages(received.key.remoteJid);
-              } else if (msg.status === status[4]) {
-                this.logger.log(`Update readed messages ${received.key.remoteJid} - ${msg.messageTimestamp}`);
+            const cachedTimestamp = await this.baileysCache.get(messageKey);
 
-                await this.updateMessagesReadedByTimestamp(received.key.remoteJid, msg.messageTimestamp);
+            if (!cachedTimestamp) {
+              if (!received.key.fromMe) {
+                if (msg.status === status[3]) {
+                  this.logger.log(`Update not read messages ${remoteJid}`);
+                  await this.updateChatUnreadMessages(remoteJid);
+                } else if (msg.status === status[4]) {
+                  this.logger.log(`Update readed messages ${remoteJid} - ${timestamp}`);
+                  await this.updateMessagesReadedByTimestamp(remoteJid, timestamp);
+                }
+              } else {
+                // is send message by me
+                this.logger.log(`Update readed messages ${remoteJid} - ${timestamp}`);
+                await this.updateMessagesReadedByTimestamp(remoteJid, timestamp);
               }
-            } else {
-              // is send message by me
-              this.logger.log(`Update readed messages ${received.key.remoteJid} - ${msg.messageTimestamp}`);
 
-              await this.updateMessagesReadedByTimestamp(received.key.remoteJid, msg.messageTimestamp);
+              await this.baileysCache.set(messageKey, true, 5 * 60);
+            } else {
+              this.logger.info(`Update readed messages duplicated ignored [avoid deadlock]: ${messageKey}`);
             }
 
             if (isMedia) {
@@ -1481,7 +1491,7 @@ export class BaileysStartupService extends ChannelStartupService {
         const cached = await this.baileysCache.get(updateKey);
 
         if (cached) {
-          this.logger.info(`Message duplicated ignored: ${key.id}`);
+          this.logger.info(`Message duplicated ignored [avoid deadlock]: ${updateKey}`);
           continue;
         }
 
@@ -1497,7 +1507,7 @@ export class BaileysStartupService extends ChannelStartupService {
           }
         }
 
-        if (key.remoteJid !== 'status@broadcast') {
+        if (key.remoteJid !== 'status@broadcast' && key.id !== undefined) {
           let pollUpdates: any;
 
           if (update.pollUpdates) {
@@ -1525,18 +1535,19 @@ export class BaileysStartupService extends ChannelStartupService {
             continue;
           }
 
+          const message: any = {
+            messageId: findMessage.id,
+            keyId: key.id,
+            remoteJid: key?.remoteJid,
+            fromMe: key.fromMe,
+            participant: key?.remoteJid,
+            status: status[update.status] ?? 'DELETED',
+            pollUpdates,
+            instanceId: this.instanceId,
+          };
+
           if (update.message === null && update.status === undefined) {
             this.sendDataWebhook(Events.MESSAGES_DELETE, key);
-
-            const message: any = {
-              messageId: findMessage.id,
-              keyId: key.id,
-              remoteJid: key.remoteJid,
-              fromMe: key.fromMe,
-              participant: key?.remoteJid,
-              status: 'DELETED',
-              instanceId: this.instanceId,
-            };
 
             if (this.configService.get<Database>('DATABASE').SAVE_DATA.MESSAGE_UPDATE)
               await this.prismaRepository.messageUpdate.create({
@@ -1556,28 +1567,31 @@ export class BaileysStartupService extends ChannelStartupService {
             if (!key.fromMe && key.remoteJid) {
               readChatToUpdate[key.remoteJid] = true;
 
-              if (status[update.status] === status[4]) {
-                this.logger.log(`Update as read ${key.remoteJid} - ${findMessage.messageTimestamp}`);
-                this.updateMessagesReadedByTimestamp(key.remoteJid, findMessage.messageTimestamp);
+              const remoteJid = key.remoteJid;
+              const timestamp = findMessage.messageTimestamp;
+              const fromMe = key.fromMe.toString();
+              const messageKey = `${remoteJid}_${timestamp}_${fromMe}`;
+
+              const cachedTimestamp = await this.baileysCache.get(messageKey);
+
+              if (!cachedTimestamp) {
+                if (status[update.status] === status[4]) {
+                  this.logger.log(`Update as read in message.update ${remoteJid} - ${timestamp}`);
+                  await this.updateMessagesReadedByTimestamp(remoteJid, timestamp);
+                  await this.baileysCache.set(messageKey, true, 5 * 60);
+                }
+
+                await this.prismaRepository.message.update({
+                  where: { id: findMessage.id },
+                  data: { status: status[update.status] },
+                });
+              } else {
+                this.logger.info(
+                  `Update readed messages duplicated ignored in message.update [avoid deadlock]: ${messageKey}`,
+                );
               }
             }
-
-            await this.prismaRepository.message.update({
-              where: { id: findMessage.id },
-              data: { status: status[update.status] },
-            });
           }
-
-          const message: any = {
-            messageId: findMessage.id,
-            keyId: key.id,
-            remoteJid: key.remoteJid,
-            fromMe: key.fromMe,
-            participant: key?.remoteJid,
-            status: status[update.status],
-            pollUpdates,
-            instanceId: this.instanceId,
-          };
 
           this.sendDataWebhook(Events.MESSAGES_UPDATE, message);
 
@@ -3745,7 +3759,7 @@ export class BaileysStartupService extends ChannelStartupService {
           break;
         }
       }
-
+      
       if (!mediaMessage) {
         throw 'The message is not of the media type';
       }

--- a/src/api/integrations/chatbot/chatwoot/utils/chatwoot-import-helper.ts
+++ b/src/api/integrations/chatbot/chatwoot/utils/chatwoot-import-helper.ts
@@ -499,25 +499,29 @@ class ChatwootImport {
       stickerMessage: msg.message.stickerMessage,
       templateMessage: msg.message.templateMessage?.hydratedTemplate?.hydratedContentText,
     };
-    const typeKey = Object.keys(types).find((key) => types[key] !== undefined);
 
+    const typeKey = Object.keys(types).find(
+      (key) => types[key] !== undefined && types[key] !== null
+    );
     switch (typeKey) {
-      case 'documentMessage':
-        return `_<File: ${msg.message.documentMessage.fileName}${
-          msg.message.documentMessage.caption ? ` ${msg.message.documentMessage.caption}` : ''
-        }>_`;
+      case 'documentMessage': {
+        const doc = msg.message.documentMessage;
+        const fileName = doc?.fileName || 'document';
+        const caption = doc?.caption ? ` ${doc.caption}` : '';
+        return `_<File: ${fileName}${caption}>_`;
+      }
 
-      case 'documentWithCaptionMessage':
-        return `_<File: ${msg.message.documentWithCaptionMessage.message.documentMessage.fileName}${
-          msg.message.documentWithCaptionMessage.message.documentMessage.caption
-            ? ` ${msg.message.documentWithCaptionMessage.message.documentMessage.caption}`
-            : ''
-        }>_`;
+      case 'documentWithCaptionMessage': {
+        const doc = msg.message.documentWithCaptionMessage?.message?.documentMessage;
+        const fileName = doc?.fileName || 'document';
+        const caption = doc?.caption ? ` ${doc.caption}` : '';
+        return `_<File: ${fileName}${caption}>_`;
+      }
 
       case 'templateMessage':
-        return msg.message.templateMessage.hydratedTemplate.hydratedTitleText
-          ? `*${msg.message.templateMessage.hydratedTemplate.hydratedTitleText}*\\n`
-          : '' + msg.message.templateMessage.hydratedTemplate.hydratedContentText;
+        const template = msg.message.templateMessage?.hydratedTemplate;
+        return (template?.hydratedTitleText ? `*${template.hydratedTitleText}*\n` : '') +
+              (template?.hydratedContentText || '');
 
       case 'imageMessage':
         return '_<Image Message>_';


### PR DESCRIPTION
## Descrição
Este PR corrige diversos problemas relacionados a deadlocks causados por mensagens upsert e update que chegam duplicadas e são processadas simultaneamente pelo script, resultando em conflitos no banco de dados.
Também soluciona falhas ao tentar inserir determinados valores no banco.

## Soluções
- Implementação de cache em memória para identificar e evitar o processamento de mensagens duplicadas, prevenindo deadlocks.
- Conversão de timestamps de milissegundos para segundos por meio de divisão por 1000, seguindo a mesma lógica adotada em outros pontos do script.
- Reorganização e correção de métodos que estavam atribuindo valores `undefined` a certas propriedades de forma indevida.

## Summary by Sourcery

Implement in-memory caching to prevent deadlocks from duplicate message processing, convert timestamps to seconds, and enforce null-safe handling of message types and payloads in WhatsApp and Chatwoot integrations

Bug Fixes:
- Prevent deadlocks by caching and skipping duplicate upsert/update messages in the WhatsApp service
- Throw errors for messages containing only context info or non-media types to avoid undefined arguments

Enhancements:
- Standardize timestamp conversion from milliseconds to seconds across edit and update workflows
- Refactor WhatsApp service to use unique cache keys, reduce TTL to 5 minutes, and skip broadcasts or undefined-ID messages for read receipts and delete events
- Improve null-safety and default fallbacks in Chatwoot import helper for document and template messages