### PR TITLE
Corrige filtro de mensagens com OR dinâmico

### DIFF
--- a/src/api/integrations/channel/whatsapp/whatsapp.baileys.service.ts
+++ b/src/api/integrations/channel/whatsapp/whatsapp.baileys.service.ts
@@ -4480,6 +4480,7 @@ export class BaileysStartupService extends ChannelStartupService {
       id?: string;
       fromMe?: boolean;
       remoteJid?: string;
+      senderPn?: string;
       participants?: string;
     };
 
@@ -4503,9 +4504,12 @@ export class BaileysStartupService extends ChannelStartupService {
         AND: [
           keyFilters?.id ? { key: { path: ['id'], equals: keyFilters?.id } } : {},
           keyFilters?.fromMe ? { key: { path: ['fromMe'], equals: keyFilters?.fromMe } } : {},
-          keyFilters?.remoteJid ? { key: { path: ['remoteJid'], equals: keyFilters?.remoteJid } } : {},
           keyFilters?.participants ? { key: { path: ['participants'], equals: keyFilters?.participants } } : {},
         ],
+        OR: [
+          keyFilters?.remoteJid ? { key: { path: ['remoteJid'], equals: keyFilters?.remoteJid } } : {},
+          keyFilters?.senderPn ? { key: { path: ['senderPn'], equals: keyFilters?.senderPn } } : {},
+        ]
       },
     });
 
@@ -4527,9 +4531,12 @@ export class BaileysStartupService extends ChannelStartupService {
         AND: [
           keyFilters?.id ? { key: { path: ['id'], equals: keyFilters?.id } } : {},
           keyFilters?.fromMe ? { key: { path: ['fromMe'], equals: keyFilters?.fromMe } } : {},
-          keyFilters?.remoteJid ? { key: { path: ['remoteJid'], equals: keyFilters?.remoteJid } } : {},
           keyFilters?.participants ? { key: { path: ['participants'], equals: keyFilters?.participants } } : {},
         ],
+        OR: [
+          keyFilters?.remoteJid ? { key: { path: ['remoteJid'], equals: keyFilters?.remoteJid } } : {},
+          keyFilters?.senderPn ? { key: { path: ['senderPn'], equals: keyFilters?.senderPn } } : {},
+        ]
       },
       orderBy: { messageTimestamp: 'desc' },
       skip: query.offset * (query?.page === 1 ? 0 : (query?.page as number) - 1),


### PR DESCRIPTION
Adicionado operador OR em "prismaRepository.message.count" e "prismaRepository.message.findMany" para filtrar as mensagens de um contato por "remoteJid" ou "senderPn".

Essa atualização serve para ajudar a buscar as mensagens do cliente que vem com o campo "remoteJid" com @lid.
Essa atualização permite trazer os resultados mais corretos para o filtro de mensagem, sem deixar as mensagens com senderPn que deveriam ter o padrão @whatsapp que vinha antes em remoteJid.

Essa atualização busca com o where da seguinte forma:
where: {
     key: {
          remoteJid: '',
          senderPn: '',
     },
}


Acredito que sirva para mais pessoas essa att, outra forma seria nem passar o senderPn no where e colocar direto no método de count ou findMany... Mas dessa forma acredito que fique melhor o uso...