### PR TITLE
fix(core): Prevent crash in cleanMessageData on null message

### DIFF
--- a/src/api/services/channel.service.ts
+++ b/src/api/services/channel.service.ts
@@ -535,11 +535,10 @@ export class ChannelStartupService {
 
     const cleanedMessage = { ...message };
 
-    const mediaUrl = cleanedMessage.message.mediaUrl;
-
-    delete cleanedMessage.message.base64;
-
     if (cleanedMessage.message) {
+      const mediaUrl = cleanedMessage.message.mediaUrl;
+      delete cleanedMessage.message.base64;
+
       // Limpa imageMessage
       if (cleanedMessage.message.imageMessage) {
         cleanedMessage.message.imageMessage = {
@@ -581,9 +580,9 @@ export class ChannelStartupService {
           name: cleanedMessage.message.documentWithCaptionMessage.name,
         };
       }
-    }
 
-    if (mediaUrl) cleanedMessage.message.mediaUrl = mediaUrl;
+      if (mediaUrl) cleanedMessage.message.mediaUrl = mediaUrl;
+    }
 
     return cleanedMessage;
   }


### PR DESCRIPTION
## 📋 Description
Modificação simples que previne erros de acesso à propriedades não definidas de objetos, que interrompem o fluxo do /chat/findChats e fazem com o que os chats no manager não sejam carregados.

Resolve esses erros:
- No manager, acessando os chats da instancia: 'The application is taking longer than expected to load, please try again in a few minutes.'
- /chat/findChats: Cannot read properties of null (reading 'mediaUrl')
- /chat/findChats: Cannot convert undefined or null to object

## 🔗 Related Issue
Closes #2058 

## 🧪 Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔧 Refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [x] 🧹 Code cleanup
- [ ] 🔒 Security fix

## 🧪 Testing
- [x] Manual testing completed
- [x] Functionality verified in development environment
- [x] No breaking changes introduced
- [ ] Tested with different connection types (if applicable)

## ✅ Checklist
<!-- Mark with an `x` all the checkboxes that apply -->
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have manually tested my changes thoroughly
- [x] I have verified the changes work with different scenarios
- [x] Any dependent changes have been merged and published

## Summary by Sourcery

Bug Fixes:
- Add null check around cleanedMessage.message to avoid reading mediaUrl and base64 on null, fixing crashes in /chat/findChats and chat manager.