### PR TITLE
Added prisma extension to convert "path" in array format (postgresql) to string format (mysql)

### DIFF
--- a/src/api/extensions/prismaExtensionPgpathToMysql.js
+++ b/src/api/extensions/prismaExtensionPgpathToMysql.js
@@ -4,7 +4,9 @@ import { Logger } from '@config/logger.config';
 const logger = new Logger('PGPATH2MYSQL');
 
 function convertPgPathToMysql (path) {
-  if (!Array.isArray(path)) return path
+  if (!Array.isArray(path)) {
+    return path
+  }
   let result = '$'
   for (const item of path) {
     if (/^\d+$/.test(item)) {

--- a/src/api/extensions/prismaExtensionPgpathToMysql.js
+++ b/src/api/extensions/prismaExtensionPgpathToMysql.js
@@ -1,0 +1,61 @@
+import { Prisma } from '@prisma/client'
+import { Logger } from '@config/logger.config';
+
+const logger = new Logger('PGPATH2MYSQL');
+
+function convertPgPathToMysql (path) {
+  if (!Array.isArray(path)) return path
+  let result = '$'
+  for (const item of path) {
+    if (/^\d+$/.test(item)) {
+      result += `[${item}]`
+    } else {
+      result += `.${item}`
+    }
+  }
+  return result
+}
+
+function processWhere (obj) {
+  if (obj && typeof obj === 'object') {
+    for (const key in obj) {
+      if (Object.prototype.hasOwnProperty.call(obj, key)) {
+        if (key === 'path') {
+          obj[key] = convertPgPathToMysql(obj[key]);
+        } else {
+          processWhere(obj[key]);
+        }
+      }
+    }
+  }
+}
+
+// https://www.prisma.io/docs/orm/prisma-client/client-extensions/query#modify-all-operations-in-all-models-of-your-schema
+// https://www.prisma.io/docs/orm/prisma-client/client-extensions/query#modify-a-specific-operation-in-a-specific-model
+
+const overriddenOperation = async ({ model, operation, args, query }) => {
+  if (args?.where) {
+    processWhere(args.where)
+  }
+  const result = await query(args)
+  logger.debug({ model, operation, args: JSON.stringify(args), result })
+  return result
+}
+
+export default Prisma.defineExtension({
+  name: 'prisma-extension-pgpath-to-mysql',
+  query: {
+    $allModels: {
+      findFirst: overriddenOperation,
+      findMany: overriddenOperation,
+      updateMany: overriddenOperation,
+      count: overriddenOperation,
+      deleteMany: overriddenOperation,
+
+      delete: overriddenOperation,
+      findUnique: overriddenOperation,
+      update: overriddenOperation,
+      upsert: overriddenOperation,
+    }
+  }
+})

--- a/src/api/integrations/channel/whatsapp/whatsapp.baileys.service.ts
+++ b/src/api/integrations/channel/whatsapp/whatsapp.baileys.service.ts
@@ -1509,7 +1509,7 @@ export class BaileysStartupService extends ChannelStartupService {
             remoteJid: key.remoteJid,
             fromMe: key.fromMe,
             participant: key?.remoteJid,
-            status: status[update.status],
+            status: status[update.status] || findMessage.status,
             pollUpdates,
             instanceId: this.instanceId,
           };

--- a/src/api/integrations/channel/whatsapp/whatsapp.baileys.service.ts
+++ b/src/api/integrations/channel/whatsapp/whatsapp.baileys.service.ts
@@ -1509,7 +1509,7 @@ export class BaileysStartupService extends ChannelStartupService {
             remoteJid: key.remoteJid,
             fromMe: key.fromMe,
             participant: key?.remoteJid,
-            status: status[update.status] || findMessage.status,
+            status: status[update.status] ?? findMessage.status,
             pollUpdates,
             instanceId: this.instanceId,
           };

--- a/src/api/server.module.ts
+++ b/src/api/server.module.ts
@@ -60,7 +60,7 @@ if (configService.get<ProviderSession>('PROVIDER').ENABLED) {
 
 const provider = configService.get<Database>('DATABASE').PROVIDER;
 let extendablePrismaRepository: PrismaRepository = new PrismaRepository(configService)
-if (provider === "mysql") {
+if (typeof provider === 'string' && provider?.toLowerCase() === 'mysql') {
   extendablePrismaRepository = extendsWithProxy(extendablePrismaRepository, pgPathToMysql);
 }
 export const prismaRepository = extendablePrismaRepository;

--- a/src/api/server.module.ts
+++ b/src/api/server.module.ts
@@ -1,7 +1,8 @@
 import { CacheEngine } from '@cache/cacheengine';
-import { Chatwoot, configService, ProviderSession, Database } from '@config/env.config';
+import { Chatwoot, configService, Database, ProviderSession } from '@config/env.config';
 import { eventEmitter } from '@config/event.config';
 import { Logger } from '@config/logger.config';
+import { extendsWithProxy } from '@utils/extendsWithProxy';
 
 import { CallController } from './controllers/call.controller';
 import { ChatController } from './controllers/chat.controller';
@@ -12,6 +13,7 @@ import { ProxyController } from './controllers/proxy.controller';
 import { SendMessageController } from './controllers/sendMessage.controller';
 import { SettingsController } from './controllers/settings.controller';
 import { TemplateController } from './controllers/template.controller';
+import pgPathToMysql from './extensions/prismaExtensionPgpathToMysql';
 import { ChannelController } from './integrations/channel/channel.controller';
 import { EvolutionController } from './integrations/channel/evolution/evolution.controller';
 import { MetaController } from './integrations/channel/meta/meta.controller';
@@ -40,9 +42,6 @@ import { ProxyService } from './services/proxy.service';
 import { SettingsService } from './services/settings.service';
 import { TemplateService } from './services/template.service';
 
-import pgPathToMysql from './extensions/prismaExtensionPgpathToMysql';
-import { extendsWithProxy } from '@utils/extendsWithProxy';
-
 const logger = new Logger('WA MODULE');
 
 let chatwootCache: CacheService = null;
@@ -59,7 +58,7 @@ if (configService.get<ProviderSession>('PROVIDER').ENABLED) {
 }
 
 const provider = configService.get<Database>('DATABASE').PROVIDER;
-let extendablePrismaRepository: PrismaRepository = new PrismaRepository(configService)
+let extendablePrismaRepository: PrismaRepository = new PrismaRepository(configService);
 if (typeof provider === 'string' && provider?.toLowerCase() === 'mysql') {
   extendablePrismaRepository = extendsWithProxy(extendablePrismaRepository, pgPathToMysql);
 }

--- a/src/utils/extendsWithProxy.ts
+++ b/src/utils/extendsWithProxy.ts
@@ -1,0 +1,27 @@
+import { PrismaClient } from '@prisma/client';
+
+type ExtensionArgs = Parameters<PrismaClient['$extends']>[0];
+
+export function extendsWithProxy<T extends PrismaClient>(
+  instanciaBase: T,
+  extensao: ExtensionArgs
+): T {
+  const instanciaEstendida = instanciaBase.$extends(extensao);
+
+  const proxy = new Proxy(instanciaBase as unknown as object, {
+    get(target, prop, receiver) {
+      if (prop === 'toString') {
+        return () => '[Proxy toString]';
+      }
+      if (prop === Symbol.toStringTag) {
+        return undefined;
+      }
+      return prop in instanciaEstendida ? Reflect.get(instanciaEstendida as any, prop, receiver) : Reflect.get(target, prop, receiver);
+    },
+    has(target, prop) {
+      return prop in target || prop in (instanciaEstendida as any);
+    },
+  });
+
+  return proxy as unknown as T;
+}

--- a/src/utils/extendsWithProxy.ts
+++ b/src/utils/extendsWithProxy.ts
@@ -2,10 +2,7 @@ import { PrismaClient } from '@prisma/client';
 
 type ExtensionArgs = Parameters<PrismaClient['$extends']>[0];
 
-export function extendsWithProxy<T extends PrismaClient>(
-  instanciaBase: T,
-  extensao: ExtensionArgs
-): T {
+export function extendsWithProxy<T extends PrismaClient>(instanciaBase: T, extensao: ExtensionArgs): T {
   const instanciaEstendida = instanciaBase.$extends(extensao);
 
   const proxy = new Proxy(instanciaBase as unknown as object, {
@@ -16,7 +13,9 @@ export function extendsWithProxy<T extends PrismaClient>(
       if (prop === Symbol.toStringTag) {
         return undefined;
       }
-      return prop in instanciaEstendida ? Reflect.get(instanciaEstendida as any, prop, receiver) : Reflect.get(target, prop, receiver);
+      return prop in instanciaEstendida
+        ? Reflect.get(instanciaEstendida as any, prop, receiver)
+        : Reflect.get(target, prop, receiver);
     },
     has(target, prop) {
       return prop in target || prop in (instanciaEstendida as any);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,6 +17,7 @@
     "strictNullChecks": false,
     "incremental": true,
     "noImplicitAny": false,
+    "allowJs": true,
     "baseUrl": ".",
     "paths": {
       "@api/*": ["./src/api/*"],


### PR DESCRIPTION
Este PR deve resolver os seguintes erros:
1. Argument `path`: Invalid value provided. Expected String, provided (String).
    * fix #1158
2. Argument `status` is missing.
    * fix #1266

O 1o erro ocorre sempre que há alguma consulta que envolve buscar algo em um campo JSON.
Por exemplo:
```
where: {
  key: {
    path: ['id'], // <- PostgreSQL
    equals: messageId,
  }
}
```
De acordo com a documentação do Prisma, o formato esperado para trabalhar com MySQL é o seguinte:
```
where: {
  key: {
    path: '$.id', // <- MySQL
    equals: messageId,
  }
}
```
A solução proposta foi criar uma extensão que é aplicada em tempo de execução quando se está usando o provider "mysql".
Ou seja, a aplicação continua usando o formato de array (postgresql) e a extensão processa a cláusula where de forma recursiva e converte o "path" em string.

Para maiores detalhes, segue links da documentação:
* https://www.prisma.io/docs/orm/prisma-client/special-fields-and-types/working-with-json-fields#filter-on-object-property
* https://www.prisma.io/docs/orm/prisma-client/special-fields-and-types/working-with-json-fields#targeting-an-array-element-by-index
* https://www.prisma.io/docs/orm/prisma-client/client-extensions/query#modify-a-specific-operation-in-a-specific-model
* https://www.prisma.io/docs/orm/prisma-client/client-extensions/query#modify-all-operations-in-all-models-of-your-schema

O 2o erro aconteceu comigo quando recebi uma mensagem editada.
Mensagens editadas não possuem status.
Então, o campo "status" terminava ficando indefinido.
Como "status" é um campo obrigatório no banco, lança o erro.

A solução proposta para este caso foi atribuir o status da mensagem original quando este for indefinido.

## Summary by Sourcery

Add runtime Prisma extension to convert PostgreSQL-style JSON path arrays into MySQL JSON path strings and apply it via a proxy when using the MySQL provider, fix missing message status fallback, and enable JavaScript support in tsconfig.

New Features:
- Add Prisma client extension to transform PG-style JSON path arrays into MySQL JSON path strings at runtime.
- Apply the extension transparently via an `extendsWithProxy` wrapper when the MySQL provider is used.

Bug Fixes:
- Fallback to the original message status when `update.status` is undefined to prevent missing status errors.

Build:
- Enable `allowJs` in tsconfig to include the new JavaScript Prisma extension file.