### PR TITLE
Revert "Ignore events that are not messages (like EPHEMERAL_SYNC_RESPONSE)"

### DIFF
--- a/src/api/integrations/chatbot/chatwoot/services/chatwoot.service.ts
+++ b/src/api/integrations/chatbot/chatwoot/services/chatwoot.service.ts
@@ -567,13 +567,6 @@ export class ChatwootService {
   }
 
   public async createConversation(instance: InstanceDto, body: any) {
-    if (!body?.key) {
-      this.logger.warn(
-        `body.key is null or undefined in createConversation. Full body object: ${JSON.stringify(body)}`,
-      );
-      return null;
-    }
-
     const isLid = body.key.previousRemoteJid?.includes('@lid') && body.key.senderPn;
     const remoteJid = body.key.remoteJid;
     const cacheKey = `${instance.instanceName}:createConversation-${remoteJid}`;
@@ -1900,12 +1893,6 @@ export class ChatwootService {
 
   public async eventWhatsapp(event: string, instance: InstanceDto, body: any) {
     try {
-      // Ignore events that are not messages (like EPHEMERAL_SYNC_RESPONSE)
-      if (body?.type && body.type !== 'message' && body.type !== 'conversation') {
-        this.logger.verbose(`Ignoring non-message event type: ${body.type}`);
-        return;
-      }
-
       const waInstance = this.waMonitor.waInstances[instance.instanceName];
 
       if (!waInstance) {
@@ -1951,11 +1938,6 @@ export class ChatwootService {
       }
 
       if (event === 'messages.upsert' || event === 'send.message') {
-        if (!body?.key) {
-          this.logger.warn(`body.key is null or undefined. Full body object: ${JSON.stringify(body)}`);
-          return;
-        }
-
         if (body.key.remoteJid === 'status@broadcast') {
           return;
         }
@@ -2278,23 +2260,10 @@ export class ChatwootService {
       }
 
       if (event === 'messages.edit' || event === 'send.message.update') {
-        // Ignore events that are not messages (like EPHEMERAL_SYNC_RESPONSE)
-        if (body?.type && body.type !== 'message') {
-          this.logger.verbose(`Ignoring non-message event type: ${body.type}`);
-          return;
-        }
-
-        if (!body?.key?.id) {
-          this.logger.warn(
-            `body.key.id is null or undefined in messages.edit. Full body object: ${JSON.stringify(body)}`,
-          );
-          return;
-        }
-
         const editedText = `${
           body?.editedMessage?.conversation || body?.editedMessage?.extendedTextMessage?.text
         }\n\n_\`${i18next.t('cw.message.edited')}.\`_`;
-        const message = await this.getMessageByKeyId(instance, body.key.id);
+        const message = await this.getMessageByKeyId(instance, body?.key?.id);
         const key = message.key as {
           id: string;
           fromMe: boolean;


### PR DESCRIPTION
Reverts EvolutionAPI/evolution-api#1732

## Summary by Sourcery

Revert previous changes that filtered and guarded against missing or non-message events, restoring full event handling and adjusting key.id access to use optional chaining.

Bug Fixes:
- Restore processing of non-message events by removing filters that ignored events based on body.type
- Remove guard clauses and logging warnings for missing body.key or key.id in createConversation, messages.upsert, and messages.edit

Enhancements:
- Apply optional chaining when accessing body.key.id to avoid runtime errors