### PR TITLE
feat: add wildcard "*" to allow all hosts to connect via websocket

### DIFF
--- a/src/api/integrations/event/websocket/websocket.controller.ts
+++ b/src/api/integrations/event/websocket/websocket.controller.ts
@@ -33,7 +33,8 @@ export class WebsocketController extends EventController implements EventControl
           const { remoteAddress } = req.socket;
           const websocketConfig = configService.get<Websocket>('WEBSOCKET');
           const allowedHosts = websocketConfig.ALLOWED_HOSTS || '127.0.0.1,::1,::ffff:127.0.0.1';
-          const isAllowedHost = allowedHosts
+          const allowAllHosts = allowedHosts.trim() === '*';
+          const isAllowedHost = allowAllHosts || allowedHosts
             .split(',')
             .map((h) => h.trim())
             .includes(remoteAddress);


### PR DESCRIPTION
## 📋 Description
Adds support for using `*` in `WEBSOCKET_ALLOWED_HOSTS` env variable to allow any host to bypass the API’s WebSocket IP-restriction checks. Useful for local/Docker setups where container IPs change. Normal host whitelisting behavior remains unchanged when `*` is not used

## 🧪 Type of Change
<!-- Mark with an `x` all the checkboxes that apply -->
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔧 Refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] 🧹 Code cleanup
- [ ] 🔒 Security fix

## 🧪 Testing
<!-- Describe the testing you performed to verify your changes -->
- [x] Manual testing completed
- [x] Functionality verified in development environment
- [x] No breaking changes introduced
- [x] Tested with different connection types (if applicable)
- [x] Verified that `WEBSOCKET_ALLOWED_HOSTS=*` bypasses IP validation
- [x] Verified that explicit host lists still work as before

## ✅ Checklist
<!-- Mark with an `x` all the checkboxes that apply -->
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have manually tested my changes thoroughly
- [x] I have verified the changes work with different scenarios

## 📝 Additional Notes
Intended only for development scenarios. Production should continue using explicit whitelists as introduced in the original security enhancement PR https://github.com/EvolutionAPI/evolution-api/pull/1929

## Summary by Sourcery

New Features:
- Support using a wildcard "*" value in WEBSOCKET_ALLOWED_HOSTS to bypass WebSocket IP-based host validation while retaining existing explicit host whitelist behavior.