### PR TITLE
fix/references-instanceName-typebot

### DIFF
--- a/src/api/integrations/chatbot/typebot/controllers/typebot.controller.ts
+++ b/src/api/integrations/chatbot/typebot/controllers/typebot.controller.ts
@@ -119,7 +119,7 @@ export class TypebotController extends BaseChatbotController<TypebotModel, Typeb
 
     const instanceData = await this.prismaRepository.instance.findFirst({
       where: {
-        id: instance.instanceName,
+        name: instance.instanceName,
       },
     });
 

--- a/src/api/integrations/chatbot/typebot/controllers/typebot.controller.ts
+++ b/src/api/integrations/chatbot/typebot/controllers/typebot.controller.ts
@@ -119,7 +119,7 @@ export class TypebotController extends BaseChatbotController<TypebotModel, Typeb
 
     const instanceData = await this.prismaRepository.instance.findFirst({
       where: {
-        id: instance.instanceId,
+        id: instance.instanceName,
       },
     });
 


### PR DESCRIPTION
Complementa o PR #1652 corrigindo as referencias de envio a instancia correta do processo do typebot.

## Summary by Sourcery

Bug Fixes:
- Query the Typebot instance by name rather than ID to ensure correct instance reference