### PR TITLE
fix: correçao do typebot não conseguir ouvir mensagens de input

### DIFF
--- a/src/api/integrations/chatbot/typebot/services/typebot.service.ts
+++ b/src/api/integrations/chatbot/typebot/services/typebot.service.ts
@@ -186,7 +186,7 @@ export class TypebotService extends BaseChatbotService<TypebotModel, any> {
       messages,
       input,
       clientSideActions,
-      this.applyFormatting,
+      this.applyFormatting.bind(this),
       this.prismaRepository,
     ).catch((err) => {
       console.error('Erro ao processar mensagens:', err);


### PR DESCRIPTION
Esse PR corrige o erro Cannot read properties of undefined (reading 'applyFormatting') que ocorre quando o Typebot envia mensagens que o usuário precisa inserir uma resposta.

![image](https://github.com/user-attachments/assets/bec221a6-5a7c-4ab7-a6df-67d9d8039e3a)
