### PR TITLE
feat(chatwoot): add support for WhatsApp catalog orderMessage

### DIFF
--- a/src/api/integrations/chatbot/chatwoot/services/chatwoot.service.ts
+++ b/src/api/integrations/chatbot/chatwoot/services/chatwoot.service.ts
@@ -1827,6 +1827,7 @@ export class ChatwootService {
     listMessage: msg.listMessage,
     listResponseMessage: msg.listResponseMessage,
     orderMessage: msg.orderMessage,
+    quotedProductMessage: msg.contextInfo?.quotedMessage?.productMessage,
     viewOnceMessageV2:
       msg?.message?.viewOnceMessageV2?.message?.imageMessage?.url ||
       msg?.message?.viewOnceMessageV2?.message?.videoMessage?.url ||
@@ -1861,6 +1862,40 @@ export class ChatwootService {
       }
       this.processedOrderIds.set(result.orderId, now);
     }
+    // Tratamento de Produto citado (WhatsApp Desktop)
+if (typeKey === 'quotedProductMessage' && result?.product) {
+  const product = result.product;
+  
+  // Extrai preço
+  let rawPrice = 0;
+  const amount = product.priceAmount1000;
+
+  if (Long.isLong(amount)) {
+    rawPrice = amount.toNumber();
+  } else if (amount && typeof amount === 'object' && 'low' in amount) {
+    rawPrice = Long.fromValue(amount).toNumber();
+  } else if (typeof amount === 'number') {
+    rawPrice = amount;
+  }
+
+  const price = (rawPrice / 1000).toLocaleString('pt-BR', {
+    style: 'currency',
+    currency: product.currencyCode || 'BRL',
+  });
+
+  const productTitle = product.title || 'Produto do catálogo';
+  const productId = product.productId || 'N/A';
+
+  return (
+    `🛒 *PRODUTO DO CATÁLOGO (Desktop)*\n` +
+    `━━━━━━━━━━━━━━━━━━━━━\n` +
+    `📦 *Produto:* ${productTitle}\n` +
+    `💰 *Preço:* ${price}\n` +
+    `🆔 *Código:* ${productId}\n` +
+    `━━━━━━━━━━━━━━━━━━━━━\n` +
+    `_Cliente perguntou: "${types.conversation || 'Me envia este produto?'}"_`
+  );
+}
     if (typeKey === 'orderMessage') {
       // Extrai o valor - pode ser Long, objeto {low, high}, ou número direto
       let rawPrice = 0;

--- a/src/api/integrations/chatbot/chatwoot/services/chatwoot.service.ts
+++ b/src/api/integrations/chatbot/chatwoot/services/chatwoot.service.ts
@@ -1758,39 +1758,58 @@ export class ChatwootService {
   }
 
   private getTypeMessage(msg: any) {
-    const types = {
-      conversation: msg.conversation,
-      imageMessage: msg.imageMessage?.caption,
-      videoMessage: msg.videoMessage?.caption,
-      extendedTextMessage: msg.extendedTextMessage?.text,
-      messageContextInfo: msg.messageContextInfo?.stanzaId,
-      stickerMessage: undefined,
-      documentMessage: msg.documentMessage?.caption,
-      documentWithCaptionMessage: msg.documentWithCaptionMessage?.message?.documentMessage?.caption,
-      audioMessage: msg.audioMessage ? (msg.audioMessage.caption ?? '') : undefined,
-      contactMessage: msg.contactMessage?.vcard,
-      contactsArrayMessage: msg.contactsArrayMessage,
-      locationMessage: msg.locationMessage,
-      liveLocationMessage: msg.liveLocationMessage,
-      listMessage: msg.listMessage,
-      listResponseMessage: msg.listResponseMessage,
-      viewOnceMessageV2:
-        msg?.message?.viewOnceMessageV2?.message?.imageMessage?.url ||
-        msg?.message?.viewOnceMessageV2?.message?.videoMessage?.url ||
-        msg?.message?.viewOnceMessageV2?.message?.audioMessage?.url,
-    };
+  const types = {
+    conversation: msg.conversation,
+    imageMessage: msg.imageMessage?.caption,
+    videoMessage: msg.videoMessage?.caption,
+    extendedTextMessage: msg.extendedTextMessage?.text,
+    messageContextInfo: msg.messageContextInfo?.stanzaId,
+    stickerMessage: undefined,
+    documentMessage: msg.documentMessage?.caption,
+    documentWithCaptionMessage: msg.documentWithCaptionMessage?.message?.documentMessage?.caption,
+    audioMessage: msg.audioMessage ? (msg.audioMessage.caption ?? '') : undefined,
+    contactMessage: msg.contactMessage?.vcard,
+    contactsArrayMessage: msg.contactsArrayMessage,
+    locationMessage: msg.locationMessage,
+    liveLocationMessage: msg.liveLocationMessage,
+    listMessage: msg.listMessage,
+    listResponseMessage: msg.listResponseMessage,
+    // Adicione a linha abaixo. Atenção à vírgula na linha de cima!
+    orderMessage: msg.orderMessage, 
+    viewOnceMessageV2:
+      msg?.message?.viewOnceMessageV2?.message?.imageMessage?.url ||
+      msg?.message?.viewOnceMessageV2?.message?.videoMessage?.url ||
+      msg?.message?.viewOnceMessageV2?.message?.audioMessage?.url,
+  };
 
-    return types;
-  }
+  return types;
+}
 
   private getMessageContent(types: any) {
     const typeKey = Object.keys(types).find((key) => types[key] !== undefined);
 
     let result = typeKey ? types[typeKey] : undefined;
 
-    // Remove externalAdReplyBody| in Chatwoot (Already Have)
+    // Remove externalAdReplyBody| in Chatwoot
     if (result && typeof result === 'string' && result.includes('externalAdReplyBody|')) {
       result = result.split('externalAdReplyBody|').filter(Boolean).join('');
+    }
+
+    // Tratamento de Pedidos do Catálogo
+    if (typeKey === 'orderMessage') {
+      const amount = result.totalAmount1000;
+      // Converte o objeto Long para número antes da divisão
+      const rawPrice = (Long.isLong(amount) ? amount.toNumber() : amount) || 0;
+      const price = (rawPrice / 1000).toLocaleString('pt-BR', {
+        style: 'currency',
+        currency: result.totalCurrencyCode || 'BRL',
+      });
+
+      return `🛒 *NOVO PEDIDO NO CATÁLOGO*\n\n` +
+             `*Produto:* ${result.orderTitle}\n` +
+             `*Valor:* ${price}\n` +
+             `*ID:* ${result.orderId}\n\n` +
+             `_Atenda agora para finalizar a venda!_`;
     }
 
     if (typeKey === 'locationMessage' || typeKey === 'liveLocationMessage') {


### PR DESCRIPTION
This PR adds support for orderMessage (catalog orders) in the Chatwoot integration. Previously, catalog orders would appear as empty messages. This change ensures that the product title, price, and ID are correctly formatted and sent as text to Chatwoot.

## Summary by Sourcery

Add support for WhatsApp Business catalog order messages in the Chatwoot integration and prevent duplicate order events from being sent.

New Features:
- Format WhatsApp catalog orderMessage payloads into readable text messages with product, quantity, total price, and order ID for Chatwoot.

Bug Fixes:
- Ensure catalog orders no longer appear as empty messages in Chatwoot by correctly extracting their content.
- Avoid sending duplicate catalog order messages by caching and deduplicating order IDs with a short TTL.