### PR TITLE
Adiciona migração para corrigir índice UNIQUE da tabela Label (#1)

### DIFF
--- a/prisma/postgresql-migrations/20251028000000_fix_label_unique_index.sql/migration.sql
+++ b/prisma/postgresql-migrations/20251028000000_fix_label_unique_index.sql/migration.sql
@@ -1,0 +1,8 @@
+-- SQL para corrigir a duplicidade e/ou problema de nome do índice na tabela "Label"
+-- 1. DROP (se existir): Garante que a operação de criação na linha 2 não falhe.
+DROP INDEX IF EXISTS "Label_labelId_instanceId_key";
+
+-- 2. CREATE UNIQUE INDEX: Recria o índice exatamente como esperado pela API.
+CREATE UNIQUE INDEX "Label_labelId_instanceId_key" ON "Label"("labelId", "instanceId");
+
+-- O comando DELETE executado anteriormente limpou os dados, então a criação do UNIQUE não terá erro de duplicidade de dados.


### PR DESCRIPTION
fix(postgres): Adiciona migração para corrigir índice UNIQUE da tabela Label
fix(postgres): Corrige índice UNIQUE em Label para resolver erro 42P10 (relacionado à Issue #1904)

## 📋 Description
<!-- Describe your changes in detail -->
Nova migração postgres para corrigir erro

## 🔗 Related Issue
<!-- Link to the issue this PR addresses -->
Closes #(issue_number)

## 🧪 Type of Change
<!-- Mark with an `x` all the checkboxes that apply -->
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔧 Refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] 🧹 Code cleanup
- [ ] 🔒 Security fix

## 🧪 Testing
<!-- Describe the testing you performed to verify your changes -->
- [x] Manual testing completed
- [ ] Functionality verified in development environment
- [ ] No breaking changes introduced
- [ ] Tested with different connection types (if applicable)

## 📸 Screenshots (if applicable)
<!-- Add screenshots to help explain your changes -->

## ✅ Checklist
<!-- Mark with an `x` all the checkboxes that apply -->
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have manually tested my changes thoroughly
- [x] I have verified the changes work with different scenarios
- [x] Any dependent changes have been merged and published

## 📝 Additional Notes
<!-- Any additional information, concerns, or questions -->
fix(postgres): Corrige índice UNIQUE em Label para resolver erro 42P10 (relacionado à Issue #1904)

## Summary by Sourcery

Bug Fixes:
- Introduce a new SQL migration that drops the existing Label_labelId_instanceId_key index if it exists and recreates it as a UNIQUE index on (labelId, instanceId)