### PR TITLE
Ignore events that are not messages (like EPHEMERAL_SYNC_RESPONSE)

### DIFF
--- a/src/api/integrations/chatbot/chatwoot/services/chatwoot.service.ts
+++ b/src/api/integrations/chatbot/chatwoot/services/chatwoot.service.ts
@@ -567,6 +567,12 @@ export class ChatwootService {
   }
 
   public async createConversation(instance: InstanceDto, body: any) {
+    if (!body?.key) {
+      this.logger.warn('body.key is null or undefined in createConversation');
+      this.logger.warn('Full body object:', JSON.stringify(body, null, 2));
+      return null;
+    }
+    
     const isLid = body.key.previousRemoteJid?.includes('@lid') && body.key.senderPn;
     const remoteJid = body.key.remoteJid;
     const cacheKey = `${instance.instanceName}:createConversation-${remoteJid}`;
@@ -1938,6 +1944,12 @@ export class ChatwootService {
       }
 
       if (event === 'messages.upsert' || event === 'send.message') {
+        if (!body?.key) {
+          this.logger.warn('body.key is null or undefined');
+          this.logger.warn('Full body object:', JSON.stringify(body, null, 2));
+          return;
+        }
+        
         if (body.key.remoteJid === 'status@broadcast') {
           return;
         }
@@ -2260,10 +2272,16 @@ export class ChatwootService {
       }
 
       if (event === 'messages.edit' || event === 'send.message.update') {
+        if (!body?.key?.id) {
+          this.logger.warn('body.key.id is null or undefined in messages.edit');
+          this.logger.warn('Full body object:', JSON.stringify(body, null, 2));
+          return;
+        }
+        
         const editedText = `${
           body?.editedMessage?.conversation || body?.editedMessage?.extendedTextMessage?.text
         }\n\n_\`${i18next.t('cw.message.edited')}.\`_`;
-        const message = await this.getMessageByKeyId(instance, body?.key?.id);
+        const message = await this.getMessageByKeyId(instance, body.key.id);
         const key = message.key as {
           id: string;
           fromMe: boolean;

--- a/src/api/integrations/chatbot/chatwoot/services/chatwoot.service.ts
+++ b/src/api/integrations/chatbot/chatwoot/services/chatwoot.service.ts
@@ -1898,6 +1898,12 @@ export class ChatwootService {
 
   public async eventWhatsapp(event: string, instance: InstanceDto, body: any) {
     try {
+      // Ignora eventos que não são mensagens (como EPHEMERAL_SYNC_RESPONSE)
+      if (body?.type && body.type !== 'message' && body.type !== 'conversation') {
+        this.logger.verbose(`Ignoring non-message event type: ${body.type}`);
+        return;
+      }
+      
       const waInstance = this.waMonitor.waInstances[instance.instanceName];
 
       if (!waInstance) {
@@ -2270,6 +2276,12 @@ export class ChatwootService {
       }
 
       if (event === 'messages.edit' || event === 'send.message.update') {
+        // Ignora eventos que não são mensagens (como EPHEMERAL_SYNC_RESPONSE)
+        if (body?.type && body.type !== 'message') {
+          this.logger.verbose(`Ignoring non-message event type: ${body.type}`);
+          return;
+        }
+        
         if (!body?.key?.id) {
           this.logger.warn(`body.key.id is null or undefined in messages.edit. Full body object: ${JSON.stringify(body)}`);
           return;

--- a/src/api/integrations/chatbot/chatwoot/services/chatwoot.service.ts
+++ b/src/api/integrations/chatbot/chatwoot/services/chatwoot.service.ts
@@ -568,8 +568,7 @@ export class ChatwootService {
 
   public async createConversation(instance: InstanceDto, body: any) {
     if (!body?.key) {
-      this.logger.warn('body.key is null or undefined in createConversation');
-      this.logger.warn('Full body object:', JSON.stringify(body, null, 2));
+      this.logger.warn(`body.key is null or undefined in createConversation. Full body object: ${JSON.stringify(body)}`);
       return null;
     }
     
@@ -1945,8 +1944,7 @@ export class ChatwootService {
 
       if (event === 'messages.upsert' || event === 'send.message') {
         if (!body?.key) {
-          this.logger.warn('body.key is null or undefined');
-          this.logger.warn('Full body object:', JSON.stringify(body, null, 2));
+          this.logger.warn(`body.key is null or undefined. Full body object: ${JSON.stringify(body)}`);
           return;
         }
         
@@ -2273,8 +2271,7 @@ export class ChatwootService {
 
       if (event === 'messages.edit' || event === 'send.message.update') {
         if (!body?.key?.id) {
-          this.logger.warn('body.key.id is null or undefined in messages.edit');
-          this.logger.warn('Full body object:', JSON.stringify(body, null, 2));
+          this.logger.warn(`body.key.id is null or undefined in messages.edit. Full body object: ${JSON.stringify(body)}`);
           return;
         }
         

--- a/src/api/integrations/chatbot/chatwoot/services/chatwoot.service.ts
+++ b/src/api/integrations/chatbot/chatwoot/services/chatwoot.service.ts
@@ -1898,7 +1898,7 @@ export class ChatwootService {
 
   public async eventWhatsapp(event: string, instance: InstanceDto, body: any) {
     try {
-      // Ignora eventos que não são mensagens (como EPHEMERAL_SYNC_RESPONSE)
+      // Ignore events that are not messages (like EPHEMERAL_SYNC_RESPONSE)
       if (body?.type && body.type !== 'message' && body.type !== 'conversation') {
         this.logger.verbose(`Ignoring non-message event type: ${body.type}`);
         return;
@@ -2276,7 +2276,7 @@ export class ChatwootService {
       }
 
       if (event === 'messages.edit' || event === 'send.message.update') {
-        // Ignora eventos que não são mensagens (como EPHEMERAL_SYNC_RESPONSE)
+        // Ignore events that are not messages (like EPHEMERAL_SYNC_RESPONSE)
         if (body?.type && body.type !== 'message') {
           this.logger.verbose(`Ignoring non-message event type: ${body.type}`);
           return;


### PR DESCRIPTION
In some cases the body.key.id doesn't exists. That cause an error.

Lock my log for debug purposes.

```
body.key.id is null or undefined in messages.edit. Full body object: {"key":{"remoteJid":"551199999999@s.whatsapp.net","fromMe":true},"type":"EPHEMERAL_SYNC_RESPONSE","ephemeralExpiration":7776000,"ephemeralSettingTimestamp":"1752775691","disappearingMode":{"initiator":"INITIATED_BY_ME","trigger":"ACCOUNT_SETTING","initiatedByMe":true}} 
```