### PR TITLE
feat: add generateMessageID method and support for messageId in sendM…

### DIFF
--- a/src/api/dto/sendMessage.dto.ts
+++ b/src/api/dto/sendMessage.dto.ts
@@ -14,6 +14,7 @@ export class Options {
   mentionsEveryOne?: boolean;
   mentioned?: string[];
   webhookUrl?: string;
+  messageId?: string;
 }
 
 export class MediaMessage {
@@ -45,6 +46,7 @@ export class Metadata {
   mentioned?: string[];
   encoding?: boolean;
   notConvertSticker?: boolean;
+  messageId?: string;
 }
 
 export class SendTextDto extends Metadata {

--- a/src/api/integrations/channel/evolution/evolution.channel.service.ts
+++ b/src/api/integrations/channel/evolution/evolution.channel.service.ts
@@ -318,7 +318,7 @@ export class EvolutionStartupService extends ChannelStartupService {
 
       let audioFile;
 
-      const messageId = options?.messageId || v4();
+      const messageId = options?.messageId ?? v4();
 
       let messageRaw: any;
 

--- a/src/api/integrations/channel/evolution/evolution.channel.service.ts
+++ b/src/api/integrations/channel/evolution/evolution.channel.service.ts
@@ -318,7 +318,7 @@ export class EvolutionStartupService extends ChannelStartupService {
 
       let audioFile;
 
-      const messageId = v4();
+      const messageId = options?.messageId || v4();
 
       let messageRaw: any;
 
@@ -548,6 +548,7 @@ export class EvolutionStartupService extends ChannelStartupService {
         linkPreview: data?.linkPreview,
         mentionsEveryOne: data?.mentionsEveryOne,
         mentioned: data?.mentioned,
+        messageId: data?.messageId,
       },
       null,
       isIntegration,
@@ -613,6 +614,7 @@ export class EvolutionStartupService extends ChannelStartupService {
         linkPreview: data?.linkPreview,
         mentionsEveryOne: data?.mentionsEveryOne,
         mentioned: data?.mentioned,
+        messageId: data?.messageId,
       },
       file,
       isIntegration,
@@ -711,6 +713,7 @@ export class EvolutionStartupService extends ChannelStartupService {
         linkPreview: data?.linkPreview,
         mentionsEveryOne: data?.mentionsEveryOne,
         mentioned: data?.mentioned,
+        messageId: data?.messageId,
       },
       file,
       isIntegration,
@@ -736,6 +739,7 @@ export class EvolutionStartupService extends ChannelStartupService {
         quoted: data?.quoted,
         mentionsEveryOne: data?.mentionsEveryOne,
         mentioned: data?.mentioned,
+        messageId: data?.messageId,
       },
       null,
       isIntegration,

--- a/src/api/integrations/channel/whatsapp/baileys.controller.ts
+++ b/src/api/integrations/channel/whatsapp/baileys.controller.ts
@@ -10,6 +10,12 @@ export class BaileysController {
     return instance.baileysOnWhatsapp(body?.jid);
   }
 
+  public async generateMessageID({ instanceName }: InstanceDto) {
+    const instance = this.waMonitor.waInstances[instanceName];
+
+    return instance.generateMessageID();
+  }
+
   public async profilePictureUrl({ instanceName }: InstanceDto, body: any) {
     const instance = this.waMonitor.waInstances[instanceName];
 

--- a/src/api/integrations/channel/whatsapp/baileys.router.ts
+++ b/src/api/integrations/channel/whatsapp/baileys.router.ts
@@ -19,6 +19,16 @@ export class BaileysRouter extends RouterBroker {
 
         res.status(HttpStatus.OK).json(response);
       })
+      .get(this.routerPath('generateMessageID'), ...guards, async (req, res) => {
+        const response = await this.dataValidate<InstanceDto>({
+          request: req,
+          schema: instanceSchema,
+          ClassRef: InstanceDto,
+          execute: (instance) => baileysController.generateMessageID(instance),
+        });
+
+        res.status(HttpStatus.OK).json(response);
+      })
       .post(this.routerPath('profilePictureUrl'), ...guards, async (req, res) => {
         const response = await this.dataValidate<InstanceDto>({
           request: req,

--- a/src/api/integrations/channel/whatsapp/whatsapp.baileys.service.ts
+++ b/src/api/integrations/channel/whatsapp/whatsapp.baileys.service.ts
@@ -128,6 +128,7 @@ import makeWASocket, {
   WAMessageKey,
   WAPresence,
   WASocket,
+  generateMessageIDV2
 } from 'baileys';
 import { Label } from 'baileys/lib/Types/Label';
 import { LabelAssociation } from 'baileys/lib/Types/LabelAssociation';
@@ -1979,6 +1980,13 @@ export class BaileysStartupService extends ChannelStartupService {
     }
   }
 
+  private async generateMessageID() {
+
+    return {
+      id: generateMessageIDV2(this.client.user?.id)
+    };
+  }
+
   private async sendMessage(
     sender: string,
     message: any,
@@ -2242,7 +2250,7 @@ export class BaileysStartupService extends ChannelStartupService {
           mentions,
           linkPreview,
           quoted,
-          null,
+          options.messageId,
           group?.ephemeralDuration,
           // group?.participants,
         );
@@ -2264,7 +2272,7 @@ export class BaileysStartupService extends ChannelStartupService {
           mentions,
           linkPreview,
           quoted,
-          null,
+          options.messageId,
           undefined,
           contextInfo,
         );
@@ -2490,6 +2498,7 @@ export class BaileysStartupService extends ChannelStartupService {
         linkPreview: data?.linkPreview,
         mentionsEveryOne: data?.mentionsEveryOne,
         mentioned: data?.mentioned,
+        messageId: data?.messageId,
       },
       isIntegration,
     );
@@ -2506,6 +2515,7 @@ export class BaileysStartupService extends ChannelStartupService {
         linkPreview: data?.linkPreview,
         mentionsEveryOne: data?.mentionsEveryOne,
         mentioned: data?.mentioned,
+        messageId: data?.messageId,
       },
     );
   }
@@ -2819,6 +2829,7 @@ export class BaileysStartupService extends ChannelStartupService {
         quoted: data?.quoted,
         mentionsEveryOne: data?.mentionsEveryOne,
         mentioned: data?.mentioned,
+        messageId: data?.messageId,
       },
     );
 
@@ -2841,6 +2852,7 @@ export class BaileysStartupService extends ChannelStartupService {
         quoted: data?.quoted,
         mentionsEveryOne: data?.mentionsEveryOne,
         mentioned: data?.mentioned,
+        messageId: data?.messageId,
       },
       isIntegration,
     );
@@ -2857,6 +2869,7 @@ export class BaileysStartupService extends ChannelStartupService {
       quoted: data?.quoted,
       mentionsEveryOne: data?.mentionsEveryOne,
       mentioned: data?.mentioned,
+      messageId: data?.messageId,
     };
 
     if (file) mediaData.media = file.buffer.toString('base64');
@@ -2872,6 +2885,7 @@ export class BaileysStartupService extends ChannelStartupService {
         quoted: data?.quoted,
         mentionsEveryOne: data?.mentionsEveryOne,
         mentioned: data?.mentioned,
+        messageId: data?.messageId,
       },
       isIntegration,
     );

--- a/src/api/integrations/channel/whatsapp/whatsapp.baileys.service.ts
+++ b/src/api/integrations/channel/whatsapp/whatsapp.baileys.service.ts
@@ -1981,7 +1981,7 @@ export class BaileysStartupService extends ChannelStartupService {
   }
   public generateMessageID() {
     return {
-      id: generateMessageIDV2(this.client.user?.id)
+      id: generateMessageIDV2(this.client.user?.id),
     };
   }
 
@@ -2248,7 +2248,7 @@ export class BaileysStartupService extends ChannelStartupService {
           mentions,
           linkPreview,
           quoted,
-          optionsoptions?.messageId ?? null,
+          options?.messageId ?? null,
           group?.ephemeralDuration,
           // group?.participants,
         );

--- a/src/api/integrations/channel/whatsapp/whatsapp.baileys.service.ts
+++ b/src/api/integrations/channel/whatsapp/whatsapp.baileys.service.ts
@@ -1979,10 +1979,9 @@ export class BaileysStartupService extends ChannelStartupService {
       return error;
     }
   }
-
-  private async generateMessageID() {
+  public generateMessageID() {
     return {
-      id: generateMessageIDV2(this.client.user?.id),
+      id: generateMessageIDV2(this.client.user?.id)
     };
   }
 

--- a/src/api/integrations/channel/whatsapp/whatsapp.baileys.service.ts
+++ b/src/api/integrations/channel/whatsapp/whatsapp.baileys.service.ts
@@ -2248,7 +2248,7 @@ export class BaileysStartupService extends ChannelStartupService {
           mentions,
           linkPreview,
           quoted,
-          options.messageId,
+          optionsoptions?.messageId ?? null,
           group?.ephemeralDuration,
           // group?.participants,
         );
@@ -2270,7 +2270,7 @@ export class BaileysStartupService extends ChannelStartupService {
           mentions,
           linkPreview,
           quoted,
-          options.messageId,
+          options?.messageId ?? null,
           undefined,
           contextInfo,
         );

--- a/src/api/integrations/channel/whatsapp/whatsapp.baileys.service.ts
+++ b/src/api/integrations/channel/whatsapp/whatsapp.baileys.service.ts
@@ -103,6 +103,7 @@ import makeWASocket, {
   DisconnectReason,
   downloadContentFromMessage,
   downloadMediaMessage,
+  generateMessageIDV2,
   generateWAMessageFromContent,
   getAggregateVotesInPollMessage,
   GetCatalogOptions,
@@ -128,7 +129,6 @@ import makeWASocket, {
   WAMessageKey,
   WAPresence,
   WASocket,
-  generateMessageIDV2
 } from 'baileys';
 import { Label } from 'baileys/lib/Types/Label';
 import { LabelAssociation } from 'baileys/lib/Types/LabelAssociation';
@@ -1981,9 +1981,8 @@ export class BaileysStartupService extends ChannelStartupService {
   }
 
   private async generateMessageID() {
-
     return {
-      id: generateMessageIDV2(this.client.user?.id)
+      id: generateMessageIDV2(this.client.user?.id),
     };
   }
 


### PR DESCRIPTION
…essage DTO

## 📋 Description
Em cenários de alto volume de envio de mensagens via Evolution API, chamadas HTTP síncronas podem sofrer timeout, fazendo com que o backend do integrador perca a referência do msg.key.id, apesar da mensagem já ter sido gerada/enviada pelo Baileys.

Como o messageId é gerado localmente pelo Baileys antes do envio, adotei uma abordagem que permite pré-gerar esse identificador no mesmo contexto da sessão, eliminando a dependência da resposta HTTP para rastreamento.

Criada uma nova API interna:

`POST /baileys/generateMessageID/{instance}`

- Essa API:
 
  - Executa dentro do processo do Baileys
  - Gera o messageId usando generateMessageIDV2(sock.user?.id)
  - Retorna um messageId válido, único e compatível com o protocolo WhatsApp

- Ajustado o fluxo de envio para:

  - Aceitar messageId opcional via options
  - Utilizar o messageId fornecido quando presente
  - Manter o comportamento padrão do Baileys (geração automática) quando não informado

Benefícios:

- Elimina perda de referência em caso de timeout HTTP
- Permite persistir o messageId antes do envio
- Mantém ACK / READ / DELIVERY totalmente compatíveis
- Não altera o comportamento padrão quando o override não é usado
- Não impacta a fila de jobs nem a integridade da sessão

Observações importantes:

- Cada messageId deve ser usado uma única vez
- O ID deve ser gerado e utilizado imediatamente, na mesma sessão ativa
- IDs não utilizados ou gerados antes de reconnect devem ser descartados
- O uso concorrente deve respeitar a serialização por instância

## 🔗 Related Issue
<!-- Link to the issue this PR addresses -->
Closes #(issue_number)

## 🧪 Type of Change
<!-- Mark with an `x` all the checkboxes that apply -->
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔧 Refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] 🧹 Code cleanup
- [ ] 🔒 Security fix

## 🧪 Testing
<!-- Describe the testing you performed to verify your changes -->
- [x] Manual testing completed
- [x] Functionality verified in development environment
- [x] No breaking changes introduced
- [x] Tested with different connection types (if applicable)

## 📸 Screenshots (if applicable)
<!-- Add screenshots to help explain your changes -->

## ✅ Checklist
<!-- Mark with an `x` all the checkboxes that apply -->
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have manually tested my changes thoroughly
- [x] I have verified the changes work with different scenarios
- [ ] Any dependent changes have been merged and published

## 📝 Additional Notes
<!-- Any additional information, concerns, or questions -->

## Summary by Sourcery

Add support for externally supplied WhatsApp message IDs and expose an internal API to pre-generate protocol-compatible message IDs per instance.

New Features:
- Expose a generateMessageID endpoint on the Baileys router/controller to return a Baileys-generated WhatsApp message ID for a given instance.
- Allow send message flows in Baileys and Evolution services to accept an optional messageId from options/DTO metadata and use it when present instead of always generating a new ID.

Enhancements:
- Propagate messageId through sendMessage DTO options and metadata to keep message tracking consistent across different WhatsApp integration paths.