### PR TITLE
chage redis host

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -235,7 +235,7 @@ EVOAI_ENABLED=false
 # Cache - Environment variables
 # Redis Cache enabled
 CACHE_REDIS_ENABLED=true
-CACHE_REDIS_URI=redis://localhost:6379/6
+CACHE_REDIS_URI=redis://redis:6379/6
 CACHE_REDIS_TTL=604800
 # Prefix serves to differentiate data from one installation to another that are using the same redis
 CACHE_REDIS_PREFIX_KEY=evolution


### PR DESCRIPTION
I added the correct working redis path in docker compose.

## Summary by Sourcery

Fix the Redis connection by pointing Docker Compose and the example environment file to the correct Redis host

Enhancements:
- Correct the Redis host path used in Docker Compose

Deployment:
- Update Docker Compose to point to the proper Redis host

Documentation:
- Sync .env.example with the updated Redis host configuration