### PR TITLE
Durante o processo de logout de uma instância, as chaves associadas a…

### DIFF
--- a/src/api/integrations/channel/whatsapp/whatsapp.baileys.service.ts
+++ b/src/api/integrations/channel/whatsapp/whatsapp.baileys.service.ts
@@ -82,7 +82,7 @@ import { createId as cuid } from '@paralleldrive/cuid2';
 import { Instance, Message } from '@prisma/client';
 import { createJid } from '@utils/createJid';
 import { fetchLatestWaWebVersion } from '@utils/fetchLatestWaWebVersion';
-import {makeProxyAgent, makeProxyAgentUndici} from '@utils/makeProxyAgent';
+import { makeProxyAgent, makeProxyAgentUndici } from '@utils/makeProxyAgent';
 import { getOnWhatsappCache, saveOnWhatsappCache } from '@utils/onWhatsappCache';
 import { status } from '@utils/renderStatus';
 import { sendTelemetry } from '@utils/sendTelemetry';

--- a/src/api/integrations/channel/whatsapp/whatsapp.baileys.service.ts
+++ b/src/api/integrations/channel/whatsapp/whatsapp.baileys.service.ts
@@ -273,19 +273,19 @@ export class BaileysStartupService extends ChannelStartupService {
     if (provider?.ENABLED) {
       const authState = await this.authStateProvider.authStateProvider(this.instance.id);
 
-      await authState.removeCreds()
+      await authState.removeCreds();
     }
 
     if (cache?.REDIS.ENABLED && cache?.REDIS.SAVE_INSTANCES) {
       const authState = await useMultiFileAuthStateRedisDb(this.instance.id, this.cache);
 
-      await authState.removeCreds()
+      await authState.removeCreds();
     }
 
     if (db.SAVE_DATA.INSTANCE) {
       const authState = await useMultiFileAuthStatePrisma(this.instance.id, this.cache);
 
-      await authState.removeCreds()
+      await authState.removeCreds();
     }
 
     const sessionExists = await this.prismaRepository.session.findFirst({ where: { sessionId: this.instanceId } });

--- a/src/api/integrations/channel/whatsapp/whatsapp.baileys.service.ts
+++ b/src/api/integrations/channel/whatsapp/whatsapp.baileys.service.ts
@@ -266,6 +266,28 @@ export class BaileysStartupService extends ChannelStartupService {
 
     this.client?.ws?.close();
 
+    const db = this.configService.get<Database>('DATABASE');
+    const cache = this.configService.get<CacheConf>('CACHE');
+    const provider = this.configService.get<ProviderSession>('PROVIDER');
+
+    if (provider?.ENABLED) {
+      const authState = await this.authStateProvider.authStateProvider(this.instance.id);
+
+      await authState.removeCreds()
+    }
+
+    if (cache?.REDIS.ENABLED && cache?.REDIS.SAVE_INSTANCES) {
+      const authState = await useMultiFileAuthStateRedisDb(this.instance.id, this.cache);
+
+      await authState.removeCreds()
+    }
+
+    if (db.SAVE_DATA.INSTANCE) {
+      const authState = await useMultiFileAuthStatePrisma(this.instance.id, this.cache);
+
+      await authState.removeCreds()
+    }
+
     const sessionExists = await this.prismaRepository.session.findFirst({ where: { sessionId: this.instanceId } });
     if (sessionExists) {
       await this.prismaRepository.session.delete({ where: { sessionId: this.instanceId } });

--- a/src/utils/makeProxyAgent.ts
+++ b/src/utils/makeProxyAgent.ts
@@ -1,6 +1,6 @@
 import { HttpsProxyAgent } from 'https-proxy-agent';
 import { SocksProxyAgent } from 'socks-proxy-agent';
-import { ProxyAgent } from 'undici'
+import { ProxyAgent } from 'undici';
 
 type Proxy = {
   host: string;

--- a/src/utils/makeProxyAgent.ts
+++ b/src/utils/makeProxyAgent.ts
@@ -1,6 +1,5 @@
 import { HttpsProxyAgent } from 'https-proxy-agent';
 import { SocksProxyAgent } from 'socks-proxy-agent';
-
 import { ProxyAgent } from 'undici'
 
 type Proxy = {
@@ -46,38 +45,38 @@ export function makeProxyAgent(proxy: Proxy | string): HttpsProxyAgent<string> |
 }
 
 export function makeProxyAgentUndici(proxy: Proxy | string): ProxyAgent {
-  let proxyUrl: string
-  let protocol: string
+  let proxyUrl: string;
+  let protocol: string;
 
   if (typeof proxy === 'string') {
-    const url = new URL(proxy)
-    protocol = url.protocol.replace(':', '')
-    proxyUrl = proxy
+    const url = new URL(proxy);
+    protocol = url.protocol.replace(':', '');
+    proxyUrl = proxy;
   } else {
-    const { host, password, port, protocol: proto, username } = proxy
-    protocol = (proto || 'http').replace(':', '')
+    const { host, password, port, protocol: proto, username } = proxy;
+    protocol = (proto || 'http').replace(':', '');
 
     if (protocol === 'socks') {
-      protocol = 'socks5'
+      protocol = 'socks5';
     }
 
-    const auth = username && password ? `${username}:${password}@` : ''
-    proxyUrl = `${protocol}://${auth}${host}:${port}`
+    const auth = username && password ? `${username}:${password}@` : '';
+    proxyUrl = `${protocol}://${auth}${host}:${port}`;
   }
 
-  const PROXY_HTTP_PROTOCOL = 'http'
-  const PROXY_HTTPS_PROTOCOL = 'https'
-  const PROXY_SOCKS4_PROTOCOL = 'socks4'
-  const PROXY_SOCKS5_PROTOCOL = 'socks5'
+  const PROXY_HTTP_PROTOCOL = 'http';
+  const PROXY_HTTPS_PROTOCOL = 'https';
+  const PROXY_SOCKS4_PROTOCOL = 'socks4';
+  const PROXY_SOCKS5_PROTOCOL = 'socks5';
 
   switch (protocol) {
     case PROXY_HTTP_PROTOCOL:
     case PROXY_HTTPS_PROTOCOL:
     case PROXY_SOCKS4_PROTOCOL:
     case PROXY_SOCKS5_PROTOCOL:
-      return new ProxyAgent(proxyUrl)
+      return new ProxyAgent(proxyUrl);
 
     default:
-      throw new Error(`Unsupported proxy protocol: ${protocol}`)
+      throw new Error(`Unsupported proxy protocol: ${protocol}`);
   }
 }

--- a/src/utils/use-multi-file-auth-state-prisma.ts
+++ b/src/utils/use-multi-file-auth-state-prisma.ts
@@ -1,11 +1,11 @@
 import { prismaRepository } from '@api/server.module';
 import { CacheService } from '@api/services/cache.service';
 import { CacheConf, configService } from '@config/env.config';
+import { Logger } from '@config/logger.config';
 import { INSTANCE_DIR } from '@config/path.config';
 import { AuthenticationState, BufferJSON, initAuthCreds, WAProto as proto } from 'baileys';
 import fs from 'fs/promises';
 import path from 'path';
-import {Logger} from "@config/logger.config";
 
 const fixFileName = (file: string): string | undefined => {
   if (!file) {
@@ -147,7 +147,6 @@ export default async function useMultiFileAuthStatePrisma(
   }
 
   async function removeCreds(): Promise<any> {
-
     const cacheConfig = configService.get<CacheConf>('CACHE');
 
     // Redis
@@ -156,7 +155,7 @@ export default async function useMultiFileAuthStatePrisma(
         await cache.delete(sessionId);
         logger.info({ action: 'redis.delete', sessionId });
 
-        return
+        return;
       }
     } catch (err) {
       logger.warn({ action: 'redis.delete', sessionId, err });
@@ -209,6 +208,6 @@ export default async function useMultiFileAuthStatePrisma(
       return writeData(creds, 'creds');
     },
 
-    removeCreds
+    removeCreds,
   };
 }

--- a/src/utils/use-multi-file-auth-state-prisma.ts
+++ b/src/utils/use-multi-file-auth-state-prisma.ts
@@ -5,6 +5,7 @@ import { INSTANCE_DIR } from '@config/path.config';
 import { AuthenticationState, BufferJSON, initAuthCreds, WAProto as proto } from 'baileys';
 import fs from 'fs/promises';
 import path from 'path';
+import {Logger} from "@config/logger.config";
 
 const fixFileName = (file: string): string | undefined => {
   if (!file) {
@@ -73,12 +74,15 @@ async function fileExists(file: string): Promise<any> {
   }
 }
 
+const logger = new Logger('useMultiFileAuthStatePrisma');
+
 export default async function useMultiFileAuthStatePrisma(
   sessionId: string,
   cache: CacheService,
 ): Promise<{
   state: AuthenticationState;
   saveCreds: () => Promise<void>;
+  removeCreds: () => Promise<void>;
 }> {
   const localFolder = path.join(INSTANCE_DIR, sessionId);
   const localFile = (key: string) => path.join(localFolder, fixFileName(key) + '.json');
@@ -142,6 +146,27 @@ export default async function useMultiFileAuthStatePrisma(
     }
   }
 
+  async function removeCreds(): Promise<any> {
+
+    const cacheConfig = configService.get<CacheConf>('CACHE');
+
+    // Redis
+    try {
+      if (cacheConfig.REDIS.ENABLED) {
+        await cache.delete(sessionId);
+        logger.info({ action: 'redis.delete', sessionId });
+
+        return
+      }
+    } catch (err) {
+      logger.warn({ action: 'redis.delete', sessionId, err });
+    }
+
+    logger.info({ action: 'auth.key.delete', sessionId });
+
+    await deleteAuthKey(sessionId);
+  }
+
   let creds = await readData('creds');
   if (!creds) {
     creds = initAuthCreds();
@@ -183,5 +208,7 @@ export default async function useMultiFileAuthStatePrisma(
     saveCreds: () => {
       return writeData(creds, 'creds');
     },
+
+    removeCreds
   };
 }

--- a/src/utils/use-multi-file-auth-state-provider-files.ts
+++ b/src/utils/use-multi-file-auth-state-provider-files.ts
@@ -97,7 +97,7 @@ export class AuthStateProvider {
         return;
       }
 
-      logger.info({ action: 'remove.session', instance });
+      logger.info({ action: 'remove.session', instance, response });
 
       return;
     };

--- a/src/utils/use-multi-file-auth-state-provider-files.ts
+++ b/src/utils/use-multi-file-auth-state-provider-files.ts
@@ -41,7 +41,7 @@ import { isNotEmpty } from 'class-validator';
 
 export type AuthState = {
   state: AuthenticationState;
-  saveCreds: () => Promise<void>
+  saveCreds: () => Promise<void>;
   removeCreds: () => Promise<void>;
 };
 
@@ -91,7 +91,6 @@ export class AuthStateProvider {
     };
 
     const removeCreds = async () => {
-
       const [response, error] = await this.providerFiles.removeSession(instance);
       if (error) {
         // this.logger.error(['removeData', error?.message, error?.stack]);
@@ -144,7 +143,7 @@ export class AuthStateProvider {
         return await writeData(creds, 'creds');
       },
 
-      removeCreds
+      removeCreds,
     };
   }
 }

--- a/src/utils/use-multi-file-auth-state-provider-files.ts
+++ b/src/utils/use-multi-file-auth-state-provider-files.ts
@@ -39,7 +39,11 @@ import { Logger } from '@config/logger.config';
 import { AuthenticationCreds, AuthenticationState, BufferJSON, initAuthCreds, proto, SignalDataTypeMap } from 'baileys';
 import { isNotEmpty } from 'class-validator';
 
-export type AuthState = { state: AuthenticationState; saveCreds: () => Promise<void> };
+export type AuthState = {
+  state: AuthenticationState;
+  saveCreds: () => Promise<void>
+  removeCreds: () => Promise<void>;
+};
 
 export class AuthStateProvider {
   constructor(private readonly providerFiles: ProviderFiles) {}
@@ -86,6 +90,19 @@ export class AuthStateProvider {
       return response;
     };
 
+    const removeCreds = async () => {
+
+      const [response, error] = await this.providerFiles.removeSession(instance);
+      if (error) {
+        // this.logger.error(['removeData', error?.message, error?.stack]);
+        return;
+      }
+
+      logger.info({ action: 'remove.session', instance });
+
+      return;
+    };
+
     const creds: AuthenticationCreds = (await readData('creds')) || initAuthCreds();
 
     return {
@@ -126,6 +143,10 @@ export class AuthStateProvider {
       saveCreds: async () => {
         return await writeData(creds, 'creds');
       },
+
+      removeCreds
     };
   }
 }
+
+const logger = new Logger('useMultiFileAuthStatePrisma');

--- a/src/utils/use-multi-file-auth-state-redis-db.ts
+++ b/src/utils/use-multi-file-auth-state-redis-db.ts
@@ -39,7 +39,6 @@ export async function useMultiFileAuthStateRedisDb(
 
   async function removeCreds(): Promise<any> {
     try {
-
       logger.warn({ action: 'redis.delete', instanceName });
 
       return await cache.delete(instanceName);
@@ -89,6 +88,6 @@ export async function useMultiFileAuthStateRedisDb(
       return await writeData(creds, 'creds');
     },
 
-    removeCreds
+    removeCreds,
   };
 }

--- a/src/utils/use-multi-file-auth-state-redis-db.ts
+++ b/src/utils/use-multi-file-auth-state-redis-db.ts
@@ -8,6 +8,7 @@ export async function useMultiFileAuthStateRedisDb(
 ): Promise<{
   state: AuthenticationState;
   saveCreds: () => Promise<void>;
+  removeCreds: () => Promise<void>;
 }> {
   const logger = new Logger('useMultiFileAuthStateRedisDb');
 
@@ -35,6 +36,17 @@ export async function useMultiFileAuthStateRedisDb(
       logger.error({ readData: 'removeData', error });
     }
   };
+
+  async function removeCreds(): Promise<any> {
+    try {
+
+      logger.warn({ action: 'redis.delete', instanceName });
+
+      return await cache.delete(instanceName);
+    } catch {
+      return;
+    }
+  }
 
   const creds: AuthenticationCreds = (await readData('creds')) || initAuthCreds();
 
@@ -76,5 +88,7 @@ export async function useMultiFileAuthStateRedisDb(
     saveCreds: async () => {
       return await writeData(creds, 'creds');
     },
+
+    removeCreds
   };
 }


### PR DESCRIPTION
## 📋 Description
Durante o processo de logout de uma instância, as chaves associadas ao estado criptográfico não estavam sendo removidas corretamente do Redis.

Dessa forma, quando uma nova conexão era estabelecida reutilizando o mesmo instanceName, o Baileys carregava chaves antigas e inválidas, incompatíveis com o novo conjunto de credenciais (creds) gerado na reconexão.

Essa inconsistência gerava o seguinte sintoma prático:

A instância autenticava com sucesso;

Contudo, ao tentar enviar mensagens, entrava em estado de bloqueio, exibindo o status “aguardando mensagem” indefinidamente.

## 🔗 Related Issue
[<!-- Link to the issue this PR addresses -->](https://github.com/EvolutionAPI/evolution-api/issues/2123)
Closes #(issue_number)

## 🧪 Type of Change
<!-- Mark with an `x` all the checkboxes that apply -->
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [x] 🔧 Refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] 🧹 Code cleanup
- [ ] 🔒 Security fix

## 🧪 Testing
<!-- Describe the testing you performed to verify your changes -->
- [x] Manual testing completed
- [x] Functionality verified in development environment
- [ ] No breaking changes introduced
- [ ] Tested with different connection types (if applicable)

## 📸 Screenshots (if applicable)
<!-- Add screenshots to help explain your changes -->

## ✅ Checklist
<!-- Mark with an `x` all the checkboxes that apply -->
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have manually tested my changes thoroughly
- [x] I have verified the changes work with different scenarios
- [x] Any dependent changes have been merged and published

## 📝 Additional Notes
<!-- Any additional information, concerns, or questions -->

## Summary by Sourcery

Ensure cryptographic keys are properly cleaned up on instance logout by adding and invoking removeCreds methods across auth state providers and logging deletion actions.

Bug Fixes:
- Delete stale authentication keys from Redis and file storage on logout to prevent session lockups.

Enhancements:
- Add removeCreds method to Prisma, Redis, and file-based auth state providers.
- Invoke removeCreds in BaileysStartupService during instance logout for all configured storage backends.
- Integrate Logger to record key deletion actions and warnings.