### PR TITLE
remove lógica de paginação duplicada no fetchChats que causa resultados vazios quando skip > 0

### DIFF
--- a/src/api/services/channel.service.ts
+++ b/src/api/services/channel.service.ts
@@ -802,12 +802,6 @@ export class ChannelStartupService {
         };
       });
 
-      if (query?.take && query?.skip) {
-        const skip = query.skip || 0;
-        const take = query.take || 20;
-        return mappedResults.slice(skip, skip + take);
-      }
-
       return mappedResults;
     }
 


### PR DESCRIPTION

### Problema
O método `fetchChats` estava aplicando a lógica de paginação duas vezes, causando resultados vazios ao usar o parâmetro `skip` com valores maiores que 0.

### Causa Raiz
1. A query SQL já aplica `LIMIT` e `OFFSET` corretamente
2. O código JavaScript então aplica `.slice(skip, skip + take)` nos resultados já paginados
3. Este "offset duplo" faz com que o slice tente acessar posições do array que não existem

### Exemplo do bug
```json
Requisição: {"take": 10, "skip": 10}
```

1. **SQL**: `LIMIT 10 OFFSET 10` → retorna chats 11-20 (10 itens)
2. **JS**: `.slice(10, 20)` → tenta pegar posições 10-20 de um array com apenas 10 itens
3. **Resultado**: `[]` (array vazio)

### Testes
- ✅ `{"take": 10, "skip": 0}` - Retorna os primeiros 10 chats
- ✅ `{"take": 10, "skip": 10}` - Retorna chats 11-20 (anteriormente retornava `[]`)
- ✅ `{"take": 5, "skip": 15}` - Retorna chats 16-20 (anteriormente retornava `[]`)

### Impacto
- ✅ Corrige a funcionalidade de paginação para todos os valores de `skip > 0`
- ✅ Mantém compatibilidade com versões anteriores
- ✅ Sem mudanças que quebrem implementações existentes

## Summary by Sourcery

Remove duplicated pagination logic in fetchChats by deleting the JavaScript slice, relying solely on SQL LIMIT and OFFSET to fix empty results with skip offsets

Bug Fixes:
- Fix empty results when skip parameter is greater than 0 due to double pagination

Enhancements:
- Remove redundant client-side pagination slicing in fetchChats method

Tests:
- Validate fetchChats returns correct chat ranges for various skip and take values