### PR TITLE
fix/media content validation

### DIFF
--- a/src/api/integrations/channel/whatsapp/whatsapp.baileys.service.ts
+++ b/src/api/integrations/channel/whatsapp/whatsapp.baileys.service.ts
@@ -3676,7 +3676,10 @@ export class BaileysStartupService extends ChannelStartupService {
         }
       }
 
-      if ('messageContextInfo' in msg.message && Object.keys(msg.message).length === 1) {
+      if (
+        Object.keys(msg.message).length === 1 &&
+        Object.prototype.hasOwnProperty.call(msg.message, 'messageContextInfo')
+      ) {
         throw 'The message is messageContextInfo';
       }
 

--- a/src/api/services/channel.service.ts
+++ b/src/api/services/channel.service.ts
@@ -826,7 +826,7 @@ export class ChannelStartupService {
     const msg = message.message;
 
     // Se só tem messageContextInfo, não é mídia válida
-    if (Object.keys(msg).length === 1 && 'messageContextInfo' in msg) {
+    if (Object.keys(msg).length === 1 && Object.prototype.hasOwnProperty.call(msg, 'messageContextInfo')) {
       return false;
     }
 


### PR DESCRIPTION
## 📋 Description
Replaces a direct `'messageContextInfo' in msg.message` check with a safer `Object.prototype.hasOwnProperty.call()` check.

This change ensures the check does not fail in rare scenarios where the `in` operator might behave unexpectedly due to object inheritance or prototype shadowing. It's a more robust and explicit way to check for an own property on the object.

This prevents false positives when validating if a message contains only `messageContextInfo`.

## 🧪 Type of Change
<!-- Mark with an `x` all the checkboxes that apply -->
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [x] 🔧 Refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] 🧹 Code cleanup
- [ ] 🔒 Security fix

## 🧪 Testing
<!-- Describe the testing you performed to verify your changes -->
- [x] Manual testing completed
- [x] Functionality verified in development environment
- [x] No breaking changes introduced
- [ ] Tested with different connection types (if applicable)

## 📸 Screenshots (if applicable)
<!-- Add screenshots to help explain your changes -->

## ✅ Checklist
<!-- Mark with an `x` all the checkboxes that apply -->
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have manually tested my changes thoroughly
- [x] I have verified the changes work with different scenarios
- [ ] Any dependent changes have been merged and published

## Summary by Sourcery

Improve the robustness of media content validation by replacing the use of the `in` operator with `Object.prototype.hasOwnProperty.call` for checking `messageContextInfo` presence, preventing false positives due to prototype inheritance issues.

Bug Fixes:
- Avoid treating messages that only contain `messageContextInfo` as valid media content

Enhancements:
- Replace `'messageContextInfo' in msg.message` checks with `hasOwnProperty.call` in WhatsApp and channel services