### PR TITLE
fix: Erro ao enviar mensagem para grupos (remoteJid failed constraint)

### DIFF
--- a/src/utils/onWhatsappCache.ts
+++ b/src/utils/onWhatsappCache.ts
@@ -65,78 +65,112 @@ interface ISaveOnWhatsappCacheParams {
   lid?: 'lid' | undefined;
 }
 
+function normalizeJid(jid: string | null | undefined): string | null {
+  if (!jid) return null;
+  return jid.startsWith('+') ? jid.slice(1) : jid;
+}
+
 export async function saveOnWhatsappCache(data: ISaveOnWhatsappCacheParams[]) {
-  if (configService.get<Database>('DATABASE').SAVE_DATA.IS_ON_WHATSAPP) {
-    for (const item of data) {
-      const remoteJid = item.remoteJid.startsWith('+') ? item.remoteJid.slice(1) : item.remoteJid;
+  if (!configService.get<Database>('DATABASE').SAVE_DATA.IS_ON_WHATSAPP) {
+    return;
+  }
 
-      // TODO: Buscar registro existente PRIMEIRO para preservar dados
-      const allJids = [remoteJid];
-
-      const altJid =
-        item.remoteJidAlt && item.remoteJidAlt.includes('@lid')
-          ? item.remoteJidAlt.startsWith('+')
-            ? item.remoteJidAlt.slice(1)
-            : item.remoteJidAlt
-          : null;
-
-      if (altJid) {
-        allJids.push(altJid);
+  // Processa todos os itens em paralelo para melhor performance
+  const processingPromises = data.map(async (item) => {
+    try {
+      const remoteJid = normalizeJid(item.remoteJid);
+      if (!remoteJid) {
+        logger.warn('[saveOnWhatsappCache] Item skipped, missing remoteJid.');
+        return;
       }
 
-      const expandedJids = allJids.flatMap((jid) => getAvailableNumbers(jid));
+      const altJidNormalized = normalizeJid(item.remoteJidAlt);
+      const lidAltJid = (altJidNormalized && altJidNormalized.includes('@lid')) ? altJidNormalized : null;
 
+      const baseJids = [remoteJid]; // Garante que o remoteJid esteja na lista inicial
+      if (lidAltJid) {
+        baseJids.push(lidAltJid);
+      }
+
+      const expandedJids = baseJids.flatMap((jid) => getAvailableNumbers(jid));
+
+      // 1. Busca entrada por jidOptions e também remoteJid
+      // Às vezes acontece do remoteJid atual NÃO ESTAR no jidOptions ainda, ocasionando o erro:
+      // 'Unique constraint failed on the fields: (`remoteJid`)'
+      // Isso acontece principalmente em grupos que possuem o número do criador no ID (ex.: '559911223345-1234567890@g.us')
       const existingRecord = await prismaRepository.isOnWhatsapp.findFirst({
         where: {
-          OR: expandedJids.map((jid) => ({ jidOptions: { contains: jid } })),
+          OR: [
+            ...expandedJids.map((jid) => ({ jidOptions: { contains: jid } })),
+            { remoteJid: remoteJid }, // TODO: Descobrir o motivo que causa o remoteJid não estar (às vezes) incluso na lista de jidOptions
+          ],
         },
       });
 
-      logger.verbose(`Register exists: ${existingRecord ? existingRecord.remoteJid : 'não not found'}`);
+      logger.verbose(`[saveOnWhatsappCache] Register exists for [${expandedJids.join(",")}]? => ${existingRecord ? existingRecord.remoteJid : 'Not found'}`);
+      
+      // 2. Unifica todos os JIDs usando um Set para garantir valores únicos
+      const finalJidOptions = new Set(expandedJids);
 
-      const finalJidOptions = [...expandedJids];
-
+      if (lidAltJid) {
+        finalJidOptions.add(lidAltJid);
+      }
+      
       if (existingRecord?.jidOptions) {
-        const existingJids = existingRecord.jidOptions.split(',');
-        // TODO: Adicionar JIDs existentes que não estão na lista atual
-        existingJids.forEach((jid) => {
-          if (!finalJidOptions.includes(jid)) {
-            finalJidOptions.push(jid);
-          }
-        });
+        existingRecord.jidOptions.split(',').forEach(jid => finalJidOptions.add(jid));
       }
 
-      // TODO: Se tiver remoteJidAlt com @lid novo, adicionar
-      if (altJid && !finalJidOptions.includes(altJid)) {
-        finalJidOptions.push(altJid);
-      }
+      // 3. Prepara o payload final
+      // Ordena os JIDs para garantir consistência na string final
+      const sortedJidOptions = [...finalJidOptions].sort();
+      const newJidOptionsString = sortedJidOptions.join(',');
+      const newLid = item.lid === 'lid' || item.remoteJid?.includes('@lid') ? 'lid' : null;
 
-      const uniqueNumbers = Array.from(new Set(finalJidOptions));
+      const dataPayload = {
+        remoteJid: remoteJid,
+        jidOptions: newJidOptionsString,
+        lid: newLid,
+      };
 
-      logger.verbose(
-        `Saving: remoteJid=${remoteJid}, jidOptions=${uniqueNumbers.join(',')}, lid=${item.lid === 'lid' || item.remoteJid?.includes('@lid') ? 'lid' : null}`,
-      );
-
+      // 4. Decide entre Criar ou Atualizar
       if (existingRecord) {
+        // Compara a string de JIDs ordenada existente com a nova
+        const existingJidOptionsString = existingRecord.jidOptions 
+          ? existingRecord.jidOptions.split(',').sort().join(',') 
+          : '';
+
+        const isDataSame = existingRecord.remoteJid === dataPayload.remoteJid &&
+                           existingJidOptionsString === dataPayload.jidOptions &&
+                           existingRecord.lid === dataPayload.lid;
+
+        if (isDataSame) {
+          logger.verbose(`[saveOnWhatsappCache] Data for ${remoteJid} is already up-to-date. Skipping update.`);
+          return; // Pula para o próximo item
+        }
+        
+        // Os dados são diferentes, então atualiza
+        logger.verbose(`[saveOnWhatsappCache] Register exists, updating: remoteJid=${remoteJid}, jidOptions=${dataPayload.jidOptions}, lid=${dataPayload.lid}`);
         await prismaRepository.isOnWhatsapp.update({
           where: { id: existingRecord.id },
-          data: {
-            remoteJid: remoteJid,
-            jidOptions: uniqueNumbers.join(','),
-            lid: item.lid === 'lid' || item.remoteJid?.includes('@lid') ? 'lid' : null,
-          },
+          data: dataPayload,
         });
+
       } else {
+        // Cria nova entrada
+        logger.verbose(`[saveOnWhatsappCache] Register does not exist, creating: remoteJid=${remoteJid}, jidOptions=${dataPayload.jidOptions}, lid=${dataPayload.lid}`);
         await prismaRepository.isOnWhatsapp.create({
-          data: {
-            remoteJid: remoteJid,
-            jidOptions: uniqueNumbers.join(','),
-            lid: item.lid === 'lid' || item.remoteJid?.includes('@lid') ? 'lid' : null,
-          },
+          data: dataPayload,
         });
       }
+
+    } catch (e) {
+      // Loga o erro mas não para a execução dos outros promises
+      logger.error(`[saveOnWhatsappCache] Error processing item for ${item.remoteJid}: `, e);
     }
-  }
+  });
+
+  // Espera todas as operações paralelas terminarem
+  await Promise.allSettled(processingPromises);
 }
 
 export async function getOnWhatsappCache(remoteJids: string[]) {


### PR DESCRIPTION
## 📋 Description

O objetivo principal destas modificações é corrigir o problema das mensagens não serem enviadas para alguns grupos, principalmente os que tem o número do criador no jid (ex.: '559911223345-1234567890@g.us').

A interrupção no fluxo do request é causada por um erro ao tentar criar um novo registro na base de dados com um remoteJid já existente, isto acontece pois os registros são buscados utilizando apenas o jidOptions, que às vezes não tem o atual remoteJid na lista.

O erro em questão:

```js
Invalid `prismaRepository.isOnWhatsapp.create()` invocation in
evolution-api/src/utils/onWhatsappCache.ts:130:45
n
  127     },
  128   });
  129 } else {
→ 130   await prismaRepository.isOnWhatsapp.create(
Unique constraint failed on the fields: (`remoteJid`)
```

Os dados diretamente na base de dados, mostrando que o remoteJid não estava no jidOptions:
```
SELECT * FROM "IsOnWhatsapp" WHERE "remoteJid" = '554212345678-1625864928@g.us';
            id             |          remoteJid           |                        jidOptions                         |        createdAt        |       updatedAt        | lid
---------------------------+------------------------------+-----------------------------------------------------------+-------------------------+------------------------+-----
 cm...ok525sz | 554212345678-1625864928@g.us | 5542998558888-1625864928@g.us,55428558888-1625864928@g.us | 2025-10-19 13:40:08.508 | 2025-10-21 15:49:53.21 |
```

A lógica de busca foi alterada para prevenir erros de 'Unique constraint failed'. 
Para corrigir isso, a busca no banco agora usa `OR` para verificar tanto pelo `jidOptions` quanto pelo `remoteJid` em uma única query.

Além dessa correção, outras otimizações foram implementadas:

1.  **Updates Desnecessários**: A função agora compara os dados novos com os dados do 'existingRecord'. O `update` só é executado se houver de fato uma mudança, reduzindo escritas desnecessárias no banco.
2.  **Processamento Paralelo**: A iteração sequencial (`for...of`) foi substituída por `Promise.allSettled`, permitindo que todos os itens do array `data` sejam processados em paralelo.
3.  **Consistência de Dados**: Os JIDs em `jidOptions` agora são ordenados antes de serem salvos ou comparados. Isso garante que a verificação de "mudança" seja precisa, independentemente da ordem de inserção.
4.  **Refactor**: A lógica de unificação de JIDs foi simplificada para usar `Set` e um helper `normalizeJid` foi criado para limpar o código. O código foi envolto em um try-catch para evitar interrupção do fluxo de envio de mensagens, visto que o cache não é crítico.

## 🧪 Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔧 Refactoring (no functional changes)
- [x] ⚡ Performance improvement
- [x] 🧹 Code cleanup
- [ ] 🔒 Security fix

## 🧪 Testing
- [x] Manual testing completed
- [x] Functionality verified in development environment
- [x] No breaking changes introduced
- [x] Tested with different connection types (if applicable)

## ✅ Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have manually tested my changes thoroughly
- [x] I have verified the changes work with different scenarios
- [x] Any dependent changes have been merged and published

## 📝 Additional Notes
TODO: Investigar a causa raiz de o remoteJid às vezes não estar no jidOptions no momento da busca inicial. Também notei na base de dados que alguns números estão vindo com o "@g.us" duplicado.

## Summary by Sourcery

Fix cache save errors for WhatsApp group messages and optimize saveOnWhatsappCache

Bug Fixes:
- Prevent unique constraint failure by querying cache entries against both jidOptions and remoteJid

Enhancements:
- Normalize and sort JIDs to ensure consistent cache entries
- Process cache updates in parallel using Promise.allSettled
- Compare new and existing records to skip unnecessary database writes

Chores:
- Extract normalizeJid helper and encapsulate processing in try-catch for resilience
- Exit early when caching is disabled via configuration