### PR TITLE
feat(audio): support LPCM and fix waveform distortion

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "@prisma/client": "^6.1.0",
     "@sentry/node": "^8.47.0",
     "amqplib": "^0.10.5",
+    "audio-decode": "^2.2.3",
     "axios": "^1.7.9",
     "baileys": "github:EvolutionAPI/Baileys",
     "class-validator": "^0.14.1",


### PR DESCRIPTION
This update adds **automatic detection and conversion of LPCM (Linear PCM)** audio files — a format commonly generated by **Google Text-to-Speech** — ensuring proper sample rate and compatibility.

✅ The following formats were tested and confirmed working:  
`m4a`, `mp3`, `mp4`, `wav`, `opus`, `oga`, `ogg`, and `lpcm`.

🧪 During testing, the resulting audio files consistently displayed **waveform previews (waves)** on **WhatsApp for Android, iOS, and Web**.

## Summary by Sourcery

Support automatic detection and conversion of LPCM audio streams in the WhatsApp integration to fix distorted waveforms and ensure cross-platform compatibility.

New Features:
- Automatically detect LPCM audio URLs and apply raw PCM ffmpeg settings for conversion

Bug Fixes:
- Fix waveform distortion in WhatsApp audio previews by correctly handling LPCM streams

Build:
- Add 'audio-decode' dependency to enable LPCM processing