### PR TITLE
Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ WORKDIR /evolution
 
 COPY ./package.json ./tsconfig.json ./
 
-RUN npm install
+RUN npm install --legacy-peer-deps
 
 COPY ./src ./src
 COPY ./public ./public


### PR DESCRIPTION
## Summary by Sourcery

Revise the Dockerfile to bypass peer dependency errors during npm install and clean up the image entrypoint.

Bug Fixes:
- Add --legacy-peer-deps flag to npm install in Dockerfile to handle peer dependency conflicts

Enhancements:
- Remove the Dockerfile ENTRYPOINT instruction and trailing newline