### PR TITLE
Avoid corrupting media URLs with query strings

### DIFF
--- a/src/api/integrations/channel/whatsapp/whatsapp.baileys.service.ts
+++ b/src/api/integrations/channel/whatsapp/whatsapp.baileys.service.ts
@@ -2504,7 +2504,9 @@ export class BaileysStartupService extends ChannelStartupService {
         imageBuffer = Buffer.from(base64Data, 'base64');
       } else {
         const timestamp = new Date().getTime();
-        const url = `${image}?timestamp=${timestamp}`;
+        const parsedURL = new URL(image);
+        parsedURL.searchParams.set('timestamp', timestamp.toString());
+        const url = parsedURL.toString();
 
         let config: any = { responseType: 'arraybuffer' };
 
@@ -2725,7 +2727,9 @@ export class BaileysStartupService extends ChannelStartupService {
 
       if (isURL(audio)) {
         const timestamp = new Date().getTime();
-        const url = `${audio}?timestamp=${timestamp}`;
+        const parsedURL = new URL(audio);
+        parsedURL.searchParams.set('timestamp', timestamp.toString());
+        const url = parsedURL.toString();
 
         const config: any = { responseType: 'stream' };
 
@@ -3591,7 +3595,9 @@ export class BaileysStartupService extends ChannelStartupService {
       let pic: WAMediaUpload;
       if (isURL(picture)) {
         const timestamp = new Date().getTime();
-        const url = `${picture}?timestamp=${timestamp}`;
+        const parsedURL = new URL(picture);
+        parsedURL.searchParams.set('timestamp', timestamp.toString());
+        const url = parsedURL.toString();
 
         let config: any = { responseType: 'arraybuffer' };
 
@@ -3873,7 +3879,9 @@ export class BaileysStartupService extends ChannelStartupService {
       let pic: WAMediaUpload;
       if (isURL(picture.image)) {
         const timestamp = new Date().getTime();
-        const url = `${picture.image}?timestamp=${timestamp}`;
+        const parsedURL = new URL(picture.image);
+        parsedURL.searchParams.set('timestamp', timestamp.toString());
+        const url = parsedURL.toString();
 
         let config: any = { responseType: 'arraybuffer' };
 


### PR DESCRIPTION
The existing logic was naively concatenating `?timestamp=...` to the end of media URLs, which resulted in corrupted URLs with two `?` whenever the URLs already had a query string.

We now use `new URL()` and `searchParams` APIs to parse and update the URL

## Summary by Sourcery

Use URL and URLSearchParams APIs to append timestamp query parameters to media URLs instead of naive string concatenation, preventing URL corruption when existing query parameters are present.

Bug Fixes:
- Prevent double '?' in media URLs by correctly handling existing query strings when adding timestamp parameters

Enhancements:
- Replace manual query string concatenation with URL("...").searchParams.set in multiple media-fetching methods