### PR TITLE
Fix: Support media extraction from templateMessage in getBase64FromMediaMessage

### DIFF
--- a/src/api/integrations/channel/whatsapp/whatsapp.baileys.service.ts
+++ b/src/api/integrations/channel/whatsapp/whatsapp.baileys.service.ts
@@ -3437,16 +3437,34 @@ export class BaileysStartupService extends ChannelStartupService {
       let mediaMessage: any;
       let mediaType: string;
 
-      for (const type of TypeMediaMessage) {
-        mediaMessage = msg.message[type];
-        if (mediaMessage) {
-          mediaType = type;
-          break;
-        }
-      }
+      if (msg.message?.templateMessage) {
+        const template =
+          msg.message.templateMessage.hydratedTemplate || msg.message.templateMessage.hydratedFourRowTemplate;
 
-      if (!mediaMessage) {
-        throw 'The message is not of the media type';
+        for (const type of TypeMediaMessage) {
+          if (template[type]) {
+            mediaMessage = template[type];
+            mediaType = type;
+            msg.message = { [type]: { ...template[type], url: template[type].staticUrl } };
+            break;
+          }
+        }
+
+        if (!mediaMessage) {
+          throw 'Template message does not contain a supported media type';
+        }
+      } else {
+        for (const type of TypeMediaMessage) {
+          mediaMessage = msg.message[type];
+          if (mediaMessage) {
+            mediaType = type;
+            break;
+          }
+        }
+
+        if (!mediaMessage) {
+          throw 'The message is not of the media type';
+        }
       }
 
       if (typeof mediaMessage['mediaKey'] === 'object') {


### PR DESCRIPTION
### Fix: Add support for templateMessage media in getBase64FromMediaMessage

#### What this does
Adds support to download media from `templateMessage` structures in `getBase64FromMediaMessage`, by checking for `hydratedTemplate` and `hydratedFourRowTemplate`.

#### Why it's needed
Currently, media inside templates (e.g. `imageMessage`, `videoMessage`, `documentMessage`) is not processed by the method, which leads to errors or media being skipped.

#### How it works
If a `templateMessage` is detected, the code looks into the inner hydrated template and assigns the correct `mediaMessage` and `mediaType`. Then it proceeds as usual with the download logic.

#### Example message
```json
{
  "message": {
    "templateMessage": {
      "hydratedTemplate": {
        "imageMessage": {
          "mimetype": "image/jpeg",
          "fileLength": 123456,
          "url": "https://..."
        }
      }
    }
  }
}

## Summary by Sourcery

Support media extraction from templateMessage structures in getBase64FromMediaMessage

Bug Fixes:
- Process media inside hydratedTemplate and hydratedFourRowTemplate to correctly retrieve mediaMessage and mediaType from templateMessage

Enhancements:
- Throw an explicit error when a templateMessage lacks a supported media type