### PR TITLE
2jji28 codex/corrigir integração com typebot

### DIFF
--- a/src/api/integrations/chatbot/typebot/services/typebot.service.ts
+++ b/src/api/integrations/chatbot/typebot/services/typebot.service.ts
@@ -189,7 +189,7 @@ export class TypebotService extends BaseChatbotService<TypebotModel, any> {
       messages,
       input,
       clientSideActions,
-      this.applyFormatting,
+      this.applyFormatting.bind(this),
       this.prismaRepository,
     ).catch((err) => {
       console.error('Erro ao processar mensagens:', err);

--- a/src/utils/getConversationMessage.ts
+++ b/src/utils/getConversationMessage.ts
@@ -1,6 +1,6 @@
 import { configService, S3 } from '@config/env.config';
 
-const getTypeMessage = (msg: any) => {
+export const getTypeMessage = (msg: any) => {
   let mediaId: string;
 
   if (configService.get<S3>('S3').ENABLE) mediaId = msg.message?.mediaUrl;


### PR DESCRIPTION
## Summary by Sourcery

Fix Typebot integration by propagating messageType in all session and message requests, ensuring correct context binding for formatting, and exporting the message type utility

Enhancements:
- Include messageType in prefilledVariables and in all payloads for session creation, continuation, and message sending to Typebot
- Bind the applyFormatting method to its class instance when used as a callback
- Export the getTypeMessage utility function for external use in determining message types