### PR TITLE
fix: unify remoteJid filtering using OR with remoteJidAlt

### DIFF
--- a/src/api/integrations/channel/whatsapp/whatsapp.baileys.service.ts
+++ b/src/api/integrations/channel/whatsapp/whatsapp.baileys.service.ts
@@ -4882,7 +4882,6 @@ export class BaileysStartupService extends ChannelStartupService {
         AND: [
           keyFilters?.id ? { key: { path: ['id'], equals: keyFilters?.id } } : {},
           keyFilters?.fromMe ? { key: { path: ['fromMe'], equals: keyFilters?.fromMe } } : {},
-          keyFilters?.remoteJid ? { key: { path: ['remoteJid'], equals: keyFilters?.remoteJid } } : {},
           keyFilters?.participant ? { key: { path: ['participant'], equals: keyFilters?.participant } } : {},
           {
             OR: [
@@ -4912,7 +4911,6 @@ export class BaileysStartupService extends ChannelStartupService {
         AND: [
           keyFilters?.id ? { key: { path: ['id'], equals: keyFilters?.id } } : {},
           keyFilters?.fromMe ? { key: { path: ['fromMe'], equals: keyFilters?.fromMe } } : {},
-          keyFilters?.remoteJid ? { key: { path: ['remoteJid'], equals: keyFilters?.remoteJid } } : {},
           keyFilters?.participant ? { key: { path: ['participant'], equals: keyFilters?.participant } } : {},
           {
             OR: [


### PR DESCRIPTION
## 📋 Description
Quando sincronizamos o nosso whatsapp com o Evolution, as mensagens ficam salvas com o seguinte formato da propriedade 'key':

{
  "id": "AC5D7F832B92FA9393B492D9F9B88C20",
  "fromMe": true,
  "remoteJid": "55449999999@s.whatsapp.net"
} 

porém, quando recebemos novas mensagens nos eventos upsert, as mensagens salvas ficam com o seguinte formato:

{
  "id": "AC5D7F832B92FA9393B492D9F9B88C20",
  "fromMe": true,
  "remoteJid": "267628186730669@lid",
  "participant": "",
  "remoteJidAlt": "554499999999@s.whatsapp.net",
  "addressingMode": "lid"
}

Como é possível observar, o remoteJid é salvo com o endereçamento LID e o JID fica na propriedade remoteJidAlt

A alteração proposta pretende corrigir o filtro de busca de mensagens para considerar tanto o remoteJid quando o remoteJidAlt dentro da cláusula OR da função fetchMessages. Atualmente a busca só funciona filtrando por remoteJid ou remoteJidAlt, e não os dois ao mesmo tempo. Por exemplo, se eu quiser filtrar pela requisição abaixo eu não consigo:

{
    "where": {
        "key": {
            "remoteJid": "55449999999@s.whatsapp.net"
            "remoteJidAlt": "55449999999@s.whatsapp.net"
        }
    }
}

Isso busca somente as mensagens com o remoteJid indicado, e não com o remoteJidAlt também.

O objetivo da modificação seria atribuir uma condição OR das duas propriedades: se existir remoteJid OU remoteJidAlt com o valor especificado.

## 🔗 Related Issue
<!-- Link to the issue this PR addresses -->
Closes #(issue_number)

## 🧪 Type of Change
<!-- Mark with an `x` all the checkboxes that apply -->
- [X] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔧 Refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] 🧹 Code cleanup
- [ ] 🔒 Security fix

## 🧪 Testing
<!-- Describe the testing you performed to verify your changes -->
- [X] Manual testing completed
- [X] Functionality verified in development environment
- [X] No breaking changes introduced
- [ ] Tested with different connection types (if applicable)

## 📸 Screenshots (if applicable)
<!-- Add screenshots to help explain your changes -->

## ✅ Checklist
<!-- Mark with an `x` all the checkboxes that apply -->
- [X] My code follows the project's style guidelines
- [X] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ X I have manually tested my changes thoroughly
- [X] I have verified the changes work with different scenarios
- [ ] Any dependent changes have been merged and published

## 📝 Additional Notes
<!-- Any additional information, concerns, or questions -->

## Summary by Sourcery

Bug Fixes:
- Fix message queries that failed to return results when filtering simultaneously by remoteJid and remoteJidAlt by consolidating these conditions into one OR clause.