### PR TITLE
fix(channel): remove duplicated pushName alias and prefer Contact.pushName in fetchChats

### DIFF
--- a/src/api/services/channel.service.ts
+++ b/src/api/services/channel.service.ts
@@ -818,7 +818,6 @@ export class ChannelStartupService {
               to_timestamp("Message"."messageTimestamp"::double precision),
               "Contact"."updatedAt"
             ) as "updatedAt",
-            "Chat"."name" as "pushName",
             "Chat"."createdAt" as "windowStart",
             "Chat"."createdAt" + INTERVAL '24 hours' as "windowExpires",
             "Chat"."unreadMessages" as "unreadMessages",

--- a/src/api/services/channel.service.ts
+++ b/src/api/services/channel.service.ts
@@ -811,7 +811,7 @@ export class ChannelStartupService {
             "Message"."key"->>'remoteJid' as "remoteJid",
             CASE
               WHEN "Message"."key"->>'remoteJid' LIKE '%@g.us' THEN COALESCE("Chat"."name", "Contact"."pushName")
-              ELSE COALESCE("Contact"."pushName", "Message"."pushName")
+              ELSE "Contact"."pushName"
             END as "pushName",
             "Contact"."profilePicUrl",
             COALESCE(

--- a/src/api/services/channel.service.ts
+++ b/src/api/services/channel.service.ts
@@ -752,7 +752,7 @@ export class ChannelStartupService {
           JSON_UNQUOTE(JSON_EXTRACT(Message.key, '$.remoteJid')) as remoteJid,
           CASE
             WHEN JSON_UNQUOTE(JSON_EXTRACT(Message.key, '$.remoteJid')) LIKE '%@g.us' THEN COALESCE(Chat.name, Contact.pushName)
-            ELSE COALESCE(Contact.pushName, Message.pushName)
+            ELSE Contact.pushName
           END as pushName,
           Contact.profilePicUrl,
           COALESCE(


### PR DESCRIPTION
### 📋 Description
This PR updates the chat listing query to ensure that the `pushName` always reflects the contact’s name, not the name from the last message sender.

Previously, in the PostgreSQL `fetchChats` query, the `pushName` for non-group chats was calculated using `COALESCE("Contact"."pushName", "Message"."pushName")`. This could lead to incorrect results: when the last message was sent by someone else (e.g., in a multi-participant context), the `pushName` would show the sender’s name instead of the contact’s name. The query has been updated so that, for non-group chats, `pushName` now uses only `"Contact"."pushName"`, preventing it from being overridden by `"Message"."pushName"` and ensuring consistent, contact-based naming.

### 🔗 Related Issue
Closes #(issue_number)

### 🧪 Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔧 Refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] 🧹 Code cleanup
- [ ] 🔒 Security fix

### 🧪 Testing
- [x] Manual testing completed
- [x] Functionality verified in development environment
- [x] No breaking changes introduced
- [ ] Tested with different connection types (if applicable)

**Testing details:**
- Verified that chats where the last message was sent by another user no longer display that user’s name as `pushName`, but instead correctly show the contact’s `pushName`.
- Confirmed that existing chats with a valid `Contact.pushName` keep the same visible name.
- Ensured the overall chat listing query still returns the expected structure and ordering.

### 📸 Screenshots (if applicable)
<!-- Add screenshots to help explain your changes -->

### ✅ Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have manually tested my changes thoroughly
- [x] I have verified the changes work with different scenarios
- [ ] Any dependent changes have been merged and published

### 📝 Additional Notes
- This change aligns the `pushName` behavior with the expectation that it always represents the contact’s name in chat lists, avoiding confusion when the last message is sent by someone else.