### PR TITLE
Alteração no whatsapp.baileys.service.ts para preservar o contextInfo completo no prepareMessage

### DIFF
--- a/src/api/integrations/channel/whatsapp/whatsapp.baileys.service.ts
+++ b/src/api/integrations/channel/whatsapp/whatsapp.baileys.service.ts
@@ -4251,9 +4251,7 @@ export class BaileysStartupService extends ChannelStartupService {
 
   private prepareMessage(message: proto.IWebMessageInfo): any {
   const contentType = getContentType(message.message);
-  const contentMsg = message?.message[contentType] as any;
 
-  // [ADD] Merge seguro de contextInfo
   const mm = message.message as Record<string, any> | undefined;
   const contentCtx =
     contentType && mm && typeof mm[contentType] === 'object'
@@ -4278,7 +4276,6 @@ export class BaileysStartupService extends ChannelStartupService {
           (message.key?.participant ? message.key.participant.split('@')[0] : null)),
     status: status[message.status],
     message: { ...message.message },
-    // [REPLACE] antes: contextInfo: contentMsg?.contextInfo,
     contextInfo: contextInfoFinal,
     messageType: contentType || 'unknown',
     messageTimestamp: message.messageTimestamp as number,


### PR DESCRIPTION
Alteração realizada para preservar todos os metadados recebidos no contextInfo (incluindo ctwa_clid, ctwaPayload, conversionData e entryPointConversion*), unificando dados vindos de:
- message.message[contentType].contextInfo
- message.message.contextInfo
- message.messageContextInfo

Essa mudança evita a perda de informações enviadas pela Meta em diferentes níveis da estrutura da mensagem, garantindo que esses campos sejam repassados integralmente para o webhook, permitindo integrações completas com a API de Conversões.

## Summary by Sourcery

Enhancements:
- Merge contextInfo from content-specific, top-level, and messageContextInfo into a single field in prepareMessage to retain all metadata fields (e.g., ctwa_clid, ctwaPayload, conversionData, entryPointConversion*)