### PR TITLE
fix: melhora a formatação e tratamento de erros na função getExistingSourceIds

### DIFF
--- a/src/api/integrations/chatbot/chatwoot/utils/chatwoot-import-helper.ts
+++ b/src/api/integrations/chatbot/chatwoot/utils/chatwoot-import-helper.ts
@@ -177,17 +177,16 @@ class ChatwootImport {
         return existingSourceIdsSet;
       }
 
+      // Ensure all sourceIds are consistently prefixed with 'WAID:' as required by downstream systems and database queries.
       const formattedSourceIds = sourceIds.map((sourceId) => `WAID:${sourceId.replace('WAID:', '')}`);
       const pgClient = postgresClient.getChatwootConnection();
-      
-      const params = conversationId 
-        ? [formattedSourceIds, conversationId] 
-        : [formattedSourceIds];
-      
+
+      const params = conversationId ? [formattedSourceIds, conversationId] : [formattedSourceIds];
+
       const query = conversationId
         ? 'SELECT source_id FROM messages WHERE source_id = ANY($1) AND conversation_id = $2'
         : 'SELECT source_id FROM messages WHERE source_id = ANY($1)';
-      
+
       const result = await pgClient.query(query, params);
       for (const row of result.rows) {
         existingSourceIdsSet.add(row.source_id);


### PR DESCRIPTION
## Problema
Mesmo após as correções de #1493 e #1490, em certas ocasiões continuou o erro:
`bind message supplies 2 parameters, but prepared statement "" requires 1`

 Passou a ter o seguinte erro no banco de dados:
`Error on import history messages: TypeError: Cannot read properties of null (reading 'has')`

## Solução
- Criar um condição para ser somente informado a quantidade de parâmetros corretos. 
- `has` não lê valores `null`, então foi alterado a possibilidade de retorno do valor `null` em caso de acionamento do bloco `catch`

## Summary by Sourcery

Fix parameter binding and error handling in getExistingSourceIds to prevent SQL parameter count mismatches and avoid returning null

Bug Fixes:
- Dynamically build the SQL query and its parameters in getExistingSourceIds to match the correct number of placeholders
- Return an empty Set instead of null in the catch block to prevent downstream TypeErrors

Enhancements:
- Log errors encountered in getExistingSourceIds for better observability

Chores:
- Remove redundant `return 0` after message deletion