### PR TITLE
fix: Prevent Duplicate Cron Jobs for Chatwoot Message Sync

### DIFF
--- a/src/api/integrations/channel/whatsapp/whatsapp.baileys.service.ts
+++ b/src/api/integrations/channel/whatsapp/whatsapp.baileys.service.ts
@@ -4367,7 +4367,11 @@ export class BaileysStartupService extends ChannelStartupService {
         const cache = this.chatwootService.getCache();
         if (cache) {
           const storedId = await cache.hGet(cronKey, this.instance.name);
-          if (storedId && storedId !== cronId) return;
+          if (storedId && storedId !== cronId) {
+            this.logger.info(`Stopping syncChatwootLostMessages cron - ID mismatch: ${cronId} vs ${storedId}`);
+            task.stop();
+            return;
+          }
         }
         this.chatwootService.syncLostMessages({ instanceName: this.instance.name }, chatwootConfig, prepare);
       });


### PR DESCRIPTION
### Bug Fix: Prevent Duplicate Cron Jobs for Chatwoot Message Sync

**Problem:** Multiple instances of the same cron job were being created when the syncChatwootLostMessages() method was called repeatedly, leading to duplicate message syncing operations.

**Solution:** Implemented a unique identifier system using cuid() to ensure only one active cron job per instance:

1. Generate unique ID: Each cron job gets a unique cronId when created
2. Store in cache: The ID is stored in Redis cache with key chatwoot:syncLostMessages and instance name
3. ID validation: Before executing sync, the cron job checks if its ID matches the stored ID
4. Skip duplicates: If IDs don't match, the job skips execution, preventing duplicate syncing

This ensures that even if multiple cron jobs are accidentally created, only the most recent one will actually execute the sync operation.

## Summary by Sourcery

Prevent duplicate cron jobs for Chatwoot message syncing by assigning each job a unique ID stored in Redis and validating it before execution.

Bug Fixes:
- Generate a unique ID (cuid) for each cron task and store it in a Redis hash keyed by instance to track the latest job.
- Check the stored ID against the job’s own ID on each run and skip execution if they don’t match to avoid duplicate sync operations.