### PR TITLE
Add  endpoint to retrieve chat data by remoteJid

### DIFF
--- a/src/api/controllers/chat.controller.ts
+++ b/src/api/controllers/chat.controller.ts
@@ -70,6 +70,10 @@ export class ChatController {
     return await this.waMonitor.waInstances[instanceName].fetchChats(query);
   }
 
+  public async findChatByRemoteJid({ instanceName }: InstanceDto, remoteJid: string) {
+    return await this.waMonitor.waInstances[instanceName].findChatByRemoteJid(remoteJid);
+  }
+
   public async sendPresence({ instanceName }: InstanceDto, data: SendPresenceDto) {
     return await this.waMonitor.waInstances[instanceName].sendPresence(data);
   }

--- a/src/api/routes/chat.router.ts
+++ b/src/api/routes/chat.router.ts
@@ -191,6 +191,16 @@ export class ChatRouter extends RouterBroker {
 
         return res.status(HttpStatus.OK).json(response);
       })
+      .get(this.routerPath('findChatByRemoteJid'), ...guards, async (req, res) => {
+        const instance = req.params as unknown as InstanceDto;
+        const { remoteJid } = req.query as unknown as { remoteJid: string };
+        if (!remoteJid) {
+          return res.status(HttpStatus.BAD_REQUEST).json({ error: "remoteJid is a required query parameter" });
+        }
+        const response = await chatController.findChatByRemoteJid(instance, remoteJid);
+
+        return res.status(HttpStatus.OK).json(response);
+      })
       // Profile routes
       .post(this.routerPath('fetchBusinessProfile'), ...guards, async (req, res) => {
         const response = await this.dataValidate<ProfilePictureDto>({

--- a/src/api/routes/chat.router.ts
+++ b/src/api/routes/chat.router.ts
@@ -195,7 +195,7 @@ export class ChatRouter extends RouterBroker {
         const instance = req.params as unknown as InstanceDto;
         const { remoteJid } = req.query as unknown as { remoteJid: string };
         if (!remoteJid) {
-          return res.status(HttpStatus.BAD_REQUEST).json({ error: "remoteJid is a required query parameter" });
+          return res.status(HttpStatus.BAD_REQUEST).json({ error: 'remoteJid is a required query parameter' });
         }
         const response = await chatController.findChatByRemoteJid(instance, remoteJid);
 

--- a/src/api/services/channel.service.ts
+++ b/src/api/services/channel.service.ts
@@ -696,6 +696,16 @@ export class ChannelStartupService {
     });
   }
 
+  public async findChatByRemoteJid(remoteJid: string) {
+    if (!remoteJid) return null;
+    return await this.prismaRepository.chat.findFirst({
+      where: {
+        instanceId: this.instanceId,
+        remoteJid: remoteJid,
+      },
+    });
+  }
+
   public async fetchChats(query: any) {
     const remoteJid = query?.where?.remoteJid
       ? query?.where?.remoteJid.includes('@')


### PR DESCRIPTION
This PR introduces a new API endpoint called `findChatByRemoteJid`, which allows retrieving chat information using a phone number (identified internally as `remoteJid`).

### What's included:
- New controller method: `findChatByRemoteJid`
- Input validation for `remoteJid`
- Integration into the existing chat service
- Basic error handling for not found or invalid inputs

This functionality will be useful for querying specific chats directly by their associated phone number.

## Summary by Sourcery

Add a new API endpoint to retrieve chat records by remoteJid, including route, controller, and service implementations with input validation and error handling.

New Features:
- Introduce GET /findChatByRemoteJid endpoint in chat router with query parameter validation
- Add ChatController.findChatByRemoteJid to delegate fetching logic
- Implement ChannelStartupService.findChatByRemoteJid using Prisma to query chat by remoteJid