### PR TITLE
(mysql): remove out-of-order wavoipToken migration

### DIFF
--- a/prisma/mysql-migrations/1707735894523_add_wavoip_token_to_settings_table/migration.sql
+++ b/prisma/mysql-migrations/1707735894523_add_wavoip_token_to_settings_table/migration.sql
@@ -1,9 +1,0 @@
-/*
-  Warnings:
-
-  - A unique constraint covering the columns `[remoteJid,instanceId]` on the table `Chat` will be added. If there are existing duplicate values, this will fail.
-*/
-
--- AlterTable
-ALTER TABLE `Setting`
-  ADD COLUMN IF NOT EXISTS `wavoipToken` VARCHAR(100);


### PR DESCRIPTION
Delete prisma/mysql-migrations/1707735894523_add_wavoip_token_to_settings_table, which executes before the initial Setting table is created and breaks fresh MySQL installs.

The later migration 20250214181954_add_wavoip_token_column, line 145, already adds the column correctly, so keeping only that directory guarantees a clean deploy.