### PR TITLE
feat: transform template message

### DIFF
--- a/src/api/integrations/channel/meta/whatsapp.business.service.ts
+++ b/src/api/integrations/channel/meta/whatsapp.business.service.ts
@@ -713,6 +713,20 @@ export class BusinessStartupService extends ChannelStartupService {
     return message;
   }
 
+  private getTemplateMessage(message: string, parameters: any[]) {
+    let transformedMessage = message;
+    for (const index in parameters) {
+      const parameter = parameters[index];
+      transformedMessage = transformedMessage.replace(`{{${index + 1}}}`, parameter.text);
+    }
+    return transformedMessage;
+  }
+
+  private getTemplateComponent(components: any[], name: string) {
+    const c = components.find((c) => c.type.toUpperCase() === name.toUpperCase());
+    return c ?? {};
+  }
+
   protected async eventHandler(content: any) {
     const database = this.configService.get<Database>('DATABASE');
     const settings = await this.findSettings();
@@ -903,7 +917,10 @@ export class BusinessStartupService extends ChannelStartupService {
             },
           };
           quoted ? (content.context = { message_id: quoted.id }) : content;
-          message = { conversation: `▶️${message['template']['name']}◀️` };
+          const body = this.getTemplateComponent(message['template']['components'], 'body');
+          message = {
+            conversation: this.getTemplateMessage(message['template']['message'], body.parameters),
+          };
           return await this.post(content, 'messages');
         }
       })();


### PR DESCRIPTION
## Summary by Sourcery

Implement rendering of WhatsApp message templates by extracting the body component and replacing its placeholders with parameter values before sending.

New Features:
- Add helper to replace WhatsApp template message placeholders with provided parameter values
- Add helper to extract specified components from WhatsApp message templates
- Render and send the actual template body with parameter values instead of the template name in outgoing messages