### PR TITLE
Fix: [Chatwoot] Corrige mensagens editas

### DIFF
--- a/src/api/integrations/channel/whatsapp/whatsapp.baileys.service.ts
+++ b/src/api/integrations/channel/whatsapp/whatsapp.baileys.service.ts
@@ -1078,7 +1078,7 @@ export class BaileysStartupService extends ChannelStartupService {
           const editedMessage =
             received?.message?.protocolMessage || received?.message?.editedMessage?.message?.protocolMessage;
 
-          if (received.message?.protocolMessage?.editedMessage && editedMessage) {
+          if (editedMessage) {
             if (this.configService.get<Chatwoot>('CHATWOOT').ENABLED && this.localChatwoot?.enabled)
               this.chatwootService.eventWhatsapp(
                 'messages.edit',
@@ -1126,7 +1126,7 @@ export class BaileysStartupService extends ChannelStartupService {
 
           if (
             (type !== 'notify' && type !== 'append') ||
-            received.message?.protocolMessage ||
+            editedMessage ||
             received.message?.pollUpdateMessage ||
             !received?.message
           ) {


### PR DESCRIPTION
## Descrição
Em algumas versões do Whats instaladas em alguns dispositivos trazem um formato de estrutura diferente de msgs editadas. Isso já tinha sido mapeado anteriormente, mas a logica atual não processava corretamente essas mensagens de edição de mensagens corretamente para esses casos excepcionais.

## Summary by Sourcery

Fix WhatsApp edited message handling in Baileys service to ensure they are properly detected and forwarded to Chatwoot

Bug Fixes:
- Correct detection of edited WhatsApp messages with varied protocol structures
- Prevent edited messages from being prematurely filtered out before Chatwoot event dispatch