### PR TITLE
added missing migrations in mysql prisma

### DIFF
--- a/prisma/mysql-migrations/20250225180031_add_nats_integration/migration.sql
+++ b/prisma/mysql-migrations/20250225180031_add_nats_integration/migration.sql
@@ -1,0 +1,17 @@
+-- CreateTable
+CREATE TABLE `Nats` (
+    `id` VARCHAR(191) NOT NULL,
+    `enabled` BOOLEAN NOT NULL DEFAULT false,
+    `events` JSON NOT NULL,
+    `createdAt` TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    `updatedAt` TIMESTAMP NOT NULL,
+    `instanceId` VARCHAR(191) NOT NULL,
+
+    PRIMARY KEY (`id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+-- CreateIndex
+CREATE UNIQUE INDEX `Nats_instanceId_key` ON `Nats`(`instanceId`);
+
+-- AddForeignKey
+ALTER TABLE `Nats` ADD CONSTRAINT `Nats_instanceId_fkey` FOREIGN KEY (`instanceId`) REFERENCES `Instance`(`id`) ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/mysql-migrations/20250514232744_add_n8n_table/migration.sql
+++ b/prisma/mysql-migrations/20250514232744_add_n8n_table/migration.sql
@@ -1,0 +1,62 @@
+-- CreateTable
+CREATE TABLE `N8n` (
+    `id` VARCHAR(191) NOT NULL,
+    `enabled` BOOLEAN NOT NULL DEFAULT true,
+    `description` VARCHAR(255),
+    `webhookUrl` VARCHAR(255),
+    `basicAuthUser` VARCHAR(255),
+    `basicAuthPass` VARCHAR(255),
+    `expire` INTEGER DEFAULT 0,
+    `keywordFinish` VARCHAR(100),
+    `delayMessage` INTEGER,
+    `unknownMessage` VARCHAR(100),
+    `listeningFromMe` BOOLEAN DEFAULT false,
+    `stopBotFromMe` BOOLEAN DEFAULT false,
+    `keepOpen` BOOLEAN DEFAULT false,
+    `debounceTime` INTEGER,
+    `ignoreJids` JSON,
+    `splitMessages` BOOLEAN DEFAULT false,
+    `timePerChar` INTEGER DEFAULT 50,
+    `triggerType` ENUM('all', 'keyword', 'none') NULL,
+    `triggerOperator` ENUM('contains', 'equals', 'startsWith', 'endsWith', 'regex') NULL,
+    `triggerValue` VARCHAR(191) NULL,
+    `createdAt` TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    `updatedAt` TIMESTAMP NOT NULL,
+    `instanceId` VARCHAR(191) NOT NULL,
+
+    PRIMARY KEY (`id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+-- CreateTable
+CREATE TABLE `N8nSetting` (
+    `id` VARCHAR(191) NOT NULL,
+    `expire` INTEGER DEFAULT 0,
+    `keywordFinish` VARCHAR(100),
+    `delayMessage` INTEGER,
+    `unknownMessage` VARCHAR(100),
+    `listeningFromMe` BOOLEAN DEFAULT false,
+    `stopBotFromMe` BOOLEAN DEFAULT false,
+    `keepOpen` BOOLEAN DEFAULT false,
+    `debounceTime` INTEGER,
+    `ignoreJids` JSON,
+    `splitMessages` BOOLEAN DEFAULT false,
+    `timePerChar` INTEGER DEFAULT 50,
+    `createdAt` TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    `updatedAt` TIMESTAMP NOT NULL,
+    `n8nIdFallback` VARCHAR(100),
+    `instanceId` VARCHAR(191) NOT NULL,
+
+    PRIMARY KEY (`id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+-- CreateIndex
+CREATE UNIQUE INDEX `N8nSetting_instanceId_key` ON `N8nSetting`(`instanceId`);
+
+-- AddForeignKey
+ALTER TABLE `N8n` ADD CONSTRAINT `N8n_instanceId_fkey` FOREIGN KEY (`instanceId`) REFERENCES `Instance`(`id`) ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE `N8nSetting` ADD CONSTRAINT `N8nSetting_n8nIdFallback_fkey` FOREIGN KEY (`n8nIdFallback`) REFERENCES `N8n`(`id`) ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE `N8nSetting` ADD CONSTRAINT `N8nSetting_instanceId_fkey` FOREIGN KEY (`instanceId`) REFERENCES `Instance`(`id`) ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/mysql-migrations/20250515211815_add_evoai_table/migration.sql
+++ b/prisma/mysql-migrations/20250515211815_add_evoai_table/migration.sql
@@ -1,0 +1,61 @@
+-- CreateTable
+CREATE TABLE `Evoai` (
+    `id` VARCHAR(191) NOT NULL,
+    `enabled` BOOLEAN NOT NULL DEFAULT true,
+    `description` VARCHAR(255),
+    `agentUrl` VARCHAR(255),
+    `apiKey` VARCHAR(255),
+    `expire` INTEGER DEFAULT 0,
+    `keywordFinish` VARCHAR(100),
+    `delayMessage` INTEGER,
+    `unknownMessage` VARCHAR(100),
+    `listeningFromMe` BOOLEAN DEFAULT false,
+    `stopBotFromMe` BOOLEAN DEFAULT false,
+    `keepOpen` BOOLEAN DEFAULT false,
+    `debounceTime` INTEGER,
+    `ignoreJids` JSON,
+    `splitMessages` BOOLEAN DEFAULT false,
+    `timePerChar` INTEGER DEFAULT 50,
+    `triggerType` ENUM('all', 'keyword', 'none') NULL,
+    `triggerOperator` ENUM('contains', 'equals', 'startsWith', 'endsWith', 'regex') NULL,
+    `triggerValue` VARCHAR(191) NULL,
+    `createdAt` TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    `updatedAt` TIMESTAMP NOT NULL,
+    `instanceId` VARCHAR(191) NOT NULL,
+
+    PRIMARY KEY (`id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+-- CreateTable
+CREATE TABLE `EvoaiSetting` (
+    `id` VARCHAR(191) NOT NULL,
+    `expire` INTEGER DEFAULT 0,
+    `keywordFinish` VARCHAR(100),
+    `delayMessage` INTEGER,
+    `unknownMessage` VARCHAR(100),
+    `listeningFromMe` BOOLEAN DEFAULT false,
+    `stopBotFromMe` BOOLEAN DEFAULT false,
+    `keepOpen` BOOLEAN DEFAULT false,
+    `debounceTime` INTEGER,
+    `ignoreJids` JSON,
+    `splitMessages` BOOLEAN DEFAULT false,
+    `timePerChar` INTEGER DEFAULT 50,
+    `createdAt` TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    `updatedAt` TIMESTAMP NOT NULL,
+    `evoaiIdFallback` VARCHAR(100),
+    `instanceId` VARCHAR(191) NOT NULL,
+
+    PRIMARY KEY (`id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+-- CreateIndex
+CREATE UNIQUE INDEX `EvoaiSetting_instanceId_key` ON `EvoaiSetting`(`instanceId`);
+
+-- AddForeignKey
+ALTER TABLE `Evoai` ADD CONSTRAINT `Evoai_instanceId_fkey` FOREIGN KEY (`instanceId`) REFERENCES `Instance`(`id`) ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE `EvoaiSetting` ADD CONSTRAINT `EvoaiSetting_evoaiIdFallback_fkey` FOREIGN KEY (`evoaiIdFallback`) REFERENCES `Evoai`(`id`) ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE `EvoaiSetting` ADD CONSTRAINT `EvoaiSetting_instanceId_fkey` FOREIGN KEY (`instanceId`) REFERENCES `Instance`(`id`) ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/mysql-migrations/20250516012152_remove_unique_atribute_for_file_name_in_media/migration.sql
+++ b/prisma/mysql-migrations/20250516012152_remove_unique_atribute_for_file_name_in_media/migration.sql
@@ -1,0 +1,2 @@
+-- DropIndex
+ALTER TABLE `Media` DROP INDEX `Media_fileName_key`;

--- a/prisma/mysql-migrations/20250612155048_add_coluns_trypebot_tables/migration.sql
+++ b/prisma/mysql-migrations/20250612155048_add_coluns_trypebot_tables/migration.sql
@@ -1,0 +1,7 @@
+-- AlterTable
+ALTER TABLE `Typebot` ADD COLUMN     `splitMessages` BOOLEAN DEFAULT false,
+ADD COLUMN     `timePerChar` INTEGER DEFAULT 50;
+
+-- AlterTable
+ALTER TABLE `TypebotSetting` ADD COLUMN     `splitMessages` BOOLEAN DEFAULT false,
+ADD COLUMN     `timePerChar` INTEGER DEFAULT 50;

--- a/prisma/mysql-migrations/20250613143000_add_lid_column_to_is_onwhatsapp/migration.sql
+++ b/prisma/mysql-migrations/20250613143000_add_lid_column_to_is_onwhatsapp/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE `IsOnWhatsapp` ADD COLUMN     `lid` VARCHAR(100);


### PR DESCRIPTION
## Summary by Sourcery

Add missing Prisma MySQL migrations for new integrations (N8n, Evoai, and Nats), extend the Typebot schema, and adjust Media and IsOnWhatsapp tables

New Features:
- Create N8n and N8nSetting tables with indexes and foreign keys
- Create Evoai and EvoaiSetting tables with indexes and foreign keys
- Create Nats table with events JSON, unique index, and foreign key

Enhancements:
- Add splitMessages and timePerChar columns to Typebot and TypebotSetting tables

Chores:
- Drop unique index on Media.fileName
- Add lid column to IsOnWhatsapp table