### PR TITLE
Fix/Adjust remote message key handling in WhatsApp service to include alternative JID

### DIFF
--- a/src/api/integrations/channel/whatsapp/whatsapp.baileys.service.ts
+++ b/src/api/integrations/channel/whatsapp/whatsapp.baileys.service.ts
@@ -1349,6 +1349,10 @@ export class BaileysStartupService extends ChannelStartupService {
             }
           }
 
+          if (messageRaw.key.remoteJid?.includes('@lid') && messageRaw.key.remoteJidAlt) {
+            messageRaw.key.remoteJid = messageRaw.key.remoteJidAlt;
+          }
+
           this.logger.log(messageRaw);
 
           this.sendDataWebhook(Events.MESSAGES_UPSERT, messageRaw);


### PR DESCRIPTION
The 'messages.upsert' event handler was not correctly handling the 'remoteJid' for messages that contained an alternative identifier ('remoteJidAlt'), such as those from LIDs ('@lid'). This resulted in webhooks being sent and internal processing using a temporary JID instead of the user's real JID.

The logic to replace 'remoteJid' with 'remoteJidAlt' already existed in the 'messages.update' handler but was missing from 'messages.upsert'.

This commit introduces a check in the 'messages.upsert' flow. After the message is prepared, the code now checks if the 'remoteJid' contains '@lid' and if 'remoteJidAlt' is present. If both are true, the 'remoteJid' of the message object ('messageRaw') is updated before being sent to webhooks, logs, and the chatbot controller.

This ensures consistency in JID handling across the application, guaranteeing that the correct contact identifier is used in all processing flows.

## Summary by Sourcery

Bug Fixes:
- Handle alternative JID in messages.upsert by replacing temporary '@lid' remoteJid with remoteJidAlt before webhooks and processing