### PR TITLE
feat: implement standardized error handling for WhatsApp API responses

### DIFF
--- a/src/api/routes/business.router.ts
+++ b/src/api/routes/business.router.ts
@@ -3,6 +3,7 @@ import { NumberDto } from '@api/dto/chat.dto';
 import { businessController } from '@api/server.module';
 import { catalogSchema, collectionsSchema } from '@validate/validate.schema';
 import { RequestHandler, Router } from 'express';
+import { createMetaErrorResponse } from '@utils/errorResponse';
 
 import { HttpStatus } from './index.router';
 
@@ -11,25 +12,43 @@ export class BusinessRouter extends RouterBroker {
     super();
     this.router
       .post(this.routerPath('getCatalog'), ...guards, async (req, res) => {
-        const response = await this.dataValidate<NumberDto>({
-          request: req,
-          schema: catalogSchema,
-          ClassRef: NumberDto,
-          execute: (instance, data) => businessController.fetchCatalog(instance, data),
-        });
+        try {
+          const response = await this.dataValidate<NumberDto>({
+            request: req,
+            schema: catalogSchema,
+            ClassRef: NumberDto,
+            execute: (instance, data) => businessController.fetchCatalog(instance, data),
+          });
 
-        return res.status(HttpStatus.OK).json(response);
+          return res.status(HttpStatus.OK).json(response);
+        } catch (error) {
+          // Log error for debugging
+          console.error('Business catalog error:', error);
+          
+          // Use utility function to create standardized error response
+          const errorResponse = createMetaErrorResponse(error, 'business_catalog');
+          return res.status(errorResponse.status).json(errorResponse);
+        }
       })
 
       .post(this.routerPath('getCollections'), ...guards, async (req, res) => {
-        const response = await this.dataValidate<NumberDto>({
-          request: req,
-          schema: collectionsSchema,
-          ClassRef: NumberDto,
-          execute: (instance, data) => businessController.fetchCollections(instance, data),
-        });
+        try {
+          const response = await this.dataValidate<NumberDto>({
+            request: req,
+            schema: collectionsSchema,
+            ClassRef: NumberDto,
+            execute: (instance, data) => businessController.fetchCollections(instance, data),
+          });
 
-        return res.status(HttpStatus.OK).json(response);
+          return res.status(HttpStatus.OK).json(response);
+        } catch (error) {
+          // Log error for debugging
+          console.error('Business collections error:', error);
+          
+          // Use utility function to create standardized error response
+          const errorResponse = createMetaErrorResponse(error, 'business_collections');
+          return res.status(errorResponse.status).json(errorResponse);
+        }
       });
   }
 

--- a/src/api/routes/business.router.ts
+++ b/src/api/routes/business.router.ts
@@ -1,9 +1,9 @@
 import { RouterBroker } from '@api/abstract/abstract.router';
 import { NumberDto } from '@api/dto/chat.dto';
 import { businessController } from '@api/server.module';
+import { createMetaErrorResponse } from '@utils/errorResponse';
 import { catalogSchema, collectionsSchema } from '@validate/validate.schema';
 import { RequestHandler, Router } from 'express';
-import { createMetaErrorResponse } from '@utils/errorResponse';
 
 import { HttpStatus } from './index.router';
 
@@ -24,7 +24,7 @@ export class BusinessRouter extends RouterBroker {
         } catch (error) {
           // Log error for debugging
           console.error('Business catalog error:', error);
-          
+
           // Use utility function to create standardized error response
           const errorResponse = createMetaErrorResponse(error, 'business_catalog');
           return res.status(errorResponse.status).json(errorResponse);
@@ -44,7 +44,7 @@ export class BusinessRouter extends RouterBroker {
         } catch (error) {
           // Log error for debugging
           console.error('Business collections error:', error);
-          
+
           // Use utility function to create standardized error response
           const errorResponse = createMetaErrorResponse(error, 'business_collections');
           return res.status(errorResponse.status).json(errorResponse);

--- a/src/api/routes/template.router.ts
+++ b/src/api/routes/template.router.ts
@@ -3,9 +3,9 @@ import { InstanceDto } from '@api/dto/instance.dto';
 import { TemplateDto } from '@api/dto/template.dto';
 import { templateController } from '@api/server.module';
 import { ConfigService } from '@config/env.config';
+import { createMetaErrorResponse } from '@utils/errorResponse';
 import { instanceSchema, templateSchema } from '@validate/validate.schema';
 import { RequestHandler, Router } from 'express';
-import { createMetaErrorResponse } from '@utils/errorResponse';
 
 import { HttpStatus } from './index.router';
 
@@ -29,7 +29,7 @@ export class TemplateRouter extends RouterBroker {
         } catch (error) {
           // Log error for debugging
           console.error('Template creation error:', error);
-          
+
           // Use utility function to create standardized error response
           const errorResponse = createMetaErrorResponse(error, 'template_creation');
           res.status(errorResponse.status).json(errorResponse);
@@ -48,7 +48,7 @@ export class TemplateRouter extends RouterBroker {
         } catch (error) {
           // Log error for debugging
           console.error('Template find error:', error);
-          
+
           // Use utility function to create standardized error response
           const errorResponse = createMetaErrorResponse(error, 'template_find');
           res.status(errorResponse.status).json(errorResponse);

--- a/src/api/routes/template.router.ts
+++ b/src/api/routes/template.router.ts
@@ -5,6 +5,7 @@ import { templateController } from '@api/server.module';
 import { ConfigService } from '@config/env.config';
 import { instanceSchema, templateSchema } from '@validate/validate.schema';
 import { RequestHandler, Router } from 'express';
+import { createMetaErrorResponse } from '@utils/errorResponse';
 
 import { HttpStatus } from './index.router';
 
@@ -16,24 +17,42 @@ export class TemplateRouter extends RouterBroker {
     super();
     this.router
       .post(this.routerPath('create'), ...guards, async (req, res) => {
-        const response = await this.dataValidate<TemplateDto>({
-          request: req,
-          schema: templateSchema,
-          ClassRef: TemplateDto,
-          execute: (instance, data) => templateController.createTemplate(instance, data),
-        });
+        try {
+          const response = await this.dataValidate<TemplateDto>({
+            request: req,
+            schema: templateSchema,
+            ClassRef: TemplateDto,
+            execute: (instance, data) => templateController.createTemplate(instance, data),
+          });
 
-        res.status(HttpStatus.CREATED).json(response);
+          res.status(HttpStatus.CREATED).json(response);
+        } catch (error) {
+          // Log error for debugging
+          console.error('Template creation error:', error);
+          
+          // Use utility function to create standardized error response
+          const errorResponse = createMetaErrorResponse(error, 'template_creation');
+          res.status(errorResponse.status).json(errorResponse);
+        }
       })
       .get(this.routerPath('find'), ...guards, async (req, res) => {
-        const response = await this.dataValidate<InstanceDto>({
-          request: req,
-          schema: instanceSchema,
-          ClassRef: InstanceDto,
-          execute: (instance) => templateController.findTemplate(instance),
-        });
+        try {
+          const response = await this.dataValidate<InstanceDto>({
+            request: req,
+            schema: instanceSchema,
+            ClassRef: InstanceDto,
+            execute: (instance) => templateController.findTemplate(instance),
+          });
 
-        res.status(HttpStatus.OK).json(response);
+          res.status(HttpStatus.OK).json(response);
+        } catch (error) {
+          // Log error for debugging
+          console.error('Template find error:', error);
+          
+          // Use utility function to create standardized error response
+          const errorResponse = createMetaErrorResponse(error, 'template_find');
+          res.status(errorResponse.status).json(errorResponse);
+        }
       });
   }
 

--- a/src/api/services/template.service.ts
+++ b/src/api/services/template.service.ts
@@ -103,7 +103,7 @@ export class TemplateService {
         return result.data;
       }
     } catch (e) {
-      this.logger.error('WhatsApp API request error: ' + (e.response?.data || e.message));
+      this.logger.error('WhatsApp API request error: ' + ( e.response?.data ? JSON.stringify(e.response?.data) : e.message));
 
       // Return the complete error response from WhatsApp API
       if (e.response?.data) {

--- a/src/api/services/template.service.ts
+++ b/src/api/services/template.service.ts
@@ -103,7 +103,9 @@ export class TemplateService {
         return result.data;
       }
     } catch (e) {
-      this.logger.error('WhatsApp API request error: ' + ( e.response?.data ? JSON.stringify(e.response?.data) : e.message));
+      this.logger.error(
+        'WhatsApp API request error: ' + (e.response?.data ? JSON.stringify(e.response?.data) : e.message),
+      );
 
       // Return the complete error response from WhatsApp API
       if (e.response?.data) {

--- a/src/api/services/template.service.ts
+++ b/src/api/services/template.service.ts
@@ -60,6 +60,13 @@ export class TemplateService {
       const response = await this.requestTemplate(postData, 'POST');
 
       if (!response || response.error) {
+        // If there's an error from WhatsApp API, throw it with the real error data
+        if (response && response.error) {
+          // Create an error object that includes the template field for Meta errors
+          const metaError = new Error(response.error.message || 'WhatsApp API Error');
+          (metaError as any).template = response.error;
+          throw metaError;
+        }
         throw new Error('Error to create template');
       }
 
@@ -75,8 +82,9 @@ export class TemplateService {
 
       return template;
     } catch (error) {
-      this.logger.error(error);
-      throw new Error('Error to create template');
+      this.logger.error('Error in create template: ' + error);
+      // Propagate the real error instead of "engolindo" it
+      throw error;
     }
   }
 
@@ -86,6 +94,7 @@ export class TemplateService {
       const version = this.configService.get<WaBusiness>('WA_BUSINESS').VERSION;
       urlServer = `${urlServer}/${version}/${this.businessId}/message_templates`;
       const headers = { 'Content-Type': 'application/json', Authorization: `Bearer ${this.token}` };
+      
       if (method === 'GET') {
         const result = await axios.get(urlServer, { headers });
         return result.data;
@@ -94,8 +103,15 @@ export class TemplateService {
         return result.data;
       }
     } catch (e) {
-      this.logger.error(e.response.data);
-      return e.response.data.error;
+      this.logger.error('WhatsApp API request error: ' + (e.response?.data || e.message));
+      
+      // Return the complete error response from WhatsApp API
+      if (e.response?.data) {
+        return e.response.data;
+      }
+      
+      // If no response data, throw connection error
+      throw new Error(`Connection error: ${e.message}`);
     }
   }
 }

--- a/src/api/services/template.service.ts
+++ b/src/api/services/template.service.ts
@@ -94,7 +94,7 @@ export class TemplateService {
       const version = this.configService.get<WaBusiness>('WA_BUSINESS').VERSION;
       urlServer = `${urlServer}/${version}/${this.businessId}/message_templates`;
       const headers = { 'Content-Type': 'application/json', Authorization: `Bearer ${this.token}` };
-      
+
       if (method === 'GET') {
         const result = await axios.get(urlServer, { headers });
         return result.data;
@@ -104,12 +104,12 @@ export class TemplateService {
       }
     } catch (e) {
       this.logger.error('WhatsApp API request error: ' + (e.response?.data || e.message));
-      
+
       // Return the complete error response from WhatsApp API
       if (e.response?.data) {
         return e.response.data;
       }
-      
+
       // If no response data, throw connection error
       throw new Error(`Connection error: ${e.message}`);
     }

--- a/src/utils/errorResponse.ts
+++ b/src/utils/errorResponse.ts
@@ -26,7 +26,7 @@ export function createMetaErrorResponse(error: any, context: string): MetaErrorR
   const metaError = error.template || error;
   const errorUserTitle = metaError.error_user_title || metaError.message || 'Unknown error';
   const errorUserMsg = metaError.error_user_msg || metaError.message || 'Unknown error';
-  
+
   return {
     status: HttpStatus.BAD_REQUEST,
     error: 'Bad Request',
@@ -40,8 +40,8 @@ export function createMetaErrorResponse(error: any, context: string): MetaErrorR
       error_subcode: metaError.error_subcode || null,
       fbtrace_id: metaError.fbtrace_id || null,
       context,
-      type: 'whatsapp_api_error'
+      type: 'whatsapp_api_error',
     },
-    timestamp: new Date().toISOString()
+    timestamp: new Date().toISOString(),
   };
 }

--- a/src/utils/errorResponse.ts
+++ b/src/utils/errorResponse.ts
@@ -1,0 +1,47 @@
+import { HttpStatus } from '@api/routes/index.router';
+
+export interface MetaErrorResponse {
+  status: number;
+  error: string;
+  message: string;
+  details: {
+    whatsapp_error: string;
+    whatsapp_code: string | number;
+    error_user_title: string;
+    error_user_msg: string;
+    error_type: string;
+    error_subcode: number | null;
+    fbtrace_id: string | null;
+    context: string;
+    type: string;
+  };
+  timestamp: string;
+}
+
+/**
+ * Creates standardized error response for Meta/WhatsApp API errors
+ */
+export function createMetaErrorResponse(error: any, context: string): MetaErrorResponse {
+  // Extract Meta/WhatsApp specific error fields
+  const metaError = error.template || error;
+  const errorUserTitle = metaError.error_user_title || metaError.message || 'Unknown error';
+  const errorUserMsg = metaError.error_user_msg || metaError.message || 'Unknown error';
+  
+  return {
+    status: HttpStatus.BAD_REQUEST,
+    error: 'Bad Request',
+    message: errorUserTitle,
+    details: {
+      whatsapp_error: errorUserMsg,
+      whatsapp_code: metaError.code || 'UNKNOWN_ERROR',
+      error_user_title: errorUserTitle,
+      error_user_msg: errorUserMsg,
+      error_type: metaError.type || 'UNKNOWN',
+      error_subcode: metaError.error_subcode || null,
+      fbtrace_id: metaError.fbtrace_id || null,
+      context,
+      type: 'whatsapp_api_error'
+    },
+    timestamp: new Date().toISOString()
+  };
+}


### PR DESCRIPTION
### feat: Implement standardized error handling for WhatsApp API responses

**Description**

This Pull Request introduces a complete refactoring of the WhatsApp API error handling to ensure that error responses are more detailed, consistent, and easier to debug. Previously, many errors from the Meta API were masked by generic messages, making it difficult to identify the root cause of issues.

---

**What was done?**

- ✅ **Standard Error Formatter Creation:** A new utility, `createMetaErrorResponse`, has been created in `src/utils/errorResponse.ts`. This function is responsible for taking a raw error from the WhatsApp API and transforming it into a well-structured and consistent JSON response object.
- ✅ **Improved Error Propagation:** The `TemplateService` was modified to propagate the complete error object returned by the WhatsApp API, instead of throwing a new error with a generic message. This ensures that no important details (like `fbtrace_id`, `error_subcode`, etc.) are lost.
- ✅ **Implementation in API Routes:** The endpoints in `BusinessRouter` and `TemplateRouter` were updated to use `try...catch` and call the new `createMetaErrorResponse` function in the `catch` block. This ensures that all communication with the client follows the new error standard.

**Why is this necessary?**

- **Debugging Difficulty:** It was hard to diagnose WhatsApp integration issues because the error messages were generic and did not contain the full context provided by Meta.
- **Inconsistency:** Different parts of the code handled errors in different ways, resulting in an inconsistent experience for developers consuming the API.
- **Loss of Information:** Valuable details for support and debugging, such as the `fbtrace_id`, were being discarded.

**How to test?**

1.  Run the application.
2.  Make a request to one of the affected endpoints (e.g., `POST /template/create`) with data that you know will cause an error in the WhatsApp API (for example, an invalid component format or a template name that violates the rules).
3.  Check the API response. It should contain a JSON with the structure defined by the `MetaErrorResponse` interface, including fields like `status`, `message`, and `details` with specific information from the WhatsApp error.
4.  Confirm that the HTTP response status is `400 Bad Request`.

## Summary by Sourcery

Implement a consistent error-handling layer for WhatsApp API interactions by adding a formatting utility, updating service error propagation, and standardizing router error responses

Enhancements:
- Introduce createMetaErrorResponse utility to format and standardize WhatsApp API errors
- Wrap BusinessRouter and TemplateRouter endpoints in try/catch, log failures, and return standardized MetaErrorResponse
- Refactor TemplateService to propagate raw Meta API errors with full context and return complete error data from axios calls