### PR TITLE
fix(docker): fix docker-compose startup failures for fresh installs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -52,7 +52,13 @@ DEL_INSTANCE=false
 
 # Provider: postgresql | mysql | psql_bouncer
 DATABASE_PROVIDER=postgresql
-DATABASE_CONNECTION_URI='postgresql://user:pass@postgres:5432/evolution_db?schema=evolution_api'
+DATABASE_CONNECTION_URI='postgresql://user:pass@evolution-postgres:5432/evolution_db?schema=evolution_api'
+
+# Postgres container settings (used by docker-compose)
+POSTGRES_DATABASE=evolution_db
+POSTGRES_USERNAME=user
+POSTGRES_PASSWORD=pass
+
 # Client name for the database connection
 # It is used to separate an API installation from another that uses the same database.
 DATABASE_CONNECTION_CLIENT_NAME=evolution_exchange

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -14,7 +14,6 @@ services:
       - evolution_instances:/evolution/instances
     networks:
       - evolution-net
-      - dokploy-network
     env_file:
       - .env
     expose:
@@ -26,6 +25,8 @@ services:
     restart: always
     ports:
       - "3000:80"
+    volumes:
+      - ./nginx.conf:/etc/nginx/conf.d/nginx.conf:ro
     networks:
       - evolution-net
 
@@ -39,9 +40,6 @@ services:
       - evolution_redis:/data
     networks:
       evolution-net:
-        aliases:
-          - evolution-redis
-      dokploy-network:
         aliases:
           - evolution-redis
     expose:
@@ -67,7 +65,6 @@ services:
       - postgres_data:/var/lib/postgresql/data
     networks:
       - evolution-net
-      - dokploy-network
     expose:
       - "5432"
 
@@ -80,5 +77,3 @@ networks:
   evolution-net:
     name: evolution-net
     driver: bridge
-  dokploy-network:
-    external: true

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,51 @@
+server {
+    listen 80;
+    server_name localhost;
+    root /usr/share/nginx/html;
+    index index.html;
+
+    # Gzip compression
+    gzip on;
+    gzip_vary on;
+    gzip_min_length 1024;
+    gzip_proxied expired no-cache no-store private auth;
+    gzip_types
+        text/plain
+        text/css
+        text/xml
+        text/javascript
+        application/javascript
+        application/xml+rss
+        application/json;
+
+    # Security headers
+    add_header X-Frame-Options "SAMEORIGIN" always;
+    add_header X-XSS-Protection "1; mode=block" always;
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header Referrer-Policy "no-referrer-when-downgrade" always;
+    add_header Content-Security-Policy "default-src 'self' http: https: data: blob: 'unsafe-inline'" always;
+
+    # Handle client routing
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+
+    # Cache static assets
+    location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg|woff|woff2|ttf|eot)$ {
+        expires 1y;
+        add_header Cache-Control "public, immutable";
+    }
+
+    # Cache HTML files for a shorter period
+    location ~* \.html$ {
+        expires 1h;
+        add_header Cache-Control "public";
+    }
+
+    # Health check endpoint
+    location /health {
+        access_log off;
+        return 200 "healthy\n";
+        add_header Content-Type text/plain;
+    }
+}


### PR DESCRIPTION
## Summary

Running `docker-compose up` on a fresh clone fails with multiple errors. This PR fixes all of them:

- **Remove `dokploy-network` external network dependency** — The compose file references `dokploy-network` as an external network, but it doesn't exist by default. This causes `docker-compose up` to fail immediately on any fresh install. Services that referenced it: `api`, `redis`, `evolution-postgres`.

- **Fix `evolution-manager` frontend nginx crash** — The `evoapicloud/evolution-manager:latest` image ships with an invalid `gzip_proxied` directive containing `must-revalidate` (a `Cache-Control` value, not a valid `gzip_proxied` option). This causes nginx to crash-loop on startup. Fix: add a corrected `nginx.conf` mounted as a volume override.

- **Add missing Postgres env vars to `.env.example`** — The `docker-compose.yaml` references `${POSTGRES_DATABASE}`, `${POSTGRES_USERNAME}`, and `${POSTGRES_PASSWORD}`, but these variables are missing from `.env.example`. This causes the postgres container to fail with `POSTGRES_PASSWORD is not specified`.

- **Fix `DATABASE_CONNECTION_URI` hostname** — The connection string in `.env.example` uses `postgres` as the hostname, but the docker-compose service is named `evolution-postgres`. This causes the API to fail to connect to the database.

## Changes

| File | Change |
|---|---|
| `docker-compose.yaml` | Remove `dokploy-network` from all services and networks section |
| `docker-compose.yaml` | Add `nginx.conf` volume mount for frontend service |
| `nginx.conf` | New file — corrected nginx config (removed invalid `must-revalidate` from `gzip_proxied`) |
| `.env.example` | Add `POSTGRES_DATABASE`, `POSTGRES_USERNAME`, `POSTGRES_PASSWORD` |
| `.env.example` | Fix hostname: `postgres` → `evolution-postgres` in `DATABASE_CONNECTION_URI` |

## Test plan

- [ ] Clone repo fresh, copy `.env.example` to `.env`, run `docker-compose up -d`
- [ ] All 4 containers should start without errors: `api`, `frontend`, `redis`, `evolution-postgres`
- [ ] `curl http://localhost:8080` returns welcome JSON
- [ ] `http://localhost:3000` loads the Evolution Manager frontend

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Resolve docker-compose startup failures on fresh installs by adjusting networking, configuration, and environment defaults for the Evolution stack.

Bug Fixes:
- Remove dependency on a non-existent external Docker network to allow services to start on fresh installs.
- Add a custom nginx configuration for the frontend container to prevent nginx startup crashes caused by an invalid gzip directive.
- Add missing Postgres environment variables to the example env file so the database container can initialize correctly.
- Correct the database connection URI hostname in the example env file so the API can reach the Postgres service.

Enhancements:
- Introduce a hardened nginx configuration for the Evolution Manager frontend with gzip compression, security headers, SPA routing, asset caching, and a health check endpoint.