### PR TITLE
feat: Add GitHub Actions workflow to run stack

### DIFF
--- a/.github/workflows/run_in_action.yml
+++ b/.github/workflows/run_in_action.yml
@@ -1,0 +1,28 @@
+name: Run Application Stack in Action
+
+on:
+  workflow_dispatch: # Allows manual triggering
+  pull_request:
+    branches: [ main, develop ] # Or specify branches as needed
+
+jobs:
+  run_stack:
+    name: Run Docker Compose Stack
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+
+      - name: Start Docker Compose Stack
+        run: docker-compose up -d
+
+      - name: Health Check
+        run: |
+          echo "Waiting for services to start..."
+          sleep 30 # Wait for 30 seconds
+          echo "Pinging API..."
+          curl -f http://localhost:8080/ | grep "Welcome to the Evolution API, it is working!"
+
+      - name: Stop Docker Compose Stack
+        if: always() # Ensures this step runs even if previous steps fail
+        run: docker-compose down


### PR DESCRIPTION
This commit introduces a new GitHub Actions workflow (`.github/workflows/run_in_action.yml`).

The workflow allows for running the entire application stack (API, Redis, PostgreSQL) using Docker Compose directly within the GitHub Actions runner. This is intended for temporary testing or preview purposes.

Key features of the workflow:
- Triggers: Manually (`workflow_dispatch`) or on pull requests targeting `main` or `develop` branches.
- Services: Starts services defined in `docker-compose.yaml`.
- Health Check: Includes a step to wait for services to initialize and then pings the API's root endpoint (/) to verify it's responsive.
- Cleanup: Ensures `docker-compose down` is executed at the end of the run, even if previous steps fail, to clean up resources.

## Summary by Sourcery

Add a GitHub Actions workflow to spin up the application stack with Docker Compose for manual or pull request testing, including a health check and cleanup step.

CI:
- Add `run_in_action.yml` workflow to run the API, Redis, and PostgreSQL stack via Docker Compose on manual dispatch or pull requests to `main`/`develop`
- Include a health check step that waits for services to initialize and verifies the API endpoint
- Ensure resources are cleaned up by running `docker-compose down` regardless of prior step outcomes