### PR TITLE
Fix problems when try build new images docker

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -29,7 +29,7 @@ DEL_INSTANCE=false
 
 # Provider: postgresql | mysql
 DATABASE_PROVIDER=postgresql
-DATABASE_CONNECTION_URI='postgresql://user:pass@postgres:5432/evolution?schema=public'
+DATABASE_CONNECTION_URI='postgresql://user:pass@api_db:5432/evolution?schema=public'
 # Client name for the database connection
 # It is used to separate an API installation from another that uses the same database.
 DATABASE_CONNECTION_CLIENT_NAME=evolution_exchange
@@ -235,7 +235,7 @@ EVOAI_ENABLED=false
 # Cache - Environment variables
 # Redis Cache enabled
 CACHE_REDIS_ENABLED=true
-CACHE_REDIS_URI=redis://localhost:6379/6
+CACHE_REDIS_URI=redis://api_redis:6379/6
 CACHE_REDIS_TTL=604800
 # Prefix serves to differentiate data from one installation to another that are using the same redis
 CACHE_REDIS_PREFIX_KEY=evolution

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ COPY ./package*.json ./
 COPY ./tsconfig.json ./
 COPY ./tsup.config.ts ./
 
-RUN npm ci --silent
+RUN npm install
 
 COPY ./src ./src
 COPY ./public ./public

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ COPY ./package*.json ./
 COPY ./tsconfig.json ./
 COPY ./tsup.config.ts ./
 
-RUN npm install
+RUN npm ci --silent
 
 COPY ./src ./src
 COPY ./public ./public

--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -1,6 +1,6 @@
 services:
   api:
-    container_name: api
+    container_name: evolution_api
     image: evolution/api:local
     build: .
     ports:

--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -3,6 +3,7 @@ services:
     container_name: evolution_api
     image: evolution/api:local
     build: .
+    restart: always
     ports:
       - 8080:8080
     volumes:

--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -1,13 +1,12 @@
 services:
   api:
-    container_name: evolution_api
+    container_name: api
     image: evolution/api:local
     build: .
-    restart: always
     ports:
       - 8080:8080
     volumes:
-      - evolution_instances:/evolution/instances
+      - instances:/evolution/instances
     networks:
       - evolution-net
     env_file:
@@ -15,8 +14,31 @@ services:
     expose:
       - 8080
 
+  api_db:
+    image: postgres:16
+    environment:
+      - POSTGRES_USER=user
+      - POSTGRES_PASSWORD=pass
+      - POSTGRES_DB=evolution
+    networks:
+      - evolution-net
+    volumes:
+      - api_db:/var/lib/postgresql/data
+
+
+  api_redis:
+    image: redis:7.2.5-alpine
+    networks:
+      - evolution-net
+    command: redis-server --port 6379 --appendonly yes
+    volumes:
+      - api_redis:/data      
+ 
+
 volumes:
-  evolution_instances:
+  instances:
+  api_redis:
+  api_db:
 
 
 networks:

--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -29,6 +29,7 @@ services:
 
   api_redis:
     image: redis:7.2.5-alpine
+    restart: unless-stopped
     networks:
       - evolution-net
     command: redis-server --port 6379 --appendonly yes

--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -6,7 +6,7 @@ services:
     ports:
       - 8080:8080
     volumes:
-      - instances:/evolution/instances
+      - evolution_instances:/evolution/instances
     networks:
       - evolution-net
     env_file:
@@ -36,7 +36,7 @@ services:
  
 
 volumes:
-  instances:
+  evolution_instances:
   api_redis:
   api_db:
 


### PR DESCRIPTION
Is missing the redis and postgres services on docker-compose.dev.yaml file, I add the services to compose files and set the right hostnames to the .env file.

## Summary by Sourcery

Add missing Redis and Postgres services to the development Docker Compose setup and align their hostnames in the environment configuration

Bug Fixes:
- Include api_db (Postgres) and api_redis (Redis) services and corresponding volumes in docker-compose.dev.yaml

Enhancements:
- Update .env example with the correct hostnames for Redis and Postgres services