### PR TITLE
fix(evolution): prevent Evolution instances from getting stuck in 'cl…

### DIFF
--- a/src/api/controllers/instance.controller.ts
+++ b/src/api/controllers/instance.controller.ts
@@ -156,6 +156,10 @@ export class InstanceController {
           getQrcode = instance.qrCode;
         }
 
+        if (instanceData.integration === Integration.EVOLUTION) {
+          await instance.connectToWhatsapp();
+        }
+
         const result = {
           instance: {
             instanceName: instance.instanceName,

--- a/src/api/integrations/channel/evolution/evolution.channel.service.ts
+++ b/src/api/integrations/channel/evolution/evolution.channel.service.ts
@@ -115,6 +115,15 @@ export class EvolutionStartupService extends ChannelStartupService {
 
   public async connectToWhatsapp(data?: any): Promise<any> {
     if (!data) {
+      this.stateConnection = { state: 'open' };
+
+      if (this.instanceId) {
+        await this.prismaRepository.instance.update({
+          where: { id: this.instanceId },
+          data: { connectionStatus: 'open' },
+        });
+      }
+
       this.loadChatwoot();
       return;
     }

--- a/src/api/services/monitor.service.ts
+++ b/src/api/services/monitor.service.ts
@@ -293,7 +293,11 @@ export class WAMonitoringService {
       ownerJid: instanceData.ownerJid,
     });
 
-    if (instanceData.connectionStatus === 'open' || instanceData.connectionStatus === 'connecting') {
+    if (
+      instanceData.connectionStatus === 'open' ||
+      instanceData.connectionStatus === 'connecting' ||
+      instanceData.integration === Integration.EVOLUTION
+    ) {
       this.logger.info(
         `Auto-connecting instance "${instanceData.instanceName}" (status: ${instanceData.connectionStatus})`,
       );


### PR DESCRIPTION
…ose' state

Evolution is a webhook-based integration that should always be considered 'open' since it passively receives events. Three changes fix the issue:

1. monitor.service.ts: Always call connectToWhatsapp() for Evolution instances on server restart, regardless of stored connection status.
2. instance.controller.ts: Call connectToWhatsapp() for Evolution instances during creation to initialize Chatwoot settings.
3. evolution.channel.service.ts: Restore stateConnection to 'open' and persist it to DB when connectToWhatsapp() is called in init mode.

Closes #2419

https://claude.ai/code/session_013wxk4cj5U2H5fr2cxCgWdH

## 📋 Description
<!-- Describe your changes in detail -->

## 🔗 Related Issue
<!-- Link to the issue this PR addresses -->
Closes #(issue_number)

## 🧪 Type of Change
<!-- Mark with an `x` all the checkboxes that apply -->
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔧 Refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] 🧹 Code cleanup
- [ ] 🔒 Security fix

## 🧪 Testing
<!-- Describe the testing you performed to verify your changes -->
- [ ] Manual testing completed
- [ ] Functionality verified in development environment
- [ ] No breaking changes introduced
- [ ] Tested with different connection types (if applicable)

## 📸 Screenshots (if applicable)
<!-- Add screenshots to help explain your changes -->

## ✅ Checklist
<!-- Mark with an `x` all the checkboxes that apply -->
- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have manually tested my changes thoroughly
- [ ] I have verified the changes work with different scenarios
- [ ] Any dependent changes have been merged and published

## 📝 Additional Notes
<!-- Any additional information, concerns, or questions -->

## Summary by Sourcery

Ensure Evolution WhatsApp integrations are always initialized and marked as open so they do not remain stuck in a closed state.

Bug Fixes:
- Reset Evolution instances' connection state to open and persist it when initialized without data.
- Auto-connect Evolution instances on server restart regardless of their stored connection status.
- Initialize Evolution instances by connecting to WhatsApp on creation so related settings are correctly set up.