### PR TITLE
Update `fetchStatusMessage` to handle empty offset / page

### DIFF
--- a/src/api/services/channel.service.ts
+++ b/src/api/services/channel.service.ts
@@ -656,6 +656,14 @@ export class ChannelStartupService {
   }
 
   public async fetchStatusMessage(query: any) {
+    if (!query?.offset) {
+      query.offset = 50;
+    }
+
+    if (!query?.page) {
+      query.page = 1;
+    }
+
     return await this.prismaRepository.messageUpdate.findMany({
       where: {
         instanceId: this.instanceId,


### PR DESCRIPTION
Currently, using and undefined value `offset` or `page` when calling `fetchStatusMessage` returns an Internal Server Error (http code 500) in the API.

This, with the fact that the docs did not mention `offset` and `page`, caused some confusion when interacting with this endpoint.

This PR adds a default value for both `offset` and `page` when they are not specified, similar to what is already done in the function [`fetchMessages` (src/api/services/channel.service.ts)](https://github.com/EvolutionAPI/evolution-api/blob/427c99499394d3894e4b065626323c45e91022e4/src/api/services/channel.service.ts#L628)

This, together with the docs update at https://github.com/EvolutionAPI/docs-evolution/pull/16, should solve the issues #1253, #1339, and #1533