### PR TITLE
fix: atualizar o handle de erros de eventos

### DIFF
--- a/src/api/integrations/channel/whatsapp/whatsapp.baileys.service.ts
+++ b/src/api/integrations/channel/whatsapp/whatsapp.baileys.service.ts
@@ -1059,6 +1059,8 @@ export class BaileysStartupService extends ChannelStartupService {
                 'failed to decrypt message',
                 'SessionError',
                 'Invalid PreKey ID',
+                'No session record',
+                'No session found to decrypt message'
               ].some((err) => param?.includes?.(err)),
             )
           ) {

--- a/src/api/integrations/channel/whatsapp/whatsapp.baileys.service.ts
+++ b/src/api/integrations/channel/whatsapp/whatsapp.baileys.service.ts
@@ -1060,7 +1060,7 @@ export class BaileysStartupService extends ChannelStartupService {
                 'SessionError',
                 'Invalid PreKey ID',
                 'No session record',
-                'No session found to decrypt message'
+                'No session found to decrypt message',
               ].some((err) => param?.includes?.(err)),
             )
           ) {

--- a/src/api/integrations/chatbot/chatwoot/services/chatwoot.service.ts
+++ b/src/api/integrations/chatbot/chatwoot/services/chatwoot.service.ts
@@ -681,7 +681,7 @@ export class ChatwootService {
               instance,
               body.key.participant.split('@')[0],
               filterInbox.id,
-              isGroup,
+              false,
               body.pushName,
               picture_url.profilePictureUrl || null,
               body.key.participant,


### PR DESCRIPTION
## Descrição
Enquanto aguardamos a solução definitiva da Baileys, tentamos reduzir as percas de msgs através do descarte de eventos com erros.

## Solução
Adicionado 2 novos eventos de erro ao bloco de descarte de erro:
` 'No session record', 'No session found to decrypt message'`

Mesmo que o parametro já era informado corretamente a criação do contato de grupo no Chatwoot, fixei ele.

## PRs
#1738

## Summary by Sourcery

Improve error handling for Baileys decryption events and correct the group flag in Chatwoot contact creation

Bug Fixes:
- Discard events containing 'No session record' and 'No session found to decrypt message' in the Baileys error filter to reduce message loss
- Fix the isGroup flag to false when creating group contacts in the Chatwoot service