### PR TITLE
fix(prisma): add unique constraint to Chat model in Postgres

### DIFF
--- a/prisma/postgresql-migrations/20251122003044_add_chat_instance_remotejid_unique/migration.sql
+++ b/prisma/postgresql-migrations/20251122003044_add_chat_instance_remotejid_unique/migration.sql
@@ -1,2 +1,16 @@
--- AlterTable
+-- 1. Cleanup: Remove duplicate chats, keeping the most recently updated one
+DELETE FROM "Chat"
+WHERE id IN (
+  SELECT id FROM (
+    SELECT id,
+           ROW_NUMBER() OVER (
+             PARTITION BY "instanceId", "remoteJid"
+             ORDER BY "updatedAt" DESC
+           ) as row_num
+    FROM "Chat"
+  ) t
+  WHERE t.row_num > 1
+);
+
+-- 2. Create the unique index (Constraint)
 CREATE UNIQUE INDEX "Chat_instanceId_remoteJid_key" ON "Chat"("instanceId", "remoteJid");

--- a/prisma/postgresql-migrations/20251122003044_add_chat_instance_remotejid_unique/migration.sql
+++ b/prisma/postgresql-migrations/20251122003044_add_chat_instance_remotejid_unique/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+CREATE UNIQUE INDEX "Chat_instanceId_remoteJid_key" ON "Chat"("instanceId", "remoteJid");

--- a/prisma/postgresql-schema.prisma
+++ b/prisma/postgresql-schema.prisma
@@ -132,6 +132,7 @@ model Chat {
   instanceId     String
   unreadMessages Int       @default(0)
 
+  @@unique([instanceId, remoteJid])
   @@index([instanceId])
   @@index([remoteJid])
 }


### PR DESCRIPTION
## 📋 Description
Fixes a critical bug affecting PostgreSQL users where label operations fail with `PrismaClientKnownRequestError` (Code `42P10`).

The issue occurs because `addLabel` and `removeLabel` methods rely on an `ON CONFLICT` clause that requires a unique constraint on `(instanceId, remoteJid)`. This PR adds the missing `@@unique` constraint to the `Chat` model in `postgresql-schema.prisma` and includes the necessary SQL migration to align behavior with MySQL.

## 🔗 Related Issue
Closes [#2152](https://github.com/EvolutionAPI/evolution-api/issues/2152)

## 🧪 Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔧 Refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] 🧹 Code cleanup
- [ ] 🔒 Security fix

## 🧪 Testing
- [x] Manual testing completed
- [x] Functionality verified in development environment
- [x] No breaking changes introduced
- [ ] Tested with different connection types (if applicable)

Manually verified by applying the migration to a clean PostgreSQL container. Confirmed via `psql` that the unique index `"Chat_instanceId_remoteJid_key"` was successfully created in the database structure.

## ✅ Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have manually tested my changes thoroughly
- [x] I have verified the changes work with different scenarios
- [ ] Any dependent changes have been merged and published

## 📝 Additional Notes
The migration file was generated using `prisma migrate dev --create-only` and populated manually with the specific `CREATE UNIQUE INDEX` command. This ensures a clean migration path without generating unnecessary SQL for existing tables.

## Summary by Sourcery

Add a unique constraint for Chat records in the PostgreSQL schema to align behavior with other databases and prevent label operation failures.

Bug Fixes:
- Resolve PostgreSQL label operation failures caused by missing uniqueness on Chat instance and remote JID combinations.

Build:
- Introduce a Prisma PostgreSQL migration that creates a unique index on Chat(instanceId, remoteJid) to enforce the new constraint.