### PR TITLE
Update Jimp and sharp dependencies for Baileys new version

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "qrcode": "^1.5.4",
     "qrcode-terminal": "^0.12.0",
     "redis": "^4.7.0",
-    "sharp": "^0.32.6",
+    "sharp": "^0.34.2",
     "socket.io": "^4.8.1",
     "socket.io-client": "^4.8.1",
     "tsup": "^8.3.5"

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "form-data": "^4.0.1",
     "https-proxy-agent": "^7.0.6",
     "i18next": "^23.7.19",
-    "jimp": "^0.16.13",
+    "jimp": "^1.6.0",
     "json-schema": "^0.4.0",
     "jsonschema": "^1.4.1",
     "jsonwebtoken": "^9.0.2",

--- a/src/api/integrations/chatbot/chatwoot/services/chatwoot.service.ts
+++ b/src/api/integrations/chatbot/chatwoot/services/chatwoot.service.ts
@@ -26,7 +26,7 @@ import axios from 'axios';
 import { proto } from 'baileys';
 import dayjs from 'dayjs';
 import FormData from 'form-data';
-import { Jimp } from 'jimp';
+import { Jimp, JimpMime } from 'jimp';
 import Long from 'long';
 import mimeTypes from 'mime-types';
 import path from 'path';
@@ -2103,8 +2103,7 @@ export class ChatwootService {
           const img = await Jimp.read(fileData);
           await img.cover(320, 180);
 
-          const mime = img.getMIME();          
-          const processedBuffer = await img.getBufferAsync(mime);
+          const processedBuffer = await img.getBuffer(JimpMime.png);
 
           const fileStream = new Readable();
           fileStream._read = () => {}; // _read is required but you can noop it

--- a/src/api/integrations/chatbot/chatwoot/services/chatwoot.service.ts
+++ b/src/api/integrations/chatbot/chatwoot/services/chatwoot.service.ts
@@ -26,7 +26,7 @@ import axios from 'axios';
 import { proto } from 'baileys';
 import dayjs from 'dayjs';
 import FormData from 'form-data';
-import Jimp, { MIME_PNG } from 'jimp';
+import { Jimp } from 'jimp';
 import Long from 'long';
 import mimeTypes from 'mime-types';
 import path from 'path';
@@ -2103,7 +2103,8 @@ export class ChatwootService {
           const img = await Jimp.read(fileData);
           await img.cover(320, 180);
 
-          const processedBuffer = await img.getBufferAsync(MIME_PNG);
+          const mime = img.getMIME();          
+          const processedBuffer = await img.getBufferAsync(mime);
 
           const fileStream = new Readable();
           fileStream._read = () => {}; // _read is required but you can noop it

--- a/src/api/integrations/chatbot/chatwoot/services/chatwoot.service.ts
+++ b/src/api/integrations/chatbot/chatwoot/services/chatwoot.service.ts
@@ -26,7 +26,7 @@ import axios from 'axios';
 import { proto } from 'baileys';
 import dayjs from 'dayjs';
 import FormData from 'form-data';
-import Jimp from 'jimp';
+import Jimp, { MIME_PNG } from 'jimp';
 import Long from 'long';
 import mimeTypes from 'mime-types';
 import path from 'path';
@@ -2103,7 +2103,7 @@ export class ChatwootService {
           const img = await Jimp.read(fileData);
           await img.cover(320, 180);
 
-          const processedBuffer = await img.getBufferAsync(Jimp.MIME_PNG);
+          const processedBuffer = await img.getBufferAsync(MIME_PNG);
 
           const fileStream = new Readable();
           fileStream._read = () => {}; // _read is required but you can noop it

--- a/src/api/integrations/chatbot/chatwoot/services/chatwoot.service.ts
+++ b/src/api/integrations/chatbot/chatwoot/services/chatwoot.service.ts
@@ -2101,7 +2101,7 @@ export class ChatwootService {
           const fileData = Buffer.from(imgBuffer.data, 'binary');
 
           const img = await Jimp.read(fileData);
-          await img.cover(320, 180);
+          img.cover({ w: 320, h: 180 });
 
           const processedBuffer = await img.getBuffer(JimpMime.png);
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,6 +11,7 @@
     "outDir": "./dist",
     "noEmitOnError": true,
     "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
     "forceConsistentCasingInFileNames": true,
     "strict": false,
     "skipLibCheck": true,


### PR DESCRIPTION
I have solved an incompatibility between sharp, jimp & Baileys, and had to change some methods in chatwoot ts

## Summary by Sourcery

Upgrade image processing libraries and adjust code and TypeScript config to resolve incompatibilities between Jimp, Sharp, and Baileys

Enhancements:
- Upgrade Jimp to 1.6.0 and Sharp to 0.34.2 to address compatibility with Baileys
- Refactor image processing to use Jimp's new cover signature and getBuffer method

Build:
- Enable allowSyntheticDefaultImports in tsconfig for improved module interoperability