### PR TITLE
feat: update default conversation message for template message

### DIFF
--- a/src/api/dto/sendMessage.dto.ts
+++ b/src/api/dto/sendMessage.dto.ts
@@ -157,6 +157,7 @@ export class SendTemplateDto extends Metadata {
   language: string;
   components: any;
   webhookUrl?: string;
+  message?: string;
 }
 export class SendContactDto extends Metadata {
   contact: ContactMessage[];

--- a/src/validate/message.schema.ts
+++ b/src/validate/message.schema.ts
@@ -34,6 +34,7 @@ export const templateMessageSchema: JSONSchema7 = {
     language: { type: 'string' },
     components: { type: 'array' },
     webhookUrl: { type: 'string' },
+    message: { type: 'string' },
   },
   required: ['name', 'language'],
 };


### PR DESCRIPTION
## Summary by Sourcery

Enable dynamic message generation for WhatsApp templates by substituting component parameters and add optional message field to SendTemplateDto and its validation schema

New Features:
- Add optional `message` field to `SendTemplateDto` and update its JSON schema for validation

Enhancements:
- Introduce `getTemplateComponent` helper to locate template components by type
- Introduce `getTemplateMessage` helper to substitute placeholder parameters in template messages
- Update eventHandler logic to generate dynamic conversation content from template components with a fallback to the template name