### PR TITLE
fix: mentionsEveryOne always active even when set to false

### DIFF
--- a/src/api/integrations/channel/whatsapp/whatsapp.baileys.service.ts
+++ b/src/api/integrations/channel/whatsapp/whatsapp.baileys.service.ts
@@ -2372,7 +2372,7 @@ export class BaileysStartupService extends ChannelStartupService {
           throw new NotFoundException('Group not found');
         }
 
-        if (options?.mentionsEveryOne) {
+        if (options?.mentionsEveryOne === true) {
           mentions = group.participants.map((participant) => participant.id);
         } else if (options?.mentioned?.length) {
           mentions = options.mentioned.map((mention) => {

--- a/src/validate/message.schema.ts
+++ b/src/validate/message.schema.ts
@@ -77,7 +77,7 @@ export const textMessageSchema: JSONSchema7 = {
       description: 'Enter a value in milliseconds',
     },
     quoted: { ...quotedOptionsSchema },
-    everyOne: { type: 'boolean', enum: [true, false] },
+    mentionsEveryOne: { type: 'boolean', enum: [true, false] },
     mentioned: {
       type: 'array',
       minItems: 1,
@@ -107,7 +107,7 @@ export const mediaMessageSchema: JSONSchema7 = {
       description: 'Enter a value in milliseconds',
     },
     quoted: { ...quotedOptionsSchema },
-    everyOne: { type: 'boolean', enum: [true, false] },
+    mentionsEveryOne: { type: 'boolean', enum: [true, false] },
     mentioned: {
       type: 'array',
       minItems: 1,
@@ -133,7 +133,7 @@ export const ptvMessageSchema: JSONSchema7 = {
       description: 'Enter a value in milliseconds',
     },
     quoted: { ...quotedOptionsSchema },
-    everyOne: { type: 'boolean', enum: [true, false] },
+    mentionsEveryOne: { type: 'boolean', enum: [true, false] },
     mentioned: {
       type: 'array',
       minItems: 1,
@@ -159,7 +159,7 @@ export const audioMessageSchema: JSONSchema7 = {
       description: 'Enter a value in milliseconds',
     },
     quoted: { ...quotedOptionsSchema },
-    everyOne: { type: 'boolean', enum: [true, false] },
+    mentionsEveryOne: { type: 'boolean', enum: [true, false] },
     mentioned: {
       type: 'array',
       minItems: 1,
@@ -209,7 +209,7 @@ export const stickerMessageSchema: JSONSchema7 = {
       description: 'Enter a value in milliseconds',
     },
     quoted: { ...quotedOptionsSchema },
-    everyOne: { type: 'boolean', enum: [true, false] },
+    mentionsEveryOne: { type: 'boolean', enum: [true, false] },
     mentioned: {
       type: 'array',
       minItems: 1,
@@ -238,7 +238,7 @@ export const locationMessageSchema: JSONSchema7 = {
       description: 'Enter a value in milliseconds',
     },
     quoted: { ...quotedOptionsSchema },
-    everyOne: { type: 'boolean', enum: [true, false] },
+    mentionsEveryOne: { type: 'boolean', enum: [true, false] },
     mentioned: {
       type: 'array',
       minItems: 1,
@@ -325,7 +325,7 @@ export const pollMessageSchema: JSONSchema7 = {
       description: 'Enter a value in milliseconds',
     },
     quoted: { ...quotedOptionsSchema },
-    everyOne: { type: 'boolean', enum: [true, false] },
+    mentionsEveryOne: { type: 'boolean', enum: [true, false] },
     mentioned: {
       type: 'array',
       minItems: 1,
@@ -382,7 +382,7 @@ export const listMessageSchema: JSONSchema7 = {
       description: 'Enter a value in milliseconds',
     },
     quoted: { ...quotedOptionsSchema },
-    everyOne: { type: 'boolean', enum: [true, false] },
+    mentionsEveryOne: { type: 'boolean', enum: [true, false] },
     mentioned: {
       type: 'array',
       minItems: 1,
@@ -433,7 +433,7 @@ export const buttonsMessageSchema: JSONSchema7 = {
       description: 'Enter a value in milliseconds',
     },
     quoted: { ...quotedOptionsSchema },
-    everyOne: { type: 'boolean', enum: [true, false] },
+    mentionsEveryOne: { type: 'boolean', enum: [true, false] },
     mentioned: {
       type: 'array',
       minItems: 1,


### PR DESCRIPTION
## Summary
- Fixed bug where `mentionsEveryOne` was always active even when set to `false`
- Fixed validation schema property name mismatch (`everyOne` → `mentionsEveryOne`)

## Root Cause
The check `if (options?.mentionsEveryOne)` used truthy evaluation. When clients (like n8n) send `"false"` as a **string** instead of a boolean, JavaScript evaluates it as truthy because it's a non-empty string.

## Changes
1. **`whatsapp.baileys.service.ts`**: Changed truthy check to strict equality (`=== true`)
2. **`message.schema.ts`**: Renamed `everyOne` to `mentionsEveryOne` in all message schemas to match DTO

## Test plan
- [ ] Send message to group with `mentionsEveryOne: false` → should NOT mention anyone
- [ ] Send message to group with `mentionsEveryOne: true` → should mention everyone
- [ ] Send message to group without `mentionsEveryOne` → should NOT mention anyone

Fixes #2431

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Align WhatsApp group mention handling with the message DTO and prevent unintended @everyone mentions when the option is false or omitted.

Bug Fixes:
- Ensure `mentionsEveryOne` only triggers @everyone mentions when explicitly set to true, avoiding truthy evaluation of string values like "false".
- Correct validation schemas to use `mentionsEveryOne` instead of the mismatched `everyOne` property so options are validated and mapped consistently across message types.