### PR TITLE
fix: resolve facebook ads context readability (externalAdReply)

### DIFF
--- a/src/utils/getConversationMessage.ts
+++ b/src/utils/getConversationMessage.ts
@@ -49,13 +49,17 @@ const getTypeMessage = (msg: any) => {
             : ''
         }`
       : undefined,
-    
+
     // --- FIX FACEBOOK ADS START ---
     externalAdReplyBody: msg?.message?.extendedTextMessage?.contextInfo?.externalAdReply?.body
       ? `externalAdReplyBody|${msg.message.extendedTextMessage.contextInfo.externalAdReply.body}`
       : msg?.message?.extendedTextMessage?.contextInfo?.externalAdReply?.title
-      ? `externalAdReplyBody|${msg.message.extendedTextMessage.contextInfo.externalAdReply.title}`
-      : undefined,
+        ? `externalAdReplyBody|${msg.message.extendedTextMessage.contextInfo.externalAdReply.title}`
+        : msg?.contextInfo?.externalAdReply?.body
+          ? `externalAdReplyBody|${msg.contextInfo.externalAdReply.body}`
+          : msg?.contextInfo?.externalAdReply?.title
+            ? `externalAdReplyBody|${msg.contextInfo.externalAdReply.title}`
+            : undefined,
     // --- FIX FACEBOOK ADS END ---
   };
 
@@ -65,7 +69,9 @@ const getTypeMessage = (msg: any) => {
 };
 
 const getMessageContent = (types: any) => {
-  const typeKey = Object.keys(types).find((key) => key !== 'externalAdReplyBody' && key !== 'messageType' && types[key] !== undefined);
+  const typeKey = Object.keys(types).find(
+    (key) => key !== 'externalAdReplyBody' && key !== 'messageType' && types[key] !== undefined,
+  );
 
   let result = typeKey ? types[typeKey] : undefined;
 

--- a/src/utils/getConversationMessage.ts
+++ b/src/utils/getConversationMessage.ts
@@ -16,7 +16,7 @@ const getTypeMessage = (msg: any) => {
     conversation: msg?.message?.conversation,
     extendedTextMessage: msg?.message?.extendedTextMessage?.text,
     contactMessage: msg?.message?.contactMessage?.displayName,
-    locationMessage: msg?.message?.locationMessage?.degreesLatitude.toString(),
+    locationMessage: msg?.message?.locationMessage?.degreesLatitude?.toString(),
     viewOnceMessageV2:
       msg?.message?.viewOnceMessageV2?.message?.imageMessage?.url ||
       msg?.message?.viewOnceMessageV2?.message?.videoMessage?.url ||
@@ -49,9 +49,14 @@ const getTypeMessage = (msg: any) => {
             : ''
         }`
       : undefined,
-    externalAdReplyBody: msg?.contextInfo?.externalAdReply?.body
-      ? `externalAdReplyBody|${msg.contextInfo.externalAdReply.body}`
+    
+    // --- FIX FACEBOOK ADS START ---
+    externalAdReplyBody: msg?.message?.extendedTextMessage?.contextInfo?.externalAdReply?.body
+      ? `externalAdReplyBody|${msg.message.extendedTextMessage.contextInfo.externalAdReply.body}`
+      : msg?.message?.extendedTextMessage?.contextInfo?.externalAdReply?.title
+      ? `externalAdReplyBody|${msg.message.extendedTextMessage.contextInfo.externalAdReply.title}`
       : undefined,
+    // --- FIX FACEBOOK ADS END ---
   };
 
   const messageType = Object.keys(types).find((key) => types[key] !== undefined) || 'unknown';
@@ -60,7 +65,7 @@ const getTypeMessage = (msg: any) => {
 };
 
 const getMessageContent = (types: any) => {
-  const typeKey = Object.keys(types).find((key) => key !== 'externalAdReplyBody' && types[key] !== undefined);
+  const typeKey = Object.keys(types).find((key) => key !== 'externalAdReplyBody' && key !== 'messageType' && types[key] !== undefined);
 
   let result = typeKey ? types[typeKey] : undefined;
 
@@ -73,8 +78,6 @@ const getMessageContent = (types: any) => {
 
 export const getConversationMessage = (msg: any) => {
   const types = getTypeMessage(msg);
-
   const messageContent = getMessageContent(types);
-
   return messageContent;
 };


### PR DESCRIPTION
## Description
This PR resolves an issue where the API fails to parse the context of Facebook/Instagram Click-to-WhatsApp ads (`externalAdReply`). Previously, if a user clicked an ad but sent only the default pre-filled message, the API would treat it as an empty or unknown message type because the ad payload resides in `contextInfo`, not the main text body.

## Changes
- Modified `src/utils/getConversationMessage.ts`.
- Added logic to detect `externalAdReply` in `msg.message.extendedTextMessage.contextInfo`.
- Extracted `body` (or `title` as fallback) from the ad payload.
- Appended the ad context to the user message string using a helper function to ensure downstream controllers receive a standard string format.

## Testing
- Verified with mocked payloads containing `externalAdReply`.
- Validated that `base-chatbot` and `typebot` services receive the concatenated string correctly.

## Summary by Sourcery

Handle Facebook/Instagram Click-to-WhatsApp ad messages by correctly extracting and appending external ad reply context to the conversation message.

Bug Fixes:
- Avoid runtime errors when location messages lack latitude by safely stringifying the latitude value.
- Treat externalAdReply context from extended text messages as part of the user message, falling back to the ad title when the body is missing, and exclude this metadata from primary message type detection.