### PR TITLE
Update 20250116001415_add_wavoip_token_to_settings_table

### DIFF
--- a/prisma/postgresql-migrations/20250116001415_add_wavoip_token_to_settings_table/migration.sql
+++ b/prisma/postgresql-migrations/20250116001415_add_wavoip_token_to_settings_table/migration.sql
@@ -6,14 +6,4 @@ Warnings:
 */
 
 -- AlterTable
-DO $$ 
-BEGIN 
-    IF NOT EXISTS (
-        SELECT 1
-        FROM information_schema.columns
-        WHERE table_name = 'Setting'
-        AND column_name = 'wavoipToken'
-    ) THEN
-        ALTER TABLE "Setting" ADD COLUMN "wavoipToken" VARCHAR(100);
-    END IF;
-END $$;
+ALTER TABLE "Setting" ADD COLUMN IF NOT EXISTS "wavoipToken" VARCHAR(100);


### PR DESCRIPTION
Ao trabalhar com vários schemas no postgres a verificação antiga falhava. 
Exemplo:
Ao executar as migrations no banco de dados evolution (schema1) a coluna era criada.
Ao executar as migrations no banco de dados evolution (schema2) a coluna não era criada.

Dessa forma usando ADD COLUMN IF NOT EXISTS ela é criada todos os schemas.

## Summary by Sourcery

Enhancements:
- Use ALTER TABLE ADD COLUMN IF NOT EXISTS for the wavoipToken column instead of a DO block with information_schema check