### PR TITLE
corrige estrutura de if/else e bloco try/catch em chatwoot-import-helper.ts

### DIFF
--- a/src/api/integrations/chatbot/chatwoot/utils/chatwoot-import-helper.ts
+++ b/src/api/integrations/chatbot/chatwoot/utils/chatwoot-import-helper.ts
@@ -181,8 +181,7 @@ class ChatwootImport {
       let query: string;
       if (conversationId) {
         query = 'SELECT source_id FROM messages WHERE source_id = ANY($1) AND conversation_id = $2';
-
-      if (!conversationId) {
+      } else {
         query = 'SELECT source_id FROM messages WHERE source_id = ANY($1)';
       }
 
@@ -337,6 +336,7 @@ class ChatwootImport {
 
       this.deleteHistoryMessages(instance);
       this.deleteRepositoryMessagesCache(instance);
+      return 0;
     }
   }
 


### PR DESCRIPTION
Esta PR corrige problemas de sintaxe no arquivo chatwoot-import-helper.ts, especificamente:
- Ajusta a estrutura do bloco if/else no método getExistingSourceIds, evitando erro de compilação do TypeScript.
- Garante que o bloco catch esteja corretamente posicionado dentro do método, retornando null em caso de erro.
- Mantém a lógica original do método, apenas corrigindo a sintaxe para permitir a compilação e execução correta do projeto. Essas correções eliminam o erro de build relacionado ao TypeScript e melhoram a robustez do código ao tratar exceções de forma adequada.

## Summary by Sourcery

Fix syntax and control flow issues in chatwoot-import-helper.ts to resolve TypeScript build errors and ensure proper method execution

Bug Fixes:
- Replace improper nested if with an else clause in getExistingSourceIds to correct the conditional structure
- Add a return statement after cleanup operations to prevent fallthrough and ensure proper method exit