### PR TITLE
fix: evitar falha em messages.update quando remoteJid estiver ausente

### DIFF
--- a/src/api/integrations/channel/whatsapp/whatsapp.baileys.service.ts
+++ b/src/api/integrations/channel/whatsapp/whatsapp.baileys.service.ts
@@ -1649,7 +1649,16 @@ export class BaileysStartupService extends ChannelStartupService {
               this.logger.warn(`Original message not found for update. Skipping. Key: ${JSON.stringify(key)}`);
               continue;
             }
+            if (!message.remoteJid) {
+              const fallbackKey = findMessage?.key as WAMessageKey | undefined;
+              message.remoteJid = fallbackKey?.remoteJid;
+            }
             message.messageId = findMessage.id;
+          }
+
+          if (!message.remoteJid) {
+            this.logger.warn(`remoteJid missing on message.update. Skipping. Key: ${JSON.stringify(key)}`);
+            continue;
           }
 
           if (update.message === null && update.status === undefined) {


### PR DESCRIPTION
## 📋 Description
Corrige falha em messages.update quando remoteJid chega ausente. Agora tenta recuperar o remoteJid do registro original e, se ainda não existir, ignora o update com warning para evitar unhandledRejection e manter o sync com o Chatwoot ativo.

🔗 Related Issue
Closes #(issue_number)

🧪 Type of Change
 🐛 Bug fix (non-breaking change which fixes an issue)
 ✨ New feature (non-breaking change which adds functionality)
 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
 📚 Documentation update
 🔧 Refactoring (no functional changes)
 ⚡ Performance improvement
 🧹 Code cleanup
 🔒 Security fix
🧪 Testing
 Manual testing completed
 Functionality verified in development environment
 No breaking changes introduced
 Tested with different connection types (if applicable)
📸 Screenshots (if applicable)
N/A

✅ Checklist
 My code follows the project's style guidelines
 I have performed a self-review of my code
 I have commented my code, particularly in hard-to-understand areas
 I have made corresponding changes to the documentation
 My changes generate no new warnings
 I have manually tested my changes thoroughly
 I have verified the changes work with different scenarios
 Any dependent changes have been merged and published
📝 Additional Notes
Essa correção evita falhas críticas quando updates do Baileys chegam sem remoteJid, cenário observado nos logs com PrismaClientValidationError.

## Summary by Sourcery

Handle WhatsApp message update events that arrive without a remoteJid by attempting to recover it and safely skipping invalid updates.

Bug Fixes:
- Recover missing remoteJid on message.update events from the original stored message key when possible to avoid failures.
- Skip processing and log a warning when remoteJid remains missing on message.update to prevent unhandled rejections and keep integrations stable.