### PR TITLE
Securing websockets

### DIFF
--- a/src/api/integrations/event/websocket/websocket.controller.ts
+++ b/src/api/integrations/event/websocket/websocket.controller.ts
@@ -28,11 +28,14 @@ export class WebsocketController extends EventController implements EventControl
       allowRequest: async (req, callback) => {
         try {
           const url = new URL(req.url || '', 'http://localhost');
-          const isInternalConnection = req.socket.remoteAddress === '127.0.0.1' || req.socket.remoteAddress === '::1';
           const params = new URLSearchParams(url.search);
 
+          const remoteAddress = req.socket.remoteAddress;
+          const isLocalhost =
+            remoteAddress === '127.0.0.1' || remoteAddress === '::1' || remoteAddress === '::ffff:127.0.0.1';
+
           // Permite conexões internas do Socket.IO (EIO=4 é o Engine.IO v4)
-          if (params.has('EIO') && isInternalConnection) {
+          if (params.has('EIO') && isLocalhost) {
             return callback(null, true);
           }
 

--- a/src/api/integrations/event/websocket/websocket.controller.ts
+++ b/src/api/integrations/event/websocket/websocket.controller.ts
@@ -28,10 +28,11 @@ export class WebsocketController extends EventController implements EventControl
       allowRequest: async (req, callback) => {
         try {
           const url = new URL(req.url || '', 'http://localhost');
+          const isInternalConnection = req.socket.remoteAddress === '127.0.0.1' || req.socket.remoteAddress === '::1';
           const params = new URLSearchParams(url.search);
 
           // Permite conexões internas do Socket.IO (EIO=4 é o Engine.IO v4)
-          if (params.has('EIO')) {
+          if (params.has('EIO') && isInternalConnection) {
             return callback(null, true);
           }
 

--- a/src/api/integrations/event/websocket/websocket.controller.ts
+++ b/src/api/integrations/event/websocket/websocket.controller.ts
@@ -30,7 +30,7 @@ export class WebsocketController extends EventController implements EventControl
           const url = new URL(req.url || '', 'http://localhost');
           const params = new URLSearchParams(url.search);
 
-          const remoteAddress = req.socket.remoteAddress;
+          const { remoteAddress } = req.socket;
           const isLocalhost =
             remoteAddress === '127.0.0.1' || remoteAddress === '::1' || remoteAddress === '::ffff:127.0.0.1';
 


### PR DESCRIPTION
Fixing publicly exposed WebSocket endpoints.

## Summary by Sourcery

Restrict WebSocket Engine.IO handshake to only allow connections from localhost

Bug Fixes:
- Prevent public exposure of WebSocket endpoints by enforcing a localhost address check on Engine.IO handshake

Enhancements:
- Add remoteAddress inspection and isLocalhost helper for IPv4 and IPv6 addresses