### PR TITLE
fix: integrate Typebot status change events for webhook in chatbot controller e service

### DIFF
--- a/src/api/integrations/chatbot/base-chatbot.controller.ts
+++ b/src/api/integrations/chatbot/base-chatbot.controller.ts
@@ -2,6 +2,7 @@ import { IgnoreJidDto } from '@api/dto/chatbot.dto';
 import { InstanceDto } from '@api/dto/instance.dto';
 import { PrismaRepository } from '@api/repository/repository.service';
 import { WAMonitoringService } from '@api/services/monitor.service';
+import { Events } from '@api/types/wa.types';
 import { Logger } from '@config/logger.config';
 import { BadRequestException } from '@exceptions';
 import { TriggerOperator, TriggerType } from '@prisma/client';
@@ -9,7 +10,6 @@ import { getConversationMessage } from '@utils/getConversationMessage';
 
 import { BaseChatbotDto } from './base-chatbot.dto';
 import { ChatbotController, ChatbotControllerInterface, EmitData } from './chatbot.controller';
-import { Events } from '@api/types/wa.types';
 
 // Common settings interface for all chatbot integrations
 export interface ChatbotSettings {
@@ -59,7 +59,7 @@ export abstract class BaseChatbotController<BotType = any, BotData extends BaseC
   settingsRepository: any;
   sessionRepository: any;
   userMessageDebounce: { [key: string]: { message: string; timeoutId: NodeJS.Timeout } } = {};
-  
+
   // Name of the integration, to be set by the derived class
   protected abstract readonly integrationName: string;
 
@@ -446,14 +446,14 @@ export abstract class BaseChatbotController<BotType = any, BotData extends BaseC
       });
 
       const remoteJid = data.remoteJid;
-      const status = data.status;      
+      const status = data.status;
       const session = await this.getSession(remoteJid, instance);
 
       if (this.integrationName === 'Typebot') {
         const typebotData = {
           remoteJid: remoteJid,
           status: status,
-          session
+          session,
         };
         this.waMonitor.waInstances[instance.instanceName].sendDataWebhook(Events.TYPEBOT_CHANGE_STATUS, typebotData);
       }
@@ -507,7 +507,7 @@ export abstract class BaseChatbotController<BotType = any, BotData extends BaseC
           status: status,
           session,
         };
-        
+
         return { bot: { ...instance, bot: botData } };
       }
     } catch (error) {
@@ -887,7 +887,7 @@ export abstract class BaseChatbotController<BotType = any, BotData extends BaseC
           };
           this.waMonitor.waInstances[instance.instanceName].sendDataWebhook(Events.TYPEBOT_CHANGE_STATUS, typebotData);
         }
-        
+
         return;
       }
 

--- a/src/api/integrations/chatbot/typebot/services/typebot.service.ts
+++ b/src/api/integrations/chatbot/typebot/services/typebot.service.ts
@@ -1,5 +1,6 @@
 import { PrismaRepository } from '@api/repository/repository.service';
 import { WAMonitoringService } from '@api/services/monitor.service';
+import { Events } from '@api/types/wa.types';
 import { Auth, ConfigService, HttpServer, Typebot } from '@config/env.config';
 import { Instance, IntegrationSession, Message, Typebot as TypebotModel } from '@prisma/client';
 import { getConversationMessage } from '@utils/getConversationMessage';
@@ -8,11 +9,10 @@ import axios from 'axios';
 
 import { BaseChatbotService } from '../../base-chatbot.service';
 import { OpenaiService } from '../../openai/services/openai.service';
-import { Events } from '@api/types/wa.types';
 
 export class TypebotService extends BaseChatbotService<TypebotModel, any> {
-  private openaiService: OpenaiService;  
-  
+  private openaiService: OpenaiService;
+
   constructor(
     waMonitor: WAMonitoringService,
     configService: ConfigService,
@@ -20,7 +20,7 @@ export class TypebotService extends BaseChatbotService<TypebotModel, any> {
     openaiService: OpenaiService,
   ) {
     super(waMonitor, prismaRepository, 'TypebotService', configService);
-    this.openaiService = openaiService;      
+    this.openaiService = openaiService;
   }
 
   /**
@@ -154,11 +154,11 @@ export class TypebotService extends BaseChatbotService<TypebotModel, any> {
       }
 
       const typebotData = {
-          remoteJid: data.remoteJid,
-          status: 'opened',
-          session,
+        remoteJid: data.remoteJid,
+        status: 'opened',
+        session,
       };
-      this.waMonitor.waInstances[instance.name].sendDataWebhook(Events.TYPEBOT_CHANGE_STATUS, typebotData);        
+      this.waMonitor.waInstances[instance.name].sendDataWebhook(Events.TYPEBOT_CHANGE_STATUS, typebotData);
 
       return { ...request.data, session };
     } catch (error) {
@@ -433,7 +433,6 @@ export class TypebotService extends BaseChatbotService<TypebotModel, any> {
         session,
       };
       instance.sendDataWebhook(Events.TYPEBOT_CHANGE_STATUS, typebotData);
-      
     }
   }
 
@@ -677,13 +676,13 @@ export class TypebotService extends BaseChatbotService<TypebotModel, any> {
                 },
               });
             }
-             
+
             const typebotData = {
               remoteJid: remoteJid,
               status: statusChange,
               session,
             };
-            waInstance.sendDataWebhook(Events.TYPEBOT_CHANGE_STATUS, typebotData);            
+            waInstance.sendDataWebhook(Events.TYPEBOT_CHANGE_STATUS, typebotData);
 
             return;
           }
@@ -836,13 +835,13 @@ export class TypebotService extends BaseChatbotService<TypebotModel, any> {
               },
             });
           }
-          
+
           const typebotData = {
-              remoteJid: remoteJid,
-              status: statusChange,
-              session,
-            };
-          waInstance.sendDataWebhook(Events.TYPEBOT_CHANGE_STATUS, typebotData);          
+            remoteJid: remoteJid,
+            status: statusChange,
+            session,
+          };
+          waInstance.sendDataWebhook(Events.TYPEBOT_CHANGE_STATUS, typebotData);
 
           return;
         }
@@ -945,7 +944,7 @@ export class TypebotService extends BaseChatbotService<TypebotModel, any> {
         session,
       };
 
-      waInstance.sendDataWebhook(Events.TYPEBOT_CHANGE_STATUS, typebotData);      
+      waInstance.sendDataWebhook(Events.TYPEBOT_CHANGE_STATUS, typebotData);
 
       return;
     }


### PR DESCRIPTION
**Does not trigger webhook for Typebot status change events (TYPEBOT_CHANGE_STATUS)**

* Issue found from the commit:

refactor(chatbot): unify keywordFinish type and enhance session handling
https://github.com/EvolutionAPI/evolution-api/commit/f9567fbeaa05d19911991d86679be5575806cc79 


Related to issues:
Status de alteração do Typebot
https://github.com/EvolutionAPI/evolution-api/issues/1382

Update Typebot Status (http request) session closed or deleted
https://github.com/EvolutionAPI/evolution-api/issues/1390

## Summary by Sourcery

Integrate TYPEBOT_CHANGE_STATUS webhook events into the chatbot flow by emitting session status changes (opened, closed, deleted, paused) from both the Typebot service and the base controller.

New Features:
- Emit TYPEBOT_CHANGE_STATUS webhook from TypebotService on session open, close, delete, and finish actions
- Forward TYPEBOT_CHANGE_STATUS webhook from BaseChatbotController for Typebot when handling delete and paused statuses