### PR TITLE
🐛 fix: Phone number as message ID for Evo AI #ISSUE 28

### DIFF
--- a/src/api/integrations/chatbot/evoai/services/evoai.service.ts
+++ b/src/api/integrations/chatbot/evoai/services/evoai.service.ts
@@ -70,7 +70,7 @@ export class EvoaiService extends BaseChatbotService<Evoai, EvoaiSetting> {
       }
 
       const callId = `req-${uuidv4().substring(0, 8)}`;
-      const messageId = msg?.key?.id || uuidv4();
+      const messageId = remoteJid.split('@')[0] || uuidv4(); // Use phone number as messageId
 
       // Prepare message parts
       const parts = [


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Use the phone number extracted from remoteJid as the messageId instead of relying on msg.key.id or a generated UUID