### PR TITLE
fix: chatwoot stability, webhook crashes and WhatsApp LID support

### DIFF
--- a/src/api/integrations/channel/whatsapp/whatsapp.baileys.service.ts
+++ b/src/api/integrations/channel/whatsapp/whatsapp.baileys.service.ts
@@ -1614,9 +1614,9 @@ export class BaileysStartupService extends ChannelStartupService {
       // This enables LID to phoneNumber conversion without breaking existing webhook consumers
 
       // Helper to normalize participantId as phone number
-      const normalizePhoneNumber = (id: string): string => {
+      const normalizePhoneNumber = (id: string | any): string => {
         // Remove @lid, @s.whatsapp.net suffixes and extract just the number part
-        return id.split('@')[0];
+        return String(id || '').split('@')[0];
       };
 
       try {

--- a/src/api/integrations/chatbot/base-chatbot.service.ts
+++ b/src/api/integrations/chatbot/base-chatbot.service.ts
@@ -211,7 +211,7 @@ export abstract class BaseChatbotService<BotType = any, SettingsType = any> {
         try {
           if (mediaType === 'audio') {
             await instance.audioWhatsapp({
-              number: remoteJid.split('@')[0],
+              number: remoteJid,
               delay: (settings as any)?.delayMessage || 1000,
               audio: url,
               caption: altText,
@@ -219,7 +219,7 @@ export abstract class BaseChatbotService<BotType = any, SettingsType = any> {
           } else {
             await instance.mediaMessage(
               {
-                number: remoteJid.split('@')[0],
+                number: remoteJid,
                 delay: (settings as any)?.delayMessage || 1000,
                 mediatype: mediaType,
                 media: url,
@@ -290,7 +290,7 @@ export abstract class BaseChatbotService<BotType = any, SettingsType = any> {
       setTimeout(async () => {
         await instance.textMessage(
           {
-            number: remoteJid.split('@')[0],
+            number: remoteJid,
             delay: settings?.delayMessage || 1000,
             text: message,
             linkPreview,

--- a/src/api/integrations/chatbot/chatwoot/services/chatwoot.service.ts
+++ b/src/api/integrations/chatbot/chatwoot/services/chatwoot.service.ts
@@ -346,12 +346,8 @@ export class ChatwootService {
 
       return contact;
     } catch (error) {
-      if (
-        (error.status === 422 || error.response?.status === 422) &&
-        (error.message?.includes('taken') || error.response?.data?.message?.includes('taken')) &&
-        jid
-      ) {
-        this.logger.warn(`Contact with identifier ${jid} already exists, trying to find it...`);
+      if ((error.status === 422 || error.response?.status === 422) && jid) {
+        this.logger.warn(`Contact with identifier ${jid} creation failed (422). Checking if it already exists...`);
         const existingContact = await this.findContactByIdentifier(instance, jid);
         if (existingContact) {
           const contactId = existingContact.id;
@@ -2535,7 +2531,7 @@ export class ChatwootService {
     if (!remoteJid) {
       return '';
     }
-    return remoteJid.replace(/:\d+/, '').replace('@s.whatsapp.net', '').replace('@g.us', '').replace('@lid', '');
+    return remoteJid.replace(/:\d+/, '').split('@')[0];
   }
 
   public startImportHistoryMessages(instance: InstanceDto) {

--- a/src/api/integrations/chatbot/chatwoot/services/chatwoot.service.ts
+++ b/src/api/integrations/chatbot/chatwoot/services/chatwoot.service.ts
@@ -2531,6 +2531,9 @@ export class ChatwootService {
     if (!remoteJid) {
       return '';
     }
+    if (remoteJid.includes('@lid')) {
+      return remoteJid;
+    }
     return remoteJid.replace(/:\d+/, '').split('@')[0];
   }
 

--- a/src/api/integrations/chatbot/typebot/services/typebot.service.ts
+++ b/src/api/integrations/chatbot/typebot/services/typebot.service.ts
@@ -327,7 +327,7 @@ export class TypebotService extends BaseChatbotService<TypebotModel, any> {
       if (message.type === 'image') {
         await instance.mediaMessage(
           {
-            number: session.remoteJid.split('@')[0],
+            number: session.remoteJid,
             delay: settings?.delayMessage || 1000,
             mediatype: 'image',
             media: message.content.url,
@@ -342,7 +342,7 @@ export class TypebotService extends BaseChatbotService<TypebotModel, any> {
       if (message.type === 'video') {
         await instance.mediaMessage(
           {
-            number: session.remoteJid.split('@')[0],
+            number: session.remoteJid,
             delay: settings?.delayMessage || 1000,
             mediatype: 'video',
             media: message.content.url,
@@ -357,7 +357,7 @@ export class TypebotService extends BaseChatbotService<TypebotModel, any> {
       if (message.type === 'audio') {
         await instance.audioWhatsapp(
           {
-            number: session.remoteJid.split('@')[0],
+            number: session.remoteJid,
             delay: settings?.delayMessage || 1000,
             encoding: true,
             audio: message.content.url,
@@ -441,7 +441,7 @@ export class TypebotService extends BaseChatbotService<TypebotModel, any> {
    */
   private async processListMessage(instance: any, formattedText: string, remoteJid: string) {
     const listJson = {
-      number: remoteJid.split('@')[0],
+      number: remoteJid,
       title: '',
       description: '',
       buttonText: '',
@@ -490,7 +490,7 @@ export class TypebotService extends BaseChatbotService<TypebotModel, any> {
    */
   private async processButtonMessage(instance: any, formattedText: string, remoteJid: string) {
     const buttonJson = {
-      number: remoteJid.split('@')[0],
+      number: remoteJid,
       thumbnailUrl: undefined,
       title: '',
       description: '',


### PR DESCRIPTION
This Pull Request resolves critical stability issues and functional bugs in the Evolution API, focusing on Chatwoot integration robustness and support for modern WhatsApp identifiers (LID). The fixes ensure reliable message processing, prevent application crashes due to webhook errors, and normalize identifier handling across services.

**Fixes:**

**WhatsApp LID (Linked Identity Device) Support:**
**Problem:** Messages originating from users with the new @lid identifier format were failing in Typebot and general message sending. The codebase aggressively stripped the domain using .split('@')[0], causing the API to lose the valid JID required for these specific identifiers. 
**Solution:** Updated BaseChatbotService, TypebotService, and ChatwootService logic to preserve the full JID when necessary. Refactored getNumberFromRemoteJid to safely handle and clean complex JID formats (e.g., removing device suffixes like :27 while keeping the user ID intact).

**Chatwoot Integration Stability (Duplicate Identifiers & Participant Errors):**
**Problem:** The Chatwoot integration suffered from two main issues: crashes due to participantAlt being undefined when parsing message keys, and "Identifier has already been taken" (422) errors during contact creation when a contact existed but wasn't initially found.
**Solution:** Added safe access checks for participantAlt to prevent runtime errors. Implemented a fallback mechanism in createContact to recover the existing contact by identifier if creation fails due to duplication, ensuring the flow continues without error.

**Webhook Crashes on Group Participant Updates:**
**Problem:** The GROUP_PARTICIPANTS_UPDATE webhook event caused the application to crash when processing participant IDs that were not strings (undefined or null) in the normalizePhoneNumber function.
**Solution:** Added strict type coercion (String(id || '')) in WhatsappBaileysService to ensure input is always a string before processing, preventing the crash.

**Unhandled Database Rejections in Chatwoot Import:**
**Problem:** The chatwoot_import feature caused unhandled promise rejections crashing the process when the separate Postgres connection was missing or failed.
**Solution:** Wrapped the updateMessageSourceID and connection logic in proper try/catch blocks to gracefully handle database connectivity issues without bringing down the main application.

**Summary by Sourcery**

Improve system stability and Chatwoot integration reliability by identifier handling, and error resilience.

**Bug Fixes:**

   * Enable full support for WhatsApp @lid identifiers in Typebot and Chatbot services by refining JID parsing.
   * Fix participantAlt undefined errors and "Identifier has already been taken" loops in Chatwoot integration.
   * Prevent GROUP_PARTICIPANTS_UPDATE webhook crashes by sanitizing participant ID inputs.
   * Handle database connection failures gracefully in Chatwoot import services to prevent unhandled rejections.

## Summary by Sourcery

Improve WhatsApp and Chatwoot integrations to better handle modern JID formats, avoid crashes, and gracefully recover from external and database errors.

Bug Fixes:
- Handle duplicate-identifier errors in Chatwoot contact creation by looking up and reusing existing contacts instead of failing.
- Prevent crashes when participantAlt is missing on group messages by only using it when available and falling back to participant.
- Avoid webhook failures on GROUP_PARTICIPANTS_UPDATE events by safely normalizing possibly non-string participant IDs.
- Prevent unhandled rejections during Chatwoot history import by wrapping message source ID updates in error handling.

Enhancements:
- Support WhatsApp LID and other JID formats end‑to‑end by preserving full remoteJid where necessary and normalizing only the domain/suffix parts.
- Add a Chatwoot helper to search contacts by identifier across multiple API shapes for more robust contact resolution.