### PR TITLE
fix: normalize fileName property to handle case-insensitivity

### DIFF
--- a/src/api/dto/sendMessage.dto.ts
+++ b/src/api/dto/sendMessage.dto.ts
@@ -12,6 +12,8 @@ export class Options {
   linkPreview?: boolean;
   encoding?: boolean;
   mentionsEveryOne?: boolean;
+  /** @deprecated use `mentionsEveryOne` instead. Kept for backward compatibility; will be removed in a future release. */
+  everyOne?: boolean;
   mentioned?: string[];
   webhookUrl?: string;
   messageId?: string;
@@ -45,6 +47,8 @@ export class Metadata {
   quoted?: Quoted;
   linkPreview?: boolean;
   mentionsEveryOne?: boolean;
+  /** @deprecated use `mentionsEveryOne` instead. Kept for backward compatibility; will be removed in a future release. */
+  everyOne?: boolean;
   mentioned?: string[];
   encoding?: boolean;
   notConvertSticker?: boolean;

--- a/src/api/integrations/channel/evolution/evolution.channel.service.ts
+++ b/src/api/integrations/channel/evolution/evolution.channel.service.ts
@@ -16,6 +16,7 @@ import { Events, wa } from '@api/types/wa.types';
 import { AudioConverter, Chatwoot, ConfigService, Openai, S3 } from '@config/env.config';
 import { BadRequestException, InternalServerErrorException } from '@exceptions';
 import { createJid } from '@utils/createJid';
+import { normalizeFileName } from '@utils/normalizeSendMessageOptions';
 import { sendTelemetry } from '@utils/sendTelemetry';
 import axios from 'axios';
 import { isBase64, isURL } from 'class-validator';
@@ -607,11 +608,7 @@ export class EvolutionStartupService extends ChannelStartupService {
   }
 
   public async mediaMessage(data: SendMediaDto, file?: any, isIntegration = false) {
-    const mediaData: SendMediaDto = {
-      ...data,
-      // Normalize filename to fileName (handle case-insensitivity)
-      fileName: data.fileName || (data as any).filename,
-    };
+    const mediaData: SendMediaDto = normalizeFileName({ ...data });
 
     if (file) mediaData.media = file.buffer.toString('base64');
 

--- a/src/api/integrations/channel/evolution/evolution.channel.service.ts
+++ b/src/api/integrations/channel/evolution/evolution.channel.service.ts
@@ -607,7 +607,11 @@ export class EvolutionStartupService extends ChannelStartupService {
   }
 
   public async mediaMessage(data: SendMediaDto, file?: any, isIntegration = false) {
-    const mediaData: SendMediaDto = { ...data };
+    const mediaData: SendMediaDto = {
+      ...data,
+      // Normalize filename to fileName (handle case-insensitivity)
+      fileName: data.fileName || (data as any).filename,
+    };
 
     if (file) mediaData.media = file.buffer.toString('base64');
 

--- a/src/api/integrations/channel/meta/whatsapp.business.service.ts
+++ b/src/api/integrations/channel/meta/whatsapp.business.service.ts
@@ -23,6 +23,7 @@ import { Events, wa } from '@api/types/wa.types';
 import { AudioConverter, Chatwoot, ConfigService, Database, Openai, S3, WaBusiness } from '@config/env.config';
 import { BadRequestException, InternalServerErrorException } from '@exceptions';
 import { createJid } from '@utils/createJid';
+import { normalizeFileName } from '@utils/normalizeSendMessageOptions';
 import { status } from '@utils/renderStatus';
 import { sendTelemetry } from '@utils/sendTelemetry';
 import axios from 'axios';
@@ -1284,11 +1285,7 @@ export class BusinessStartupService extends ChannelStartupService {
   }
 
   public async mediaMessage(data: SendMediaDto, file?: any, isIntegration = false) {
-    const mediaData: SendMediaDto = {
-      ...data,
-      // Normalize filename to fileName (handle case-insensitivity)
-      fileName: data.fileName || (data as any).filename,
-    };
+    const mediaData: SendMediaDto = normalizeFileName({ ...data });
 
     if (file) mediaData.media = file.buffer.toString('base64');
 

--- a/src/api/integrations/channel/meta/whatsapp.business.service.ts
+++ b/src/api/integrations/channel/meta/whatsapp.business.service.ts
@@ -1284,7 +1284,11 @@ export class BusinessStartupService extends ChannelStartupService {
   }
 
   public async mediaMessage(data: SendMediaDto, file?: any, isIntegration = false) {
-    const mediaData: SendMediaDto = { ...data };
+    const mediaData: SendMediaDto = {
+      ...data,
+      // Normalize filename to fileName (handle case-insensitivity)
+      fileName: data.fileName || (data as any).filename,
+    };
 
     if (file) mediaData.media = file.buffer.toString('base64');
 

--- a/src/api/integrations/channel/whatsapp/whatsapp.baileys.service.ts
+++ b/src/api/integrations/channel/whatsapp/whatsapp.baileys.service.ts
@@ -86,6 +86,7 @@ import { Instance, Message } from '@prisma/client';
 import { createJid } from '@utils/createJid';
 import { fetchLatestWaWebVersion } from '@utils/fetchLatestWaWebVersion';
 import { makeProxyAgent, makeProxyAgentUndici } from '@utils/makeProxyAgent';
+import { normalizeFileName, resolveMentionsEveryOne } from '@utils/normalizeSendMessageOptions';
 import { getOnWhatsappCache, saveOnWhatsappCache } from '@utils/onWhatsappCache';
 import { status } from '@utils/renderStatus';
 import { sendTelemetry } from '@utils/sendTelemetry';
@@ -2643,7 +2644,7 @@ export class BaileysStartupService extends ChannelStartupService {
           throw new NotFoundException('Group not found');
         }
 
-        if (options?.mentionsEveryOne === true) {
+        if (resolveMentionsEveryOne(options)) {
           mentions = group.participants.map((participant) => participant.id);
         } else if (options?.mentioned?.length) {
           mentions = options.mentioned.map((mention) => {
@@ -3265,11 +3266,7 @@ export class BaileysStartupService extends ChannelStartupService {
   }
 
   public async mediaMessage(data: SendMediaDto, file?: any, isIntegration = false) {
-    const mediaData: SendMediaDto = {
-      ...data,
-      // Normalize filename to fileName (handle case-insensitivity)
-      fileName: data.fileName || (data as any).filename,
-    };
+    const mediaData: SendMediaDto = normalizeFileName({ ...data });
 
     if (file) mediaData.media = file.buffer.toString('base64');
 

--- a/src/api/integrations/channel/whatsapp/whatsapp.baileys.service.ts
+++ b/src/api/integrations/channel/whatsapp/whatsapp.baileys.service.ts
@@ -3265,7 +3265,11 @@ export class BaileysStartupService extends ChannelStartupService {
   }
 
   public async mediaMessage(data: SendMediaDto, file?: any, isIntegration = false) {
-    const mediaData: SendMediaDto = { ...data };
+    const mediaData: SendMediaDto = {
+      ...data,
+      // Normalize filename to fileName (handle case-insensitivity)
+      fileName: data.fileName || (data as any).filename,
+    };
 
     if (file) mediaData.media = file.buffer.toString('base64');
 

--- a/src/utils/normalizeSendMessageOptions.ts
+++ b/src/utils/normalizeSendMessageOptions.ts
@@ -1,0 +1,32 @@
+import { Logger } from '@config/logger.config';
+
+const logger = new Logger('SendMessageOptions');
+const warnedAliases = new Set<string>();
+
+const warnOnce = (key: string, message: string) => {
+  if (warnedAliases.has(key)) return;
+  warnedAliases.add(key);
+  logger.warn(message);
+};
+
+export const normalizeFileName = <T extends { fileName?: string }>(data: T): T => {
+  if (!data) return data;
+  const legacy = (data as any).filename;
+  if (data.fileName === undefined && legacy !== undefined) {
+    return { ...data, fileName: legacy };
+  }
+  return data;
+};
+
+export const resolveMentionsEveryOne = (input: any): boolean => {
+  if (!input) return false;
+  if (input.mentionsEveryOne === true) return true;
+  if (input.everyOne === true) {
+    warnOnce(
+      'everyOne',
+      '"everyOne" is deprecated and will be removed in a future release. Use "mentionsEveryOne" instead.',
+    );
+    return true;
+  }
+  return false;
+};

--- a/src/validate/message.schema.ts
+++ b/src/validate/message.schema.ts
@@ -78,6 +78,7 @@ export const textMessageSchema: JSONSchema7 = {
     },
     quoted: { ...quotedOptionsSchema },
     mentionsEveryOne: { type: 'boolean', enum: [true, false] },
+    everyOne: { type: 'boolean', enum: [true, false], description: 'Deprecated alias for "mentionsEveryOne".' },
     mentioned: {
       type: 'array',
       minItems: 1,
@@ -117,6 +118,7 @@ export const mediaMessageSchema: JSONSchema7 = {
     },
     quoted: { ...quotedOptionsSchema },
     mentionsEveryOne: { type: 'boolean', enum: [true, false] },
+    everyOne: { type: 'boolean', enum: [true, false], description: 'Deprecated alias for "mentionsEveryOne".' },
     mentioned: {
       type: 'array',
       minItems: 1,
@@ -143,6 +145,7 @@ export const ptvMessageSchema: JSONSchema7 = {
     },
     quoted: { ...quotedOptionsSchema },
     mentionsEveryOne: { type: 'boolean', enum: [true, false] },
+    everyOne: { type: 'boolean', enum: [true, false], description: 'Deprecated alias for "mentionsEveryOne".' },
     mentioned: {
       type: 'array',
       minItems: 1,
@@ -169,6 +172,7 @@ export const audioMessageSchema: JSONSchema7 = {
     },
     quoted: { ...quotedOptionsSchema },
     mentionsEveryOne: { type: 'boolean', enum: [true, false] },
+    everyOne: { type: 'boolean', enum: [true, false], description: 'Deprecated alias for "mentionsEveryOne".' },
     mentioned: {
       type: 'array',
       minItems: 1,
@@ -219,6 +223,7 @@ export const stickerMessageSchema: JSONSchema7 = {
     },
     quoted: { ...quotedOptionsSchema },
     mentionsEveryOne: { type: 'boolean', enum: [true, false] },
+    everyOne: { type: 'boolean', enum: [true, false], description: 'Deprecated alias for "mentionsEveryOne".' },
     mentioned: {
       type: 'array',
       minItems: 1,
@@ -248,6 +253,7 @@ export const locationMessageSchema: JSONSchema7 = {
     },
     quoted: { ...quotedOptionsSchema },
     mentionsEveryOne: { type: 'boolean', enum: [true, false] },
+    everyOne: { type: 'boolean', enum: [true, false], description: 'Deprecated alias for "mentionsEveryOne".' },
     mentioned: {
       type: 'array',
       minItems: 1,
@@ -335,6 +341,7 @@ export const pollMessageSchema: JSONSchema7 = {
     },
     quoted: { ...quotedOptionsSchema },
     mentionsEveryOne: { type: 'boolean', enum: [true, false] },
+    everyOne: { type: 'boolean', enum: [true, false], description: 'Deprecated alias for "mentionsEveryOne".' },
     mentioned: {
       type: 'array',
       minItems: 1,
@@ -392,6 +399,7 @@ export const listMessageSchema: JSONSchema7 = {
     },
     quoted: { ...quotedOptionsSchema },
     mentionsEveryOne: { type: 'boolean', enum: [true, false] },
+    everyOne: { type: 'boolean', enum: [true, false], description: 'Deprecated alias for "mentionsEveryOne".' },
     mentioned: {
       type: 'array',
       minItems: 1,
@@ -443,6 +451,7 @@ export const buttonsMessageSchema: JSONSchema7 = {
     },
     quoted: { ...quotedOptionsSchema },
     mentionsEveryOne: { type: 'boolean', enum: [true, false] },
+    everyOne: { type: 'boolean', enum: [true, false], description: 'Deprecated alias for "mentionsEveryOne".' },
     mentioned: {
       type: 'array',
       minItems: 1,


### PR DESCRIPTION
## Summary

- Fixes the inconsistency in the `/message/sendMedia/{instance}` endpoint where the `fileName` property was case-sensitive
- For images, only `filename` (lowercase) worked
- For documents/videos, only `fileName` (camelCase) worked
- Now both `fileName` and `filename` are accepted for all media types

## Changes

Added property normalization at the beginning of the `mediaMessage` method in all three channel services:

- `src/api/integrations/channel/whatsapp/whatsapp.baileys.service.ts`
- `src/api/integrations/channel/evolution/evolution.channel.service.ts`  
- `src/api/integrations/channel/meta/whatsapp.business.service.ts`

The fix normalizes `filename` to `fileName` by using:
```typescript
fileName: data.fileName || (data as any).filename,
```

## Test plan

- [ ] Send image with `fileName` property - should work
- [ ] Send image with `filename` property - should work
- [ ] Send document with `fileName` property - should work
- [ ] Send document with `filename` property - should work
- [ ] Send video with `fileName` property - should work
- [ ] Send video with `filename` property - should work

Closes #2459

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Normalize media message filename handling across channels and refine group mention options for message schemas and WhatsApp integration.

Bug Fixes:
- Allow both `fileName` and `filename` properties when sending media messages across WhatsApp, Evolution, and Meta channel services.
- Ensure `mentionsEveryOne` only applies when explicitly set to true in WhatsApp Baileys group messaging.

Enhancements:
- Rename message schema property from `everyOne` to `mentionsEveryOne` for clearer and more consistent API semantics across all message types.