### PR TITLE
refactor(chatwoot): Melhora e ajusta tratamento de números @lid

### DIFF
--- a/src/api/integrations/channel/whatsapp/whatsapp.baileys.service.ts
+++ b/src/api/integrations/channel/whatsapp/whatsapp.baileys.service.ts
@@ -822,10 +822,10 @@ export class BaileysStartupService extends ChannelStartupService {
               if (this.configService.get<Chatwoot>('CHATWOOT').ENABLED && this.localChatwoot?.enabled) {
                 const instance = { instanceName: this.instance.name, instanceId: this.instance.id };
 
-                const findParticipant = await this.chatwootService.findContact(instance, {
-                  identifier: contact.remoteJid,
-                  phone_number: contact.remoteJid.split('@')[0],
-                });
+                const findParticipant = await this.chatwootService.findContact(
+                  instance,
+                  contact.remoteJid.split('@')[0],
+                );
 
                 if (!findParticipant) {
                   return;


### PR DESCRIPTION
## Descrição
Melhora e refatora parte dos commits anteriores que tens como objetivo solucionar a criação dos contatos `@lid` no Chatwoot.

@DavidsonGomes com todo o respeito, analisei e testei essas ultimas implementações suas. Mas em certos pontos os `@lid` estão sendo tratados em condições junto com grupos, esses `@lid` são diferente disso. Em alguns momentos funciona e em outros não.

Desde 11/06 vim testando insistentemente e reproduzindo o erro com contatos que eu mesmo consegui simular. Estou com um cliente que teve 263 contatos criados com lid, cliente com fluxo atual de 40 mil a 50 mil msgs por dia.

A solução que empreguei é bem mais simples e totalmente funcional.

Nos meus teste, o script foi capaz:
1. Criar contatos `@lid` com `@s.whatsapp.net` corretamente.
1. Atualizar contatos já criados com `@lid` e atualizar o identificador para o número correto `@s.whatsapp.net` .
2. Retomar conversas anteriormente já criadas.

### Diferenças:
O evento é diferente que eventos de participantes de grupo:

Grupo:
```key: {
    remoteJid: '142902286143727@lid',
    fromMe: false,
    id: '#',
    senderLid: '142902286143727@lid',
    senderPn: undefined,
    participant: 55########6898@s.whatsapp.net,
    participantLid: undefined
  },
```

lid:
```key: {
    remoteJid: '#############@g.us',
    fromMe: false,
    id: '######',
    senderLid: undefined,
    senderPn: '55#######6898@s.whatsapp.net',
    participant: undefined,
    participantLid: undefined
  },
```

## Summary by Sourcery

Refactor Chatwoot integration to streamline contact lookup and creation by unifying method signatures, removing redundant lid-specific branches, and improving detection and updating of @lid contact identifiers during conversations.

Enhancements:
- Streamline findContact and createContact methods to accept a phone number string and drop the isLid flag
- Consolidate contact identifier logic to uniformly handle single and group chats
- Remove normalizeContactIdentifier helper and update createConversation to detect and refresh @lid contacts via senderPn
- Adjust remoteJid resolution in createConversation for lid events and ensure existing contacts are updated
- Introduce a triple-check on cache before creating new conversations to prevent race conditions
- Update Baileys startup service to use the simplified findContact signature