### PR TITLE
feat: convert LID to phoneNumber on GROUP_PARTICIPANTS_UPDATE webhook

### DIFF
--- a/src/api/integrations/channel/whatsapp/whatsapp.baileys.service.ts
+++ b/src/api/integrations/channel/whatsapp/whatsapp.baileys.service.ts
@@ -500,8 +500,8 @@ export class BaileysStartupService extends ChannelStartupService {
     try {
       // Use raw SQL to avoid JSON path issues
       const webMessageInfo = (await this.prismaRepository.$queryRaw`
-        SELECT * FROM "Message" 
-        WHERE "instanceId" = ${this.instanceId} 
+        SELECT * FROM "Message"
+        WHERE "instanceId" = ${this.instanceId}
         AND "key"->>'id' = ${key.id}
       `) as proto.IWebMessageInfo[];
 
@@ -1491,8 +1491,8 @@ export class BaileysStartupService extends ChannelStartupService {
           if (configDatabaseData.HISTORIC || configDatabaseData.NEW_MESSAGE) {
             // Use raw SQL to avoid JSON path issues
             const messages = (await this.prismaRepository.$queryRaw`
-              SELECT * FROM "Message" 
-              WHERE "instanceId" = ${this.instanceId} 
+              SELECT * FROM "Message"
+              WHERE "instanceId" = ${this.instanceId}
               AND "key"->>'id' = ${key.id}
               LIMIT 1
             `) as any[];
@@ -1600,33 +1600,33 @@ export class BaileysStartupService extends ChannelStartupService {
       // MAINTAINS: participants: string[] (original JID strings)
       // ADDS: participantsData: { jid: string, phoneNumber: string, name?: string, imgUrl?: string }[]
       // This enables LID to phoneNumber conversion without breaking existing webhook consumers
-      
+
       // Helper to normalize participantId as phone number
       const normalizePhoneNumber = (id: string): string => {
         // Remove @lid, @s.whatsapp.net suffixes and extract just the number part
         return id.split('@')[0];
       };
-      
+
       try {
-        // Usa o mesmo método que o endpoint /group/participants 
+        // Usa o mesmo método que o endpoint /group/participants
         const groupParticipants = await this.findParticipants({ groupJid: participantsUpdate.id });
-        
+
         // Validação para garantir que temos dados válidos
         if (!groupParticipants?.participants || !Array.isArray(groupParticipants.participants)) {
           throw new Error('Invalid participant data received from findParticipants');
         }
-        
+
         // Filtra apenas os participantes que estão no evento
         const resolvedParticipants = participantsUpdate.participants.map((participantId) => {
-          const participantData = groupParticipants.participants.find(p => p.id === participantId);
-          
+          const participantData = groupParticipants.participants.find((p) => p.id === participantId);
+
           let phoneNumber: string;
           if (participantData?.phoneNumber) {
             phoneNumber = participantData.phoneNumber;
           } else {
             phoneNumber = normalizePhoneNumber(participantId);
           }
-          
+
           return {
             jid: participantId,
             phoneNumber,
@@ -1639,13 +1639,14 @@ export class BaileysStartupService extends ChannelStartupService {
         const enhancedParticipantsUpdate = {
           ...participantsUpdate,
           participants: participantsUpdate.participants, // Mantém array original de strings
-          participantsData: resolvedParticipants // Adiciona dados resolvidos em campo separado
+          // Adiciona dados resolvidos em campo separado
+          participantsData: resolvedParticipants,
         };
-        
+
         this.sendDataWebhook(Events.GROUP_PARTICIPANTS_UPDATE, enhancedParticipantsUpdate);
       } catch (error) {
         this.logger.error(
-          `Failed to resolve participant data for GROUP_PARTICIPANTS_UPDATE webhook: ${error.message} | Group: ${participantsUpdate.id} | Participants: ${participantsUpdate.participants.length}`
+          `Failed to resolve participant data for GROUP_PARTICIPANTS_UPDATE webhook: ${error.message} | Group: ${participantsUpdate.id} | Participants: ${participantsUpdate.participants.length}`,
         );
         // Fallback - envia sem conversão
         this.sendDataWebhook(Events.GROUP_PARTICIPANTS_UPDATE, participantsUpdate);
@@ -4514,7 +4515,7 @@ export class BaileysStartupService extends ChannelStartupService {
 
     // Use raw SQL to avoid JSON path issues
     const result = await this.prismaRepository.$executeRaw`
-      UPDATE "Message" 
+      UPDATE "Message"
       SET "status" = ${status[4]}
       WHERE "instanceId" = ${this.instanceId}
       AND "key"->>'remoteJid' = ${remoteJid}
@@ -4539,7 +4540,7 @@ export class BaileysStartupService extends ChannelStartupService {
       this.prismaRepository.chat.findFirst({ where: { remoteJid } }),
       // Use raw SQL to avoid JSON path issues
       this.prismaRepository.$queryRaw`
-        SELECT COUNT(*)::int as count FROM "Message" 
+        SELECT COUNT(*)::int as count FROM "Message"
         WHERE "instanceId" = ${this.instanceId}
         AND "key"->>'remoteJid' = ${remoteJid}
         AND ("key"->>'fromMe')::boolean = false


### PR DESCRIPTION
## 📋 Description
## Summary
  This PR enhances the `GROUP_PARTICIPANTS_UPDATE` -> add - webhook to properly
  convert LID (Local Identifier) values to real phone numbers, ensuring
   consistency with the existing `/group/participants` endpoint
  behavior.

  ## Problem
  Currently, when the `GROUP_PARTICIPANTS_UPDATE` webhook is triggered,
   participants with LID identifiers return the raw LID value instead
  of the actual phone number:

  **Before:**
  json
  {
    "jid": "131159895875721@lid",
    "phoneNumber": "131159895875721@lid"
  }

  Solution

  The webhook now uses the same logic as the /group/participants
  endpoint to resolve LID values to actual phone numbers:

  After:
  {
    "jid": "131159895875721@lid",
    "phoneNumber": "5511965525438@s.whatsapp.net"
  }

  Changes Made

  - Enhanced GROUP_PARTICIPANTS_UPDATE webhook handler to call
  findParticipants() method
  - Added proper LID to phone number conversion using existing group
  metadata
  - Maintained backward compatibility for normal JID formats
  - Added fallback mechanism in case of conversion errors

  Testing

  - Webhook correctly handles normal JID participants
  - Webhook properly converts LID participants to real phone numbers
  - Existing /group/participants endpoint remains unaffected
  - Error handling works correctly with fallback to original data

PS: This solves my biggest problem around here on group entrances, but i don't know if it's the best approach.

## 🧪 Type of Change
<!-- Mark with an `x` all the checkboxes that apply -->
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔧 Refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] 🧹 Code cleanup
- [ ] 🔒 Security fix

## 🧪 Testing
<!-- Describe the testing you performed to verify your changes -->
- [x] Manual testing completed
- [ ] Functionality verified in development environment
- [ ] No breaking changes introduced
- [ ] Tested with different connection types (if applicable)

## 📸 Screenshots (if applicable)
<!-- Add screenshots to help explain your changes -->

## ✅ Checklist
<!-- Mark with an `x` all the checkboxes that apply -->
- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have manually tested my changes thoroughly
- [ ] I have verified the changes work with different scenarios
- [ ] Any dependent changes have been merged and published

## 📝 Additional Notes
PS: This solves my biggest problem around here on group entrances, but i don't know if it's the best approach.

## Summary by Sourcery

Enhance the GROUP_PARTICIPANTS_UPDATE webhook handler to fetch full participant metadata, convert LID identifiers to real phone numbers, and include name and image URL fields, while preserving backward compatibility and adding an error fallback.

New Features:
- Resolve local participant identifiers (LIDs) to actual phone numbers in GROUP_PARTICIPANTS_UPDATE webhook payloads
- Populate participant name and image URL in the GROUP_PARTICIPANTS_UPDATE webhook

Bug Fixes:
- Fix phoneNumber field returning raw LID instead of real number

Enhancements:
- Maintain backward compatibility for non-LID JIDs
- Add fallback to original payload on lookup errors