### PR TITLE
fix: allowing the chatbot return after the time expires and after human interaction (stopBotFromMe)

### DIFF
--- a/src/api/integrations/chatbot/base-chatbot.controller.ts
+++ b/src/api/integrations/chatbot/base-chatbot.controller.ts
@@ -878,7 +878,7 @@ export abstract class BaseChatbotController<BotType = any, BotData extends BaseC
       // Skip if session exists but not awaiting user input
       if (session && session.status === 'closed') {
         return;
-      }      
+      }
 
       // Merged settings
       const mergedSettings = {

--- a/src/api/integrations/chatbot/base-chatbot.controller.ts
+++ b/src/api/integrations/chatbot/base-chatbot.controller.ts
@@ -878,13 +878,7 @@ export abstract class BaseChatbotController<BotType = any, BotData extends BaseC
       // Skip if session exists but not awaiting user input
       if (session && session.status === 'closed') {
         return;
-      }
-
-      // Skip if session exists and status is paused
-      if (session && session.status === 'paused') {
-        this.logger.warn(`Session for ${remoteJid} is paused, skipping message processing`);
-        return;
-      }
+      }      
 
       // Merged settings
       const mergedSettings = {


### PR DESCRIPTION
**Does not return the chatbot after it is paused when human interaction occurs (stopBotFromMe)**

* Problem started from the commit of the issue below:

fix: ajuste na validacao dos bots e pausar sessao
https://github.com/EvolutionAPI/evolution-api/pull/1599

---

* It may fix the following issues:

Baileys Instance with TypeBot integration stop working after "Expire in minutes" has reached.
https://github.com/EvolutionAPI/evolution-api/issues/1654

O tempo de expiração da API de evolução não funciona
https://github.com/EvolutionAPI/evolution-api/issues/1260

## Summary by Sourcery

Remove skip logic for paused chatbot sessions to allow the bot to resume after session expiration or human interaction

Bug Fixes:
- Allow chatbot to process messages again after a session is paused rather than permanently skipping
- Restore bot functionality after expiration time is reached, fixing TypeBot/Baileys integration issue
- Fix evolution API session expiration logic so timeout works as intended