### PR TITLE
fix(whatsapp): resolve this.isZero error in list messages by removing destructive JSON cloning

### DIFF
--- a/src/api/integrations/channel/whatsapp/whatsapp.baileys.service.ts
+++ b/src/api/integrations/channel/whatsapp/whatsapp.baileys.service.ts
@@ -678,14 +678,10 @@ export class BaileysStartupService extends ChannelStartupService {
         if (
           message.deviceSentMessage?.message?.listMessage?.listType === proto.Message.ListMessage.ListType.PRODUCT_LIST
         ) {
-          message = JSON.parse(JSON.stringify(message));
-
           message.deviceSentMessage.message.listMessage.listType = proto.Message.ListMessage.ListType.SINGLE_SELECT;
         }
 
-        if (message.listMessage?.listType == proto.Message.ListMessage.ListType.PRODUCT_LIST) {
-          message = JSON.parse(JSON.stringify(message));
-
+        if (message.listMessage?.listType === proto.Message.ListMessage.ListType.PRODUCT_LIST) {
           message.listMessage.listType = proto.Message.ListMessage.ListType.SINGLE_SELECT;
         }
 

--- a/src/api/integrations/channel/whatsapp/whatsapp.baileys.service.ts
+++ b/src/api/integrations/channel/whatsapp/whatsapp.baileys.service.ts
@@ -224,6 +224,12 @@ async function getVideoDuration(input: Buffer | string | Readable): Promise<numb
   return Math.round(parseFloat(duration));
 }
 
+function normalizeListType(listMessage?: proto.Message.IListMessage | null): void {
+  if (listMessage?.listType === proto.Message.ListMessage.ListType.PRODUCT_LIST) {
+    listMessage.listType = proto.Message.ListMessage.ListType.SINGLE_SELECT;
+  }
+}
+
 export class BaileysStartupService extends ChannelStartupService {
   private messageProcessor = new BaileysMessageProcessor();
 
@@ -675,15 +681,8 @@ export class BaileysStartupService extends ChannelStartupService {
       userDevicesCache: this.userDevicesCache,
       transactionOpts: { maxCommitRetries: 10, delayBetweenTriesMs: 3000 },
       patchMessageBeforeSending(message) {
-        if (
-          message.deviceSentMessage?.message?.listMessage?.listType === proto.Message.ListMessage.ListType.PRODUCT_LIST
-        ) {
-          message.deviceSentMessage.message.listMessage.listType = proto.Message.ListMessage.ListType.SINGLE_SELECT;
-        }
-
-        if (message.listMessage?.listType === proto.Message.ListMessage.ListType.PRODUCT_LIST) {
-          message.listMessage.listType = proto.Message.ListMessage.ListType.SINGLE_SELECT;
-        }
+        normalizeListType(message.deviceSentMessage?.message?.listMessage);
+        normalizeListType(message.listMessage);
 
         return message;
       },


### PR DESCRIPTION
## 📋 Description

This PR resolves the `TypeError: this.isZero is not a function` crash that occurs when attempting to send list messages via the `/message/sendList/` endpoint.

**Root Cause:**
Inside `src/api/integrations/channel/whatsapp/whatsapp.baileys.service.ts`, the `patchMessageBeforeSending` hook was using `JSON.parse(JSON.stringify(message))` to clone the message payload before modifying the `listType`. This destructive cloning operation stripped the prototype methods from underlying Protobuf `Long` objects (which Baileys uses for timestamps and message IDs). When Baileys later attempted to encode the message, it called `.isZero()` on what it expected to be a `Long` instance, resulting in a crash.

**Fix:**
Removed the `JSON.parse(JSON.stringify())` calls. The code now directly mutates the `listType` property on the existing message object, preserving the prototype chain of all nested Protobuf instances and allowing Baileys to encode the message successfully.

## 🔗 Related Issue

Closes #(issue_number) *(Note: Replace with the actual issue number if you opened one, e.g., #2188 or #2351)*

## 🧪 Type of Change

* [x] 🐛 Bug fix (non-breaking change which fixes an issue)
* [ ] ✨ New feature (non-breaking change which adds functionality)
* [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ] 📚 Documentation update
* [ ] 🔧 Refactoring (no functional changes)
* [ ] ⚡ Performance improvement
* [ ] 🧹 Code cleanup
* [ ] 🔒 Security fix

## 🧪 Testing

* [x] Manual testing completed
* [x] Functionality verified in development environment
* [x] No breaking changes introduced
* [x] Tested with different connection types (if applicable)

## 📸 Screenshots (if applicable)

N/A

## ✅ Checklist

* [x] My code follows the project's style guidelines
* [x] I have performed a self-review of my code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [x] I have manually tested my changes thoroughly
* [x] I have verified the changes work with different scenarios
* [x] Any dependent changes have been merged and published

## 📝 Additional Notes

This specifically addresses the remaining `/message/sendList/` failures reported in v2.3.6 and v2.3.7. Note that PR #2105 previously attempted to fix `this.isZero` by simplifying the logger, but it did not resolve this specific issue because the crash here occurs during the `patchMessageBeforeSending` Protobuf encoding phase, well before the logger is invoked.

## Summary by Sourcery

Bug Fixes:
- Prevent `this.isZero is not a function` crashes when sending WhatsApp list messages by mutating listType in place instead of JSON-cloning the message payload.