### PR TITLE
fix(whatsapp-baileys): Verifica eventos com falhas e fallback para erro ao baixar mídias

### DIFF
--- a/src/api/integrations/channel/whatsapp/whatsapp.baileys.service.ts
+++ b/src/api/integrations/channel/whatsapp/whatsapp.baileys.service.ts
@@ -3253,8 +3253,8 @@ export class BaileysStartupService extends ChannelStartupService {
             typeof numberVerified?.lid === 'string'
               ? numberVerified.lid
               : numberJid.includes('@lid')
-              ? numberJid.split('@')[1]
-              : undefined;
+                ? numberJid.split('@')[1]
+                : undefined;
           return new OnWhatsAppDto(
             numberJid,
             !!numberVerified?.exists,
@@ -3452,7 +3452,7 @@ export class BaileysStartupService extends ChannelStartupService {
     return map[mediaType] || null;
   }
 
-    public async getBase64FromMediaMessage(data: getBase64FromMediaMessageDto, getBuffer = false) {
+  public async getBase64FromMediaMessage(data: getBase64FromMediaMessageDto, getBuffer = false) {
     try {
       const m = data?.message;
       const convertToMp4 = data?.convertToMp4 ?? false;


### PR DESCRIPTION
## Descrição
1. Em alguns momentos raros, temos os erros 400 e 403 ao receber eventos da Baileys. Esses erros são por diversos motivos como token invalido de descriptografia, sessão expirada, etc.
2. Outros momentos também raros ao tentar baixar uma mídia utilizando `getBase64FromMediaMessage` recebemos um erro de download.
3. A implementação anterior de evitar os eventos `message.upsert` foi super positiva, mas nos momentos em que recebo os erros 400 e 403 com a descrição de No matching sessions found for message, Bad MAC, failed to decrypt message ou SessionError, impede o re-processamento de do evento no retry da Baileys. Isso causa em certas situações o impedimento do processamento das primeiras mensagens até que a sessão e tokens de descriptografia estejam validos.

## Solução
1. Implementado a verificação de erros conhecidos provenientes dos erros 400 e 403 da Baileys antes do restante do bloco de processamento `try` dos eventos `message.upsert`.
2. Implementação de fallback com o método da Baileys `downloadContentFromMessage` após erro ao tentar baixar com o método `getBase64FromMediaMessage`. (Por algum motivo `downloadContentFromMessage` funciona melhor.)
3. Com a primeira implementação se corrigiu este problema.

## Summary by Sourcery

Handle transient Baileys decryption errors by filtering specific message stub parameters before processing and improve media download reliability with a retry fallback using downloadContentFromMessage.

Enhancements:
- Skip processing and log warnings for message.upsert events containing known decryption or session errors (e.g., Bad MAC, No matching sessions found, SessionError).
- Implement a fallback strategy for media downloads by retrying after a delay and using Baileys' downloadContentFromMessage when downloadMediaMessage fails.
- Add a mapMediaType helper to translate message types for the downloadContentFromMessage fallback.