### PR TITLE
fix: Corrige envio da apiKey da instância nos payloads do Evolution Bot e N8N

### DIFF
--- a/src/api/integrations/chatbot/evolutionBot/services/evolutionBot.service.ts
+++ b/src/api/integrations/chatbot/evolutionBot/services/evolutionBot.service.ts
@@ -52,7 +52,7 @@ export class EvolutionBotService extends BaseChatbotService<EvolutionBot, Evolut
           fromMe: msg?.key?.fromMe,
           instanceName: instance.instanceName,
           serverUrl: this.configService.get<HttpServer>('SERVER').URL,
-          apiKey: this.configService.get<Auth>('AUTHENTICATION').API_KEY.KEY,
+          apiKey: instance.token,
         },
         query: content,
         conversation_id: session.sessionId === remoteJid ? undefined : session.sessionId,

--- a/src/api/integrations/chatbot/n8n/services/n8n.service.ts
+++ b/src/api/integrations/chatbot/n8n/services/n8n.service.ts
@@ -135,7 +135,7 @@ export class N8nService extends BaseChatbotService<N8n, N8nSetting> {
         fromMe: msg?.key?.fromMe,
         instanceName: instance.instanceName,
         serverUrl: this.configService.get<HttpServer>('SERVER').URL,
-        apiKey: this.configService.get<Auth>('AUTHENTICATION').API_KEY.KEY,
+        apiKey: instance.token,
       };
 
       // Handle audio messages


### PR DESCRIPTION
Corrige o envio da apiKey nos payloads do Evolution Bot e N8N para usar a apiKey específica da instância ao invés da apiKey global do sistema.

## Summary by Sourcery

Fix apiKey payloads in Evolution Bot and N8N services to use the instance-specific token instead of the global system API key

Bug Fixes:
- Use instance.token as apiKey in Evolution Bot payloads instead of the global API key
- Use instance.token as apiKey in N8N payloads instead of the global API key