### PR TITLE
feat(label): add GET /label/syncLabels endpoint to force WhatsApp label re-sync

### DIFF
--- a/src/api/controllers/label.controller.ts
+++ b/src/api/controllers/label.controller.ts
@@ -12,4 +12,8 @@ export class LabelController {
   public async handleLabel({ instanceName }: InstanceDto, data: HandleLabelDto) {
     return await this.waMonitor.waInstances[instanceName].handleLabel(data);
   }
+
+  public async syncLabels({ instanceName }: InstanceDto) {
+    return await this.waMonitor.waInstances[instanceName].syncLabels();
+  }
 }

--- a/src/api/integrations/channel/evolution/evolution.channel.service.ts
+++ b/src/api/integrations/channel/evolution/evolution.channel.service.ts
@@ -876,6 +876,9 @@ export class EvolutionStartupService extends ChannelStartupService {
   public async fetchLabels() {
     throw new BadRequestException('Method not available on Evolution Channel');
   }
+  public async syncLabels() {
+    throw new BadRequestException('Method not available on Evolution Channel');
+  }
   public async handleLabel() {
     throw new BadRequestException('Method not available on Evolution Channel');
   }

--- a/src/api/integrations/channel/meta/whatsapp.business.service.ts
+++ b/src/api/integrations/channel/meta/whatsapp.business.service.ts
@@ -1759,6 +1759,9 @@ export class BusinessStartupService extends ChannelStartupService {
   public async fetchLabels() {
     throw new BadRequestException('Method not available on WhatsApp Business API');
   }
+  public async syncLabels() {
+    throw new BadRequestException('Method not available on WhatsApp Business API');
+  }
   public async handleLabel() {
     throw new BadRequestException('Method not available on WhatsApp Business API');
   }

--- a/src/api/integrations/channel/whatsapp/whatsapp.baileys.service.ts
+++ b/src/api/integrations/channel/whatsapp/whatsapp.baileys.service.ts
@@ -1,4 +1,4 @@
-import { getCollectionsDto } from '@api/dto/business.dto';
+﻿import { getCollectionsDto } from '@api/dto/business.dto';
 import { OfferCallDto } from '@api/dto/call.dto';
 import {
   ArchiveChatDto,
@@ -4254,6 +4254,20 @@ export class BaileysStartupService extends ChannelStartupService {
       predefinedId: label.predefinedId,
     }));
   }
+
+  public async syncLabels(): Promise<LabelDto[]> {
+    // Force Baileys to re-download label app state from WhatsApp (incremental)
+    // Using true for isLatest = incremental sync (safe, no disconnect)
+    // Using false would download full snapshot and may cause disconnection
+    await this.client.resyncAppState(['regular'], true);
+
+    // Wait for LABELS_EDIT and LABELS_ASSOCIATION events to be processed
+    await new Promise((resolve) => setTimeout(resolve, 3000));
+
+    // Return the now-updated labels from database
+    return this.fetchLabels();
+  }
+
 
   public async handleLabel(data: HandleLabelDto) {
     const whatsappContact = await this.whatsappNumber({ numbers: [data.number] });

--- a/src/api/routes/label.router.ts
+++ b/src/api/routes/label.router.ts
@@ -20,6 +20,16 @@ export class LabelRouter extends RouterBroker {
 
         return res.status(HttpStatus.OK).json(response);
       })
+      .get(this.routerPath('syncLabels'), ...guards, async (req, res) => {
+        const response = await this.dataValidate<LabelDto>({
+          request: req,
+          schema: null,
+          ClassRef: LabelDto,
+          execute: (instance) => labelController.syncLabels(instance),
+        });
+
+        return res.status(HttpStatus.OK).json(response);
+      })
       .post(this.routerPath('handleLabel'), ...guards, async (req, res) => {
         const response = await this.dataValidate<HandleLabelDto>({
           request: req,


### PR DESCRIPTION
## 📋 Description
Add `GET /label/syncLabels/:instanceName` endpoint that forces WhatsApp to re-download labels via Baileys' `resyncAppState(['regular'], true)`.

### Problem
Currently, `GET /label/findLabels/:instanceName` only reads labels from the Prisma database. Labels created, renamed, or recolored on WhatsApp **after** the initial connection are never reflected in the API response. There is no way to force a re-sync of labels from WhatsApp.

### Solution
New endpoint `syncLabels` that:
1. Calls `this.client.resyncAppState(['regular'], true)` to trigger an incremental re-download of WhatsApp's label app state
2. Waits 3 seconds for the existing `LABELS_EDIT` and `LABELS_ASSOCIATION` event handlers to process incoming data
3. Returns the updated labels from the database (same `LabelDto[]` format as `findLabels`)

### Key Technical Details
- **`resyncAppState(['regular'], true)`** — the `true` parameter means "incremental" (only fetch changes since last sync). This is safe and does NOT cause disconnects.
- **`resyncAppState(['regular'], false)`** — would download the FULL snapshot, which causes WhatsApp to disconnect the session. This was tested and confirmed in production. We intentionally use `true`.
- **3-second delay** allows Baileys' built-in event handlers (`labelHandle[Events.LABELS_EDIT]` and `labelHandle[Events.LABELS_ASSOCIATION]`) to process and persist the incoming label data before reading from DB.
- **No schema validation needed** — like `findLabels`, this is a simple GET with only the `instanceName` parameter.

### Use Case
CRM integrations (Odoo, Chatwoot, etc.) that need to keep label data in sync with WhatsApp. The CRM calls `syncLabels` periodically to ensure it has the latest labels before mapping them to contacts/conversations.

### Files Changed
| File | Change |
|------|--------|
| `whatsapp.baileys.service.ts` | Added `syncLabels()` method using `resyncAppState` + `fetchLabels()` |
| `label.controller.ts` | Added `syncLabels()` delegation (same pattern as `fetchLabels`) |
| `label.router.ts` | Added `GET /label/syncLabels/:instanceName` route (same pattern as `findLabels`) |
| `evolution.channel.service.ts` | Added stub throwing `BadRequestException` |
| `whatsapp.business.service.ts` | Added stub throwing `BadRequestException` |

## 🔗 Related Issue
This addresses a gap in the label management API. Related to #1904 (labels.association handling).

## 🧪 Type of Change
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔧 Refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] 🧹 Code cleanup
- [ ] 🔒 Security fix

## 🧪 Testing
- [x] Manual testing completed
- [x] Functionality verified in development environment
- [x] No breaking changes introduced
- [x] Tested with different connection types (if applicable)

**Test results (production VPS, Evolution API v2.2.0):**
- ✅ `GET /label/syncLabels/testInstance` → HTTP 200, returns updated `LabelDto[]`
- ✅ No WhatsApp disconnection (incremental sync with `isLatest=true`)
- ✅ Labels created after initial connection are now returned after sync
- ✅ Existing `findLabels` and `handleLabel` endpoints completely unaffected
- ✅ Evolution Channel stub correctly returns 400 BadRequestException
- ✅ WhatsApp Business API stub correctly returns 400 BadRequestException
- ✅ Tested integration with Odoo CRM — labels synced successfully

## ✅ Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have manually tested my changes thoroughly
- [x] I have verified the changes work with different scenarios
- [x] Any dependent changes have been merged and published

## 📝 Additional Notes
- The `resyncAppState` function is provided by Baileys but was never used anywhere in the Evolution API codebase before this PR.
- This feature is particularly valuable for multi-device setups where labels are managed from the phone but need to be reflected in the API.
- The 3-second delay is a pragmatic choice based on production testing. It could be made configurable in a future enhancement.

## Summary by Sourcery

Add support for explicitly re-syncing WhatsApp labels and expose it via a new HTTP endpoint.

New Features:
- Introduce a Baileys service method to trigger an incremental WhatsApp label resync and return updated labels.
- Expose a new GET /label/syncLabels/:instanceName route and controller method to trigger label resync for a given instance.

Chores:
- Add stub syncLabels methods for Evolution and WhatsApp Business channels that return BadRequest exceptions.