### PR TITLE
chore: possibilita o envio de medias do tipo [svg, tiff] vindas do Chatwoot

### DIFF
--- a/src/api/integrations/chatbot/chatwoot/services/chatwoot.service.ts
+++ b/src/api/integrations/chatbot/chatwoot/services/chatwoot.service.ts
@@ -1110,7 +1110,7 @@ export class ChatwootService {
         return messageSent;
       }
 
-      const documentExtensions = ['.gif', '.svg'];
+      const documentExtensions = ['.gif', '.svg', '.tiff'];
       if (type === 'image' && parsedMedia && documentExtensions.includes(parsedMedia?.ext)) {
         type = 'document';
       }

--- a/src/api/integrations/chatbot/chatwoot/services/chatwoot.service.ts
+++ b/src/api/integrations/chatbot/chatwoot/services/chatwoot.service.ts
@@ -1110,7 +1110,7 @@ export class ChatwootService {
         return messageSent;
       }
 
-      const documentExtensions = ['.gif', '.svg', '.tiff'];
+      const documentExtensions = ['.gif', '.svg', '.tiff', '.tif'];
       if (type === 'image' && parsedMedia && documentExtensions.includes(parsedMedia?.ext)) {
         type = 'document';
       }

--- a/src/api/integrations/chatbot/chatwoot/services/chatwoot.service.ts
+++ b/src/api/integrations/chatbot/chatwoot/services/chatwoot.service.ts
@@ -1110,7 +1110,8 @@ export class ChatwootService {
         return messageSent;
       }
 
-      if (type === 'image' && parsedMedia && parsedMedia?.ext === '.gif') {
+      const documentExtensions = ['.gif', '.svg'];
+      if (type === 'image' && parsedMedia && documentExtensions.includes(parsedMedia?.ext)) {
         type = 'document';
       }
 


### PR DESCRIPTION
## Descrição
Este PR adiciona a possiblidade de envio de arquivos do tipo `SVG` e `TIFF` da mesma forma que faz com do tipo `GIF` vindas do Chatwoot.
Atualmente o WhatsApp WEB somente aceita imagens do tipo `JPG, PNG e WEBP` de forma nativa, `GIF` e `SVG` o core processa as imagens em `JPEG` e `PNG` respectivamente.

Como o Chatwoot não entende que isso é um problema no canal de API deles, visto que o envio do arquivo é feito puro. Então sim, se entende ser um problema da API. Devemos tratar esses attachs na API Evolution. 

## Proposta
Enviar os tipos `SVG` e `TIFF` da mesma forma que atualmente é feito com as imagens do tipo `GIF`.

## Solução
Adicionei uma constante com um array de extensões de mimetype: image e que deverão ser enviadas como tipo document. O array permite a fácil inclusão de outros tipos de imagens que poderão ser identificadas futuramente.

```
const documentExtensions = ['.gif', '.svg', '.tiff'];
if (type === 'image' && parsedMedia && documentExtensions.includes(parsedMedia?.ext)) {
  type = 'document';
}
```

## Futuro
Futuramente poderíamos implementar um processador de imagens. Convertendo nos formatos aceitáveis pelo WhatsApp.
