### PR TITLE
improv: Ajustado isEmoji para aceitar todos os emojis.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "cors": "^2.8.5",
         "dayjs": "^1.11.13",
         "dotenv": "^16.4.7",
+        "emoji-regex": "^10.4.0",
         "eventemitter2": "^6.4.9",
         "express": "^4.21.2",
         "express-async-errors": "^3.1.1",
@@ -5901,9 +5902,10 @@
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="
     },
     "node_modules/emoji-regex": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.4.0.tgz",
+      "integrity": "sha512-EC+0oUMY1Rqm4O6LLrgjtYDvcVYTy7chDnM4Q7030tP4Kwj3u/pR6gP9ygnp2CJMK5Gq+9Q2oqmrFJAz01DXjw==",
+      "license": "MIT"
     },
     "node_modules/encodeurl": {
       "version": "2.0.0",
@@ -11052,6 +11054,18 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/string-width-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/string-width/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
     },
     "node_modules/string.prototype.trim": {
       "version": "1.2.10",

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "cors": "^2.8.5",
     "dayjs": "^1.11.13",
     "dotenv": "^16.4.7",
+    "emoji-regex": "^10.4.0",
     "eventemitter2": "^6.4.9",
     "express": "^4.21.2",
     "express-async-errors": "^3.1.1",

--- a/src/api/controllers/sendMessage.controller.ts
+++ b/src/api/controllers/sendMessage.controller.ts
@@ -19,10 +19,12 @@ import { BadRequestException } from '@exceptions';
 import { isBase64, isURL } from 'class-validator';
 import emojiRegex from 'emoji-regex';
 
+const regex = emojiRegex();
+
 function isEmoji(str: string) {
   if (str === '') return true;
 
-  const match = str.match(emojiRegex());
+  const match = str.match(regex);
   return match?.length === 1 && match[0] === str;
 }
 

--- a/src/api/controllers/sendMessage.controller.ts
+++ b/src/api/controllers/sendMessage.controller.ts
@@ -17,13 +17,13 @@ import {
 import { WAMonitoringService } from '@api/services/monitor.service';
 import { BadRequestException } from '@exceptions';
 import { isBase64, isURL } from 'class-validator';
+import emojiRegex from 'emoji-regex';
 
 function isEmoji(str: string) {
   if (str === '') return true;
 
-  const emojiRegex =
-    /^[\u{1F300}-\u{1F9FF}\u{2600}-\u{26FF}\u{2700}-\u{27BF}\u{1F000}-\u{1F02F}\u{1F0A0}-\u{1F0FF}\u{1F100}-\u{1F64F}\u{1F680}-\u{1F6FF}]$/u;
-  return emojiRegex.test(str);
+  const match = str.match(emojiRegex());
+  return match?.length === 1 && match[0] === str;
 }
 
 export class SendMessageController {


### PR DESCRIPTION
##  Descrição

Este PR melhora a função `isEmoji` no `sendMessage.controller.ts` para validar corretamente strings que contêm apenas um emoji. A implementação anterior não deixava ser enviado alguns Emojis.

##  O que foi feito

- Substituí a lógica de verificação de emoji por uma implementação mais robusta utilizando a biblioteca `emoji-regex`.
- Garanti que a função retorne `true` apenas se a string for exatamente um emoji.

## Summary by Sourcery

Improve emoji validation in sendMessage.controller by using emoji-regex to ensure only single-emoji strings return true

Enhancements:
- Replace custom emoji regex with emoji-regex library to validate that strings contain exactly one emoji

Build:
- Add emoji-regex dependency to package.json