### PR TITLE
fix(docker): change private image to public image in docker-compose

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -3,7 +3,7 @@ version: "3.8"
 services:
   api:
     container_name: evolution_api
-    image: evolution/api:metrics
+    image: evoapicloud/evolution-api:latest
     restart: always
     depends_on:
       - redis


### PR DESCRIPTION
## 📋 Description
Changed the service image from a private registry to a public one so the project can run without authentication issues.

## 🧪 Type of Change
<!-- Mark with an `x` all the checkboxes that apply -->
- [ x ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔧 Refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] 🧹 Code cleanup
- [ ] 🔒 Security fix


## ✅ Checklist
<!-- Mark with an `x` all the checkboxes that apply -->
- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have manually tested my changes thoroughly
- [ x ] I have verified the changes work with different scenarios
- [ ] Any dependent changes have been merged and published

## Summary by Sourcery

Bug Fixes:
- Switch the api service image from evolution/api:metrics to evoapicloud/evolution-api:latest