### PR TITLE
feat: add BaileysMessageProcessor for improved message handling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -55,6 +55,7 @@
         "qrcode": "^1.5.4",
         "qrcode-terminal": "^0.12.0",
         "redis": "^4.7.0",
+        "rxjs": "^7.8.2",
         "sharp": "^0.32.6",
         "socket.io": "^4.8.1",
         "socket.io-client": "^4.8.1",
@@ -10370,6 +10371,15 @@
       ],
       "dependencies": {
         "queue-microtask": "^1.2.2"
+      }
+    },
+    "node_modules/rxjs": {
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
+      "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.1.0"
       }
     },
     "node_modules/safe-array-concat": {

--- a/package.json
+++ b/package.json
@@ -95,6 +95,7 @@
     "qrcode": "^1.5.4",
     "qrcode-terminal": "^0.12.0",
     "redis": "^4.7.0",
+    "rxjs": "^7.8.2",
     "sharp": "^0.32.6",
     "socket.io": "^4.8.1",
     "socket.io-client": "^4.8.1",

--- a/src/api/integrations/channel/whatsapp/baileysMessage.processor.ts
+++ b/src/api/integrations/channel/whatsapp/baileysMessage.processor.ts
@@ -1,0 +1,51 @@
+import { Logger } from '@config/logger.config';
+import { BaileysEventMap, MessageUpsertType, proto } from 'baileys';
+import { catchError, concatMap, EMPTY, from, Subject, Subscription, tap } from 'rxjs';
+
+type MessageUpsertPayload = BaileysEventMap['messages.upsert'];
+type MountProps = {
+  onMessageReceive: (payload: MessageUpsertPayload, settings: any) => Promise<void>;
+};
+
+export class BaileysMessageProcessor {
+  private processorLogs = new Logger('BaileysMessageProcessor');
+  private subscription?: Subscription;
+
+  protected messageSubject = new Subject<{
+    messages: proto.IWebMessageInfo[];
+    type: MessageUpsertType;
+    requestId?: string;
+    settings: any;
+  }>();
+
+  mount({ onMessageReceive }: MountProps) {
+    this.subscription = this.messageSubject
+      .pipe(
+        tap(({ messages }) => {
+          this.processorLogs.log(`Processing batch of ${messages.length} messages`);
+        }),
+        concatMap(({ messages, type, requestId, settings }) =>
+          from(onMessageReceive({ messages, type, requestId }, settings)),
+        ),
+        catchError((error) => {
+          this.processorLogs.error(`Error processing message batch: ${error}`);
+          return EMPTY;
+        }),
+      )
+      .subscribe({
+        error: (error) => {
+          this.processorLogs.error(`Message stream error: ${error}`);
+        },
+      });
+  }
+
+  processMessage(payload: MessageUpsertPayload, settings: any) {
+    const { messages, type, requestId } = payload;
+    this.messageSubject.next({ messages, type, requestId, settings });
+  }
+
+  onDestroy() {
+    this.subscription?.unsubscribe();
+    this.messageSubject.complete();
+  }
+}

--- a/src/api/integrations/channel/whatsapp/whatsapp.baileys.service.ts
+++ b/src/api/integrations/channel/whatsapp/whatsapp.baileys.service.ts
@@ -147,6 +147,7 @@ import sharp from 'sharp';
 import { PassThrough, Readable } from 'stream';
 import { v4 } from 'uuid';
 
+import { BaileysMessageProcessor } from './baileysMessage.processor';
 import { useVoiceCallsBaileys } from './voiceCalls/useVoiceCallsBaileys';
 
 const groupMetadataCache = new CacheService(new CacheEngine(configService, 'groups').getEngine());
@@ -212,6 +213,8 @@ async function getVideoDuration(input: Buffer | string | Readable): Promise<numb
 }
 
 export class BaileysStartupService extends ChannelStartupService {
+  private messageProcessor = new BaileysMessageProcessor();
+
   constructor(
     public readonly configService: ConfigService,
     public readonly eventEmitter: EventEmitter2,
@@ -223,6 +226,9 @@ export class BaileysStartupService extends ChannelStartupService {
   ) {
     super(configService, eventEmitter, prismaRepository, chatwootCache);
     this.instance.qrcode = { count: 0 };
+    this.messageProcessor.mount({
+      onMessageReceive: this.messageHandle['messages.upsert'].bind(this), // Bind the method to the current context
+    });
 
     this.authStateProvider = new AuthStateProvider(this.providerFiles);
   }
@@ -242,6 +248,7 @@ export class BaileysStartupService extends ChannelStartupService {
   }
 
   public async logoutInstance() {
+    this.messageProcessor.onDestroy();
     await this.client?.logout('Log out instance: ' + this.instanceName);
 
     this.client?.ws?.close();
@@ -1618,7 +1625,9 @@ export class BaileysStartupService extends ChannelStartupService {
 
         if (events['messages.upsert']) {
           const payload = events['messages.upsert'];
-          this.messageHandle['messages.upsert'](payload, settings);
+
+          this.messageProcessor.processMessage(payload, settings);
+          // this.messageHandle['messages.upsert'](payload, settings);
         }
 
         if (events['messages.update']) {


### PR DESCRIPTION

#### PT
Essa implementação adiciona uma fila reativa para o processamento de mensagens recebidas pelo Baileys, utilizando RxJS. O objetivo é garantir que os lotes de mensagens sejam processados de forma sequencial, evitando concorrência e race conditions que poderiam ocorrer em fluxos com alto volume.

Com o uso do `Subject` em conjunto com `concatMap`, garantimos que uma nova mensagem só será processada após a conclusão da anterior. Isso é especialmente importante em cenários onde o `onMessageReceive` realiza operações assíncronas que não devem ocorrer em paralelo (ex: gravação em banco, chamadas de API, etc).

Além disso, o tratamento de erros impede que falhas isoladas interrompam o fluxo completo de mensagens.

Essa abordagem torna o processamento mais previsível, seguro e resiliente, principalmente sob carga.

### ENHere’s the English version for the PR:

---

This implementation introduces a reactive queue for processing incoming Baileys messages using RxJS. The goal is to ensure that message batches are processed sequentially, avoiding concurrency issues and race conditions that could occur under high message volume.

By leveraging a `Subject` combined with `concatMap`, we ensure that each batch is only processed after the previous one completes. This is critical in scenarios where `onMessageReceive` performs asynchronous operations that must not run in parallel (e.g., database writes, external API calls).

Error handling is also included to prevent a single failure from breaking the entire message stream.

Overall, this approach improves the reliability, safety, and predictability of message processing, especially under heavy load.


## Summary by Sourcery

Introduce BaileysMessageProcessor leveraging RxJS to asynchronously batch and process incoming WhatsApp messages, integrate it into BaileysStartupService for message handling and cleanup

New Features:
- Introduce BaileysMessageProcessor class to asynchronously process incoming WhatsApp messages using RxJS streams
- Mount BaileysMessageProcessor in BaileysStartupService to handle messages and teardown on logout

Enhancements:
- Refactor message upsert handling in BaileysStartupService to route through the new processor instead of direct invocation

Build:
- Add rxjs as a dependency in package.json