### PR TITLE
Fix-chatwoot-import

### DIFF
--- a/src/api/integrations/chatbot/chatwoot/services/chatwoot.service.ts
+++ b/src/api/integrations/chatbot/chatwoot/services/chatwoot.service.ts
@@ -930,7 +930,7 @@ export class ChatwootService {
     quotedMsg?: MessageModel,
   ) {
     if (sourceId && this.isImportHistoryAvailable()) {
-      const messageAlreadySaved = await chatwootImport.getExistingSourceIds([sourceId]);
+      const messageAlreadySaved = await chatwootImport.getExistingSourceIds([sourceId], conversationId);
       if (messageAlreadySaved) {
         if (messageAlreadySaved.size > 0) {
           this.logger.warn('Message already saved on chatwoot');

--- a/src/api/integrations/chatbot/chatwoot/utils/chatwoot-import-helper.ts
+++ b/src/api/integrations/chatbot/chatwoot/utils/chatwoot-import-helper.ts
@@ -169,7 +169,7 @@ class ChatwootImport {
     }
   }
 
-  public async getExistingSourceIds(sourceIds: string[]): Promise<Set<string>> {
+  public async getExistingSourceIds(sourceIds: string[], conversationId?: number): Promise<Set<string>> {
     try {
       const existingSourceIdsSet = new Set<string>();
 
@@ -178,9 +178,17 @@ class ChatwootImport {
       }
 
       const formattedSourceIds = sourceIds.map((sourceId) => `WAID:${sourceId.replace('WAID:', '')}`); // Make sure the sourceId is always formatted as WAID:1234567890
-      const query = 'SELECT source_id FROM messages WHERE source_id = ANY($1)';
+      let query: string;
+      if (conversationId) {
+       query = 'SELECT source_id FROM messages WHERE source_id = ANY($1)';
+      }
+
+      if(!conversationId) {
+        query = 'SELECT source_id FROM messages WHERE source_id = ANY($1) AND conversation_id = $2';
+      }
+
       const pgClient = postgresClient.getChatwootConnection();
-      const result = await pgClient.query(query, [formattedSourceIds]);
+      const result = await pgClient.query(query, [formattedSourceIds, conversationId]);
 
       for (const row of result.rows) {
         existingSourceIdsSet.add(row.source_id);


### PR DESCRIPTION
Sugestão de correção para issue: 

https://github.com/EvolutionAPI/evolution-api/issues/1480

## Summary by Sourcery

Fix message import to avoid duplicates by scoping retrieval of existing source IDs to the correct conversation

Bug Fixes:
- Accept an optional conversationId in getExistingSourceIds and adjust the SQL query to filter by conversation_id when provided
- Pass conversationId from ChatwootService to getExistingSourceIds to prevent duplicate message imports