### PR TITLE
fix: convert mediaKey from media messages to avoid bad decrypt errors

### DIFF
--- a/src/api/integrations/channel/whatsapp/whatsapp.baileys.service.ts
+++ b/src/api/integrations/channel/whatsapp/whatsapp.baileys.service.ts
@@ -3601,7 +3601,7 @@ export class BaileysStartupService extends ChannelStartupService {
       }
 
       if (typeof mediaMessage['mediaKey'] === 'object') {
-        msg.message = JSON.parse(JSON.stringify(msg.message));
+        msg.message[mediaType].mediaKey = Uint8Array.from(Object.values(mediaMessage['mediaKey']));
       }
 
       let buffer: Buffer;


### PR DESCRIPTION
Calling baileys downloadMediaMessage or downloadContentFromMessage with parameter "mediaKey" with an object will fail.

## Summary by Sourcery

Bug Fixes:
- Convert mediaKey from object to Uint8Array before media download to prevent bad decrypt errors