### PR TITLE
Feat/update and delete meta templates

### DIFF
--- a/src/api/controllers/template.controller.ts
+++ b/src/api/controllers/template.controller.ts
@@ -12,4 +12,15 @@ export class TemplateController {
   public async findTemplate(instance: InstanceDto) {
     return this.templateService.find(instance);
   }
+
+  public async editTemplate(
+    instance: InstanceDto,
+    data: { templateId: string; category?: string; components?: any; allowCategoryChange?: boolean; ttl?: number },
+  ) {
+    return this.templateService.edit(instance, data);
+  }
+
+  public async deleteTemplate(instance: InstanceDto, data: { name: string; hsmId?: string }) {
+    return this.templateService.delete(instance, data);
+  }
 }

--- a/src/api/dto/template.dto.ts
+++ b/src/api/dto/template.dto.ts
@@ -6,3 +6,16 @@ export class TemplateDto {
   components: any;
   webhookUrl?: string;
 }
+
+export class TemplateEditDto {
+  templateId: string;
+  category?: 'AUTHENTICATION' | 'MARKETING' | 'UTILITY';
+  allowCategoryChange?: boolean;
+  ttl?: number;
+  components?: any;
+}
+
+export class TemplateDeleteDto {
+  name: string;
+  hsmId?: string;
+}

--- a/src/api/integrations/channel/whatsapp/whatsapp.baileys.service.ts
+++ b/src/api/integrations/channel/whatsapp/whatsapp.baileys.service.ts
@@ -82,7 +82,7 @@ import { createId as cuid } from '@paralleldrive/cuid2';
 import { Instance, Message } from '@prisma/client';
 import { createJid } from '@utils/createJid';
 import { fetchLatestWaWebVersion } from '@utils/fetchLatestWaWebVersion';
-import {makeProxyAgent, makeProxyAgentUndici} from '@utils/makeProxyAgent';
+import { makeProxyAgent, makeProxyAgentUndici } from '@utils/makeProxyAgent';
 import { getOnWhatsappCache, saveOnWhatsappCache } from '@utils/onWhatsappCache';
 import { status } from '@utils/renderStatus';
 import { sendTelemetry } from '@utils/sendTelemetry';

--- a/src/api/routes/template.router.ts
+++ b/src/api/routes/template.router.ts
@@ -1,9 +1,11 @@
 import { RouterBroker } from '@api/abstract/abstract.router';
 import { InstanceDto } from '@api/dto/instance.dto';
-import { TemplateDto } from '@api/dto/template.dto';
+import { TemplateDeleteDto, TemplateDto, TemplateEditDto } from '@api/dto/template.dto';
 import { templateController } from '@api/server.module';
 import { ConfigService } from '@config/env.config';
 import { createMetaErrorResponse } from '@utils/errorResponse';
+import { templateDeleteSchema } from '@validate/templateDelete.schema';
+import { templateEditSchema } from '@validate/templateEdit.schema';
 import { instanceSchema, templateSchema } from '@validate/validate.schema';
 import { RequestHandler, Router } from 'express';
 
@@ -32,6 +34,38 @@ export class TemplateRouter extends RouterBroker {
 
           // Use utility function to create standardized error response
           const errorResponse = createMetaErrorResponse(error, 'template_creation');
+          res.status(errorResponse.status).json(errorResponse);
+        }
+      })
+      .post(this.routerPath('edit'), ...guards, async (req, res) => {
+        try {
+          const response = await this.dataValidate<TemplateEditDto>({
+            request: req,
+            schema: templateEditSchema,
+            ClassRef: TemplateEditDto,
+            execute: (instance, data) => templateController.editTemplate(instance, data),
+          });
+
+          res.status(HttpStatus.OK).json(response);
+        } catch (error) {
+          console.error('Template edit error:', error);
+          const errorResponse = createMetaErrorResponse(error, 'template_edit');
+          res.status(errorResponse.status).json(errorResponse);
+        }
+      })
+      .delete(this.routerPath('delete'), ...guards, async (req, res) => {
+        try {
+          const response = await this.dataValidate<TemplateDeleteDto>({
+            request: req,
+            schema: templateDeleteSchema,
+            ClassRef: TemplateDeleteDto,
+            execute: (instance, data) => templateController.deleteTemplate(instance, data),
+          });
+
+          res.status(HttpStatus.OK).json(response);
+        } catch (error) {
+          console.error('Template delete error:', error);
+          const errorResponse = createMetaErrorResponse(error, 'template_delete');
           res.status(errorResponse.status).json(errorResponse);
         }
       })

--- a/src/api/services/template.service.ts
+++ b/src/api/services/template.service.ts
@@ -88,6 +88,77 @@ export class TemplateService {
     }
   }
 
+  public async edit(
+    instance: InstanceDto,
+    data: { templateId: string; category?: string; components?: any; allowCategoryChange?: boolean; ttl?: number },
+  ) {
+    const getInstance = await this.waMonitor.waInstances[instance.instanceName].instance;
+    if (!getInstance) {
+      throw new Error('Instance not found');
+    }
+
+    this.businessId = getInstance.businessId;
+    this.token = getInstance.token;
+
+    const payload: Record<string, unknown> = {};
+    if (typeof data.category === 'string') payload.category = data.category;
+    if (typeof data.allowCategoryChange === 'boolean') payload.allow_category_change = data.allowCategoryChange;
+    if (typeof data.ttl === 'number') payload.time_to_live = data.ttl;
+    if (data.components) payload.components = data.components;
+
+    const response = await this.requestEditTemplate(data.templateId, payload);
+
+    if (!response || response.error) {
+      if (response && response.error) {
+        const metaError = new Error(response.error.message || 'WhatsApp API Error');
+        (metaError as any).template = response.error;
+        throw metaError;
+      }
+      throw new Error('Error to edit template');
+    }
+
+    return response;
+  }
+
+  public async delete(instance: InstanceDto, data: { name: string; hsmId?: string }) {
+    const getInstance = await this.waMonitor.waInstances[instance.instanceName].instance;
+    if (!getInstance) {
+      throw new Error('Instance not found');
+    }
+
+    this.businessId = getInstance.businessId;
+    this.token = getInstance.token;
+
+    const response = await this.requestDeleteTemplate({ name: data.name, hsm_id: data.hsmId });
+
+    if (!response || response.error) {
+      if (response && response.error) {
+        const metaError = new Error(response.error.message || 'WhatsApp API Error');
+        (metaError as any).template = response.error;
+        throw metaError;
+      }
+      throw new Error('Error to delete template');
+    }
+
+    try {
+      // Best-effort local cleanup of stored template metadata
+      await this.prismaRepository.template.deleteMany({
+        where: {
+          OR: [
+            { name: data.name, instanceId: getInstance.id },
+            data.hsmId ? { templateId: data.hsmId, instanceId: getInstance.id } : undefined,
+          ].filter(Boolean) as any,
+        },
+      });
+    } catch (err) {
+      this.logger.warn(
+        `Failed to cleanup local template records after delete: ${(err as Error)?.message || String(err)}`,
+      );
+    }
+
+    return response;
+  }
+
   private async requestTemplate(data: any, method: string) {
     try {
       let urlServer = this.configService.get<WaBusiness>('WA_BUSINESS').URL;
@@ -113,6 +184,40 @@ export class TemplateService {
       }
 
       // If no response data, throw connection error
+      throw new Error(`Connection error: ${e.message}`);
+    }
+  }
+
+  private async requestEditTemplate(templateId: string, data: any) {
+    try {
+      let urlServer = this.configService.get<WaBusiness>('WA_BUSINESS').URL;
+      const version = this.configService.get<WaBusiness>('WA_BUSINESS').VERSION;
+      urlServer = `${urlServer}/${version}/${templateId}`;
+      const headers = { 'Content-Type': 'application/json', Authorization: `Bearer ${this.token}` };
+      const result = await axios.post(urlServer, data, { headers });
+      return result.data;
+    } catch (e) {
+      this.logger.error(
+        'WhatsApp API request error: ' + (e.response?.data ? JSON.stringify(e.response?.data) : e.message),
+      );
+      if (e.response?.data) return e.response.data;
+      throw new Error(`Connection error: ${e.message}`);
+    }
+  }
+
+  private async requestDeleteTemplate(params: { name: string; hsm_id?: string }) {
+    try {
+      let urlServer = this.configService.get<WaBusiness>('WA_BUSINESS').URL;
+      const version = this.configService.get<WaBusiness>('WA_BUSINESS').VERSION;
+      urlServer = `${urlServer}/${version}/${this.businessId}/message_templates`;
+      const headers = { Authorization: `Bearer ${this.token}` };
+      const result = await axios.delete(urlServer, { headers, params });
+      return result.data;
+    } catch (e) {
+      this.logger.error(
+        'WhatsApp API request error: ' + (e.response?.data ? JSON.stringify(e.response?.data) : e.message),
+      );
+      if (e.response?.data) return e.response.data;
       throw new Error(`Connection error: ${e.message}`);
     }
   }

--- a/src/utils/makeProxyAgent.ts
+++ b/src/utils/makeProxyAgent.ts
@@ -1,7 +1,6 @@
 import { HttpsProxyAgent } from 'https-proxy-agent';
 import { SocksProxyAgent } from 'socks-proxy-agent';
-
-import { ProxyAgent } from 'undici'
+import { ProxyAgent } from 'undici';
 
 type Proxy = {
   host: string;
@@ -46,38 +45,38 @@ export function makeProxyAgent(proxy: Proxy | string): HttpsProxyAgent<string> |
 }
 
 export function makeProxyAgentUndici(proxy: Proxy | string): ProxyAgent {
-  let proxyUrl: string
-  let protocol: string
+  let proxyUrl: string;
+  let protocol: string;
 
   if (typeof proxy === 'string') {
-    const url = new URL(proxy)
-    protocol = url.protocol.replace(':', '')
-    proxyUrl = proxy
+    const url = new URL(proxy);
+    protocol = url.protocol.replace(':', '');
+    proxyUrl = proxy;
   } else {
-    const { host, password, port, protocol: proto, username } = proxy
-    protocol = (proto || 'http').replace(':', '')
+    const { host, password, port, protocol: proto, username } = proxy;
+    protocol = (proto || 'http').replace(':', '');
 
     if (protocol === 'socks') {
-      protocol = 'socks5'
+      protocol = 'socks5';
     }
 
-    const auth = username && password ? `${username}:${password}@` : ''
-    proxyUrl = `${protocol}://${auth}${host}:${port}`
+    const auth = username && password ? `${username}:${password}@` : '';
+    proxyUrl = `${protocol}://${auth}${host}:${port}`;
   }
 
-  const PROXY_HTTP_PROTOCOL = 'http'
-  const PROXY_HTTPS_PROTOCOL = 'https'
-  const PROXY_SOCKS4_PROTOCOL = 'socks4'
-  const PROXY_SOCKS5_PROTOCOL = 'socks5'
+  const PROXY_HTTP_PROTOCOL = 'http';
+  const PROXY_HTTPS_PROTOCOL = 'https';
+  const PROXY_SOCKS4_PROTOCOL = 'socks4';
+  const PROXY_SOCKS5_PROTOCOL = 'socks5';
 
   switch (protocol) {
     case PROXY_HTTP_PROTOCOL:
     case PROXY_HTTPS_PROTOCOL:
     case PROXY_SOCKS4_PROTOCOL:
     case PROXY_SOCKS5_PROTOCOL:
-      return new ProxyAgent(proxyUrl)
+      return new ProxyAgent(proxyUrl);
 
     default:
-      throw new Error(`Unsupported proxy protocol: ${protocol}`)
+      throw new Error(`Unsupported proxy protocol: ${protocol}`);
   }
 }

--- a/src/validate/templateDelete.schema.ts
+++ b/src/validate/templateDelete.schema.ts
@@ -1,0 +1,32 @@
+import { JSONSchema7 } from 'json-schema';
+import { v4 } from 'uuid';
+
+const isNotEmpty = (...propertyNames: string[]): JSONSchema7 => {
+  const properties: Record<string, unknown> = {};
+  propertyNames.forEach(
+    (property) =>
+      (properties[property] = {
+        minLength: 1,
+        description: `The "${property}" cannot be empty`,
+      }),
+  );
+  return {
+    if: {
+      propertyNames: {
+        enum: [...propertyNames],
+      },
+    },
+    then: { properties },
+  } as JSONSchema7;
+};
+
+export const templateDeleteSchema: JSONSchema7 = {
+  $id: v4(),
+  type: 'object',
+  properties: {
+    name: { type: 'string' },
+    hsmId: { type: 'string' },
+  },
+  required: ['name'],
+  ...isNotEmpty('name'),
+};

--- a/src/validate/templateEdit.schema.ts
+++ b/src/validate/templateEdit.schema.ts
@@ -1,0 +1,35 @@
+import { JSONSchema7 } from 'json-schema';
+import { v4 } from 'uuid';
+
+const isNotEmpty = (...propertyNames: string[]): JSONSchema7 => {
+  const properties: Record<string, unknown> = {};
+  propertyNames.forEach(
+    (property) =>
+      (properties[property] = {
+        minLength: 1,
+        description: `The "${property}" cannot be empty`,
+      }),
+  );
+  return {
+    if: {
+      propertyNames: {
+        enum: [...propertyNames],
+      },
+    },
+    then: { properties },
+  } as JSONSchema7;
+};
+
+export const templateEditSchema: JSONSchema7 = {
+  $id: v4(),
+  type: 'object',
+  properties: {
+    templateId: { type: 'string' },
+    category: { type: 'string', enum: ['AUTHENTICATION', 'MARKETING', 'UTILITY'] },
+    allowCategoryChange: { type: 'boolean' },
+    ttl: { type: 'number' },
+    components: { type: 'array' },
+  },
+  required: ['templateId'],
+  ...isNotEmpty('templateId'),
+};

--- a/src/validate/validate.schema.ts
+++ b/src/validate/validate.schema.ts
@@ -8,5 +8,7 @@ export * from './message.schema';
 export * from './proxy.schema';
 export * from './settings.schema';
 export * from './template.schema';
+export * from './templateDelete.schema';
+export * from './templateEdit.schema';
 export * from '@api/integrations/chatbot/chatbot.schema';
 export * from '@api/integrations/event/event.schema';


### PR DESCRIPTION
## 📋 Description
Adds Template management endpoints for WhatsApp Business templates.

## 🔗 Related Issue
<!-- Link to the issue this PR addresses -->
Closes #(issue_number)

## 🧪 Type of Change
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [X ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔧 Refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] 🧹 Code cleanup
- [ ] 🔒 Security fix

## 🧪 Testing
- [x] Manual testing completed
- [x] Functionality verified in development environment
- [x] No breaking changes introduced
- [ ] Tested with different connection types (if applicable)

Manual checks:
- POST `/template/create` with valid `TemplateDto` creates template and stores metadata
- POST `/template/edit` updates template fields via Meta API
- DELETE `/template/delete` deletes template by name or hsm_id and performs best-effort local cleanup
- GET `/template/find` retrieves templates for the instance
- Validation via JSONSchema7 blocks invalid payloads
- Error responses are standardized and include Meta error payload when applicable

## ✅ Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have manually tested my changes thoroughly
- [x] I have verified the changes work with different scenarios
- [x] Any dependent changes have been merged and published

## 📝 Additional Notes
- Multi-tenant: All operations are scoped by instance through `WAMonitoringService`
- Validation: Uses JSONSchema7 and DTO classes following Evolution patterns
- Error handling: Service propagates Meta API errors with structured payloads; routes use `createMetaErrorResponse`
- Database: On delete, performs best-effort cleanup of local template metadata via Prisma

## Summary by Sourcery

Add update and delete operations for WhatsApp Business message templates

New Features:
- Implement TemplateService.edit to update templates via Meta API
- Implement TemplateService.delete to remove templates and perform local metadata cleanup
- Expose POST /template/edit and DELETE /template/delete routes with guards and error handling

Enhancements:
- Introduce TemplateEditDto and TemplateDeleteDto with JSONSchema7 validation
- Wrap and propagate Meta API errors into standardized responses

Chores:
- Apply formatting and semicolon tweaks in makeProxyAgentUndici