### PR TITLE
Fix: Chatwoot service fails when processing read message

### DIFF
--- a/src/api/integrations/chatbot/chatwoot/services/chatwoot.service.ts
+++ b/src/api/integrations/chatbot/chatwoot/services/chatwoot.service.ts
@@ -2338,7 +2338,7 @@ export class ChatwootService {
             const url =
               `/public/api/v1/inboxes/${inbox.inbox_identifier}/contacts/${sourceId}` +
               `/conversations/${conversationId}/update_last_seen`;
-            chatwootRequest(this.getClientCwConfig(), {
+            await chatwootRequest(this.getClientCwConfig(), {
               method: 'POST',
               url: url,
             });


### PR DESCRIPTION
## 📋 Description
All messages on chatwoot do not get `read` status due an issue on chatwoot service that is missing `await` tag when calling  `chatwootRequest` method that hits `update_last_seen` endpoint.

## 🔗 Related Issue
https://github.com/EvolutionAPI/evolution-api/issues/2116

## 🧪 Type of Change
<!-- Mark with an `x` all the checkboxes that apply -->
- [X] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔧 Refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] 🧹 Code cleanup
- [ ] 🔒 Security fix

## 🧪 Testing
<!-- Describe the testing you performed to verify your changes -->
- [X] Manual testing completed
- [X] Functionality verified in development environment
- [X] No breaking changes introduced
- [ ] Tested with different connection types (if applicable)

## 📸 Screenshots (if applicable)
<img width="176" height="90" alt="Screenshot 2025-11-12 at 22 50 38" src="https://github.com/user-attachments/assets/02bb1c1a-c575-4f2d-9339-80ee0dc77b88" />


## ✅ Checklist
- [X] My code follows the project's style guidelines
- [X] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [X] I have manually tested my changes thoroughly
- [X] I have verified the changes work with different scenarios
- [ ] Any dependent changes have been merged and published

## 📝 Additional Notes

## Summary by Sourcery

Bug Fixes:
- Await the chatwootRequest call for update_last_seen to ensure read receipts are transmitted