### PR TITLE
fix: normalize remoteJid in message updates and handle race condition in contact cache

### DIFF
--- a/src/api/integrations/channel/whatsapp/whatsapp.baileys.service.ts
+++ b/src/api/integrations/channel/whatsapp/whatsapp.baileys.service.ts
@@ -1674,7 +1674,9 @@ export class BaileysStartupService extends ChannelStartupService {
             }
 
             if (!findMessage?.id) {
-              this.logger.warn(`Original message not found for update. Skipping. Key: ${JSON.stringify(key)}`);
+              this.logger.verbose(
+                `Original message not found for update after ${maxRetries} retries. Skipping. This is expected for protocol messages or ephemeral events not saved to the database. Key: ${JSON.stringify(key)}`,
+              );
               continue;
             }
             if (findMessage?.key?.remoteJid && findMessage.key.remoteJid !== key.remoteJid) {

--- a/src/api/integrations/channel/whatsapp/whatsapp.baileys.service.ts
+++ b/src/api/integrations/channel/whatsapp/whatsapp.baileys.service.ts
@@ -1565,8 +1565,15 @@ export class BaileysStartupService extends ChannelStartupService {
 
       for await (const { key, update } of args) {
         const keyAny = key as any;
-        const normalizedRemoteJid = keyAny.remoteJid?.replace(/:.*$/, '');
-        const normalizedParticipant = keyAny.participant?.replace(/:.*$/, '');
+        if (keyAny.remoteJid) {
+          keyAny.remoteJid = keyAny.remoteJid.replace(/:.*$/, '');
+        }
+        if (keyAny.participant) {
+          keyAny.participant = keyAny.participant.replace(/:.*$/, '');
+        }
+
+        const normalizedRemoteJid = keyAny.remoteJid;
+        const normalizedParticipant = keyAny.participant;
 
         if (settings?.groupsIgnore && normalizedRemoteJid?.includes('@g.us')) {
           continue;
@@ -1644,17 +1651,37 @@ export class BaileysStartupService extends ChannelStartupService {
 
             const searchId = originalMessageId || key.id;
 
-            const messages = (await this.prismaRepository.$queryRaw`
-              SELECT * FROM "Message"
-              WHERE "instanceId" = ${this.instanceId}
-              AND "key"->>'id' = ${searchId}
-              LIMIT 1
-            `) as any[];
-            findMessage = messages[0] || null;
+            let retries = 0;
+            const maxRetries = 3;
+
+            while (retries < maxRetries) {
+              const messages = (await this.prismaRepository.$queryRaw`
+                SELECT * FROM "Message"
+                WHERE "instanceId" = ${this.instanceId}
+                AND "key"->>'id' = ${searchId}
+                LIMIT 1
+              `) as any[];
+              findMessage = messages[0] || null;
+
+              if (findMessage?.id) {
+                break;
+              }
+
+              retries++;
+              if (retries < maxRetries) {
+                await delay(2000);
+              }
+            }
 
             if (!findMessage?.id) {
               this.logger.warn(`Original message not found for update. Skipping. Key: ${JSON.stringify(key)}`);
               continue;
+            }
+            if (findMessage?.key?.remoteJid && findMessage.key.remoteJid !== key.remoteJid) {
+              this.logger.verbose(
+                `Updating key.remoteJid from ${key.remoteJid} to ${findMessage.key.remoteJid} based on stored message`,
+              );
+              key.remoteJid = findMessage.key.remoteJid;
             }
             message.messageId = findMessage.id;
           }

--- a/src/utils/onWhatsappCache.ts
+++ b/src/utils/onWhatsappCache.ts
@@ -1,6 +1,7 @@
 import { prismaRepository } from '@api/server.module';
 import { configService, Database } from '@config/env.config';
 import { Logger } from '@config/logger.config';
+import { Prisma } from '@prisma/client';
 import dayjs from 'dayjs';
 
 const logger = new Logger('OnWhatsappCache');
@@ -170,7 +171,11 @@ export async function saveOnWhatsappCache(data: ISaveOnWhatsappCacheParams[]) {
           });
         } catch (error: any) {
           // Check for unique constraint violation (Prisma error code P2002)
-          if (error.code === 'P2002' && error.meta?.target?.includes('remoteJid')) {
+          if (
+            error instanceof Prisma.PrismaClientKnownRequestError &&
+            error.code === 'P2002' &&
+            (error.meta?.target as string[])?.includes('remoteJid')
+          ) {
             logger.verbose(
               `[saveOnWhatsappCache] Race condition detected for ${remoteJid}, updating existing record instead.`,
             );


### PR DESCRIPTION
## 📋 Description

This PR addresses two critical issues related to data consistency and race conditions in
the WhatsApp integration (Baileys) and contact caching mechanism:

1. **Original Message Not Found (Fix):**
   * **Normalization:** Implements strict normalization of `remoteJid` and
     `participant` in the `messages.update` handler to remove device suffixes (e.g.,
     `:42@s.whatsapp.net` -> `@s.whatsapp.net`). This ensures that keys used for lookups match
     the stored format.
   * **Identifier Synchronization:** Adds logic to update the incoming `key.remoteJid`
     with the value stored in the database if the message is found. This resolves mismatches
     where an update might come in with a LID while the stored message uses a phone number JID
     (or vice versa), ensuring the correct identifier is used for subsequent logic.
   * **Retry Mechanism:** Introduces a retry loop (3 attempts, 2s delay) when fetching
     the original message for an update. This handles race conditions where the
     `messages.update` event arrives before the initial `messages.upsert` has finished
     committing the message to the database.

2. **Unique Constraint Failed in Cache (Fix):**
   * **Race Condition Handling:** Wraps the `prismaRepository.isOnWhatsapp.create`
     call in a `try-catch` block specifically catching `P2002` (Unique Constraint Violation)
     errors on `remoteJid`.
   * **Fallback Strategy:** If a race condition is detected (another process created
     the record between the check and the insert), the code now gracefully falls back to
     updating the existing record instead of crashing.

## 🔗 Related Issue
<!-- Link to the issue this PR addresses -->
Closes # (Add issue number if applicable)

## 🧪 Type of Change
<!-- Mark with an `x` all the checkboxes that apply -->
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not
  work as expected)
- [ ] 📚 Documentation update
- [ ] 🔧 Refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] 🧹 Code cleanup
- [ ] 🔒 Security fix

## 🧪 Testing
<!-- Describe the testing you performed to verify your changes -->
- [x] Manual testing completed
- [x] Functionality verified in development environment
- [x] No breaking changes introduced
- [x] Verified that "Original message not found" errors are reduced/eliminated.
- [x] Verified that "Unique constraint failed" errors on `remoteJid` no longer crash the
  process.

## 📸 Screenshots (if applicable)
<!-- Add screenshots to help explain your changes -->

## ✅ Checklist
<!-- Mark with an `x` all the checkboxes that apply -->
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have manually tested my changes thoroughly
- [x] I have verified the changes work with different scenarios
- [ ] Any dependent changes have been merged and published

## 📝 Additional Notes
<!-- Any additional information, concerns, or questions -->
The race condition in `saveOnWhatsappCache` was causing intermittent `P2002` errors in
logs, which are now handled gracefully. The `messages.update` fixes ensure that read
receipts and other status updates are correctly applied even when network events arrive
out of order or with slightly different JID formats.

## Summary by Sourcery

Normalize WhatsApp message identifiers in update handling and add safeguards against race conditions in message lookup and contact cache writes.

Bug Fixes:
- Ensure message update events use normalized remoteJid and participant values consistent with stored messages.
- Add a retry mechanism when fetching the original message for updates to handle timing races with initial message persistence.
- Synchronize key.remoteJid with the stored message identifier when they differ to prevent mismatched lookups and processing.
- Handle Prisma P2002 unique-constraint violations in the WhatsApp contact cache by falling back to updating the existing record instead of failing.