### PR TITLE
fix(engine): resolve lint-staged and json path typing

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
     "start:prod": "node dist/main",
     "dev:server": "tsx watch ./src/main.ts",
     "test": "tsx watch ./test/all.test.ts",
-    "lint": "eslint --fix --ext .ts src",
-    "lint:check": "eslint --ext .ts src",
+    "lint": "ESLINT_USE_FLAT_CONFIG=false eslint --fix --ext .ts src",
+    "lint:check": "ESLINT_USE_FLAT_CONFIG=false eslint --ext .ts src",
     "commit": "cz",
     "commitlint": "commitlint --edit",
     "db:generate": "node runWithProvider.js \"npx prisma generate --schema ./prisma/DATABASE_PROVIDER-schema.prisma\"",
@@ -53,7 +53,7 @@
   "homepage": "https://github.com/EvolutionAPI/evolution-api#readme",
   "lint-staged": {
     "src/**/*.{ts,js}": [
-      "eslint --fix"
+      "sh -c 'ESLINT_USE_FLAT_CONFIG=false eslint --fix'"
     ],
     "src/**/*.ts": [
       "sh -c 'tsc --noEmit'"

--- a/project.json
+++ b/project.json
@@ -1,0 +1,38 @@
+{
+  "name": "engine",
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "apps/engine/src",
+  "projectType": "application",
+  "prefix": "engine",
+  "targets": {
+    "serve": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "npm run dev:server",
+        "cwd": "apps/engine"
+      }
+    },
+    "build": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "npm run build",
+        "cwd": "apps/engine"
+      }
+    },
+    "db:migrate": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "npm run db:deploy",
+        "cwd": "apps/engine"
+      }
+    },
+    "db:seed": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "npm run db:seed",
+        "cwd": "apps/engine"
+      }
+    }
+  },
+  "tags": ["type:app", "scope:engine"]
+}

--- a/src/api/integrations/channel/meta/whatsapp.business.service.ts
+++ b/src/api/integrations/channel/meta/whatsapp.business.service.ts
@@ -758,7 +758,7 @@ export class BusinessStartupService extends ChannelStartupService {
               where: {
                 instanceId: this.instanceId,
                 key: {
-                  path: ['id'],
+                  path: '$.id',
                   equals: key.id,
                 },
               },

--- a/src/api/integrations/channel/whatsapp/whatsapp.baileys.service.ts
+++ b/src/api/integrations/channel/whatsapp/whatsapp.baileys.service.ts
@@ -1819,7 +1819,7 @@ export class BaileysStartupService extends ChannelStartupService {
       const savedLabel = labelsRepository.find((l) => l.labelId === label.id);
       if (label.deleted && savedLabel) {
         await this.prismaRepository.label.delete({
-          where: { labelId_instanceId: { instanceId: this.instanceId, labelId: label.id } },
+          where: { id: savedLabel.id },
         });
         this.sendDataWebhook(Events.LABELS_EDIT, { ...label, instance: this.instance.name });
         return;
@@ -1835,11 +1835,16 @@ export class BaileysStartupService extends ChannelStartupService {
             predefinedId: label.predefinedId,
             instanceId: this.instanceId,
           };
-          await this.prismaRepository.label.upsert({
-            where: { labelId_instanceId: { instanceId: labelData.instanceId, labelId: labelData.labelId } },
-            update: labelData,
-            create: labelData,
-          });
+          if (savedLabel) {
+            await this.prismaRepository.label.update({
+              where: { id: savedLabel.id },
+              data: labelData,
+            });
+          } else {
+            await this.prismaRepository.label.create({
+              data: labelData,
+            });
+          }
         }
       }
     },
@@ -3776,7 +3781,7 @@ export class BaileysStartupService extends ChannelStartupService {
         if (messageId) {
           const isLogicalDeleted = configService.get<Database>('DATABASE').DELETE_DATA.LOGICAL_MESSAGE_DELETE;
           let message = await this.prismaRepository.message.findFirst({
-            where: { key: { path: ['id'], equals: messageId } },
+            where: { key: { path: '$.id', equals: messageId } },
           });
           if (isLogicalDeleted) {
             if (!message) return response;
@@ -4196,7 +4201,7 @@ export class BaileysStartupService extends ChannelStartupService {
           const messageId = messageSent.message?.protocolMessage?.key?.id;
           if (messageId && this.configService.get<Database>('DATABASE').SAVE_DATA.NEW_MESSAGE) {
             let message = await this.prismaRepository.message.findFirst({
-              where: { key: { path: ['id'], equals: messageId } },
+              where: { key: { path: '$.id', equals: messageId } },
             });
             if (!message) throw new NotFoundException('Message not found');
 
@@ -4734,6 +4739,26 @@ export class BaileysStartupService extends ChannelStartupService {
   private async updateMessagesReadedByTimestamp(remoteJid: string, timestamp?: number): Promise<number> {
     if (timestamp === undefined || timestamp === null) return 0;
 
+    const dbProvider = String(this.configService.get<Database>('DATABASE')?.PROVIDER || '').toLowerCase();
+
+    if (dbProvider === 'mysql') {
+      const result = await this.prismaRepository.$executeRaw`
+        UPDATE \`Message\`
+        SET \`status\` = ${status[4]}
+        WHERE \`instanceId\` = ${this.instanceId}
+        AND JSON_UNQUOTE(JSON_EXTRACT(\`key\`, '$.remoteJid')) = ${remoteJid}
+        AND JSON_EXTRACT(\`key\`, '$.fromMe') = false
+        AND \`messageTimestamp\` <= ${timestamp}
+        AND (\`status\` IS NULL OR \`status\` = ${status[3]})
+      `;
+
+      if (result && result > 0) {
+        this.updateChatUnreadMessages(remoteJid);
+      }
+
+      return result || 0;
+    }
+
     // Use raw SQL to avoid JSON path issues
     const result = await this.prismaRepository.$executeRaw`
       UPDATE "Message"
@@ -4757,16 +4782,25 @@ export class BaileysStartupService extends ChannelStartupService {
   }
 
   private async updateChatUnreadMessages(remoteJid: string): Promise<number> {
+    const dbProvider = String(this.configService.get<Database>('DATABASE')?.PROVIDER || '').toLowerCase();
+
     const [chat, unreadMessages] = await Promise.all([
       this.prismaRepository.chat.findFirst({ where: { remoteJid } }),
-      // Use raw SQL to avoid JSON path issues
-      this.prismaRepository.$queryRaw`
-        SELECT COUNT(*)::int as count FROM "Message"
-        WHERE "instanceId" = ${this.instanceId}
-        AND "key"->>'remoteJid' = ${remoteJid}
-        AND ("key"->>'fromMe')::boolean = false
-        AND "status" = ${status[3]}
-      `.then((result: any[]) => result[0]?.count || 0),
+      dbProvider === 'mysql'
+        ? this.prismaRepository.$queryRaw`
+              SELECT COUNT(*) as count FROM \`Message\`
+              WHERE \`instanceId\` = ${this.instanceId}
+              AND JSON_UNQUOTE(JSON_EXTRACT(\`key\`, '$.remoteJid')) = ${remoteJid}
+              AND JSON_EXTRACT(\`key\`, '$.fromMe') = false
+              AND \`status\` = ${status[3]}
+            `.then((result: any[]) => Number(result?.[0]?.count || 0))
+        : this.prismaRepository.$queryRaw`
+              SELECT COUNT(*)::int as count FROM "Message"
+              WHERE "instanceId" = ${this.instanceId}
+              AND "key"->>'remoteJid' = ${remoteJid}
+              AND ("key"->>'fromMe')::boolean = false
+              AND "status" = ${status[3]}
+            `.then((result: any[]) => result[0]?.count || 0),
     ]);
 
     if (chat && chat.unreadMessages !== unreadMessages) {
@@ -5013,7 +5047,7 @@ export class BaileysStartupService extends ChannelStartupService {
     }
   }
 
-  public async fetchMessages(query: Query<Message>) {
+  public async fetchMessages(query: Query<Message>): Promise<any> {
     const keyFilters = query?.where?.key as ExtendedIMessageKey;
 
     const timestampFilter = {};
@@ -5034,13 +5068,13 @@ export class BaileysStartupService extends ChannelStartupService {
         messageType: query?.where?.messageType,
         ...timestampFilter,
         AND: [
-          keyFilters?.id ? { key: { path: ['id'], equals: keyFilters?.id } } : {},
-          keyFilters?.fromMe ? { key: { path: ['fromMe'], equals: keyFilters?.fromMe } } : {},
-          keyFilters?.participant ? { key: { path: ['participant'], equals: keyFilters?.participant } } : {},
+          keyFilters?.id ? { key: { path: '$.id', equals: keyFilters?.id } } : {},
+          keyFilters?.fromMe ? { key: { path: '$.fromMe', equals: keyFilters?.fromMe } } : {},
+          keyFilters?.participant ? { key: { path: '$.participant', equals: keyFilters?.participant } } : {},
           {
             OR: [
-              keyFilters?.remoteJid ? { key: { path: ['remoteJid'], equals: keyFilters?.remoteJid } } : {},
-              keyFilters?.remoteJidAlt ? { key: { path: ['remoteJidAlt'], equals: keyFilters?.remoteJidAlt } } : {},
+              keyFilters?.remoteJid ? { key: { path: '$.remoteJid', equals: keyFilters?.remoteJid } } : {},
+              keyFilters?.remoteJidAlt ? { key: { path: '$.remoteJidAlt', equals: keyFilters?.remoteJidAlt } } : {},
             ],
           },
         ],
@@ -5063,13 +5097,13 @@ export class BaileysStartupService extends ChannelStartupService {
         messageType: query?.where?.messageType,
         ...timestampFilter,
         AND: [
-          keyFilters?.id ? { key: { path: ['id'], equals: keyFilters?.id } } : {},
-          keyFilters?.fromMe ? { key: { path: ['fromMe'], equals: keyFilters?.fromMe } } : {},
-          keyFilters?.participant ? { key: { path: ['participant'], equals: keyFilters?.participant } } : {},
+          keyFilters?.id ? { key: { path: '$.id', equals: keyFilters?.id } } : {},
+          keyFilters?.fromMe ? { key: { path: '$.fromMe', equals: keyFilters?.fromMe } } : {},
+          keyFilters?.participant ? { key: { path: '$.participant', equals: keyFilters?.participant } } : {},
           {
             OR: [
-              keyFilters?.remoteJid ? { key: { path: ['remoteJid'], equals: keyFilters?.remoteJid } } : {},
-              keyFilters?.remoteJidAlt ? { key: { path: ['remoteJidAlt'], equals: keyFilters?.remoteJidAlt } } : {},
+              keyFilters?.remoteJid ? { key: { path: '$.remoteJid', equals: keyFilters?.remoteJid } } : {},
+              keyFilters?.remoteJidAlt ? { key: { path: '$.remoteJidAlt', equals: keyFilters?.remoteJidAlt } } : {},
             ],
           },
         ],

--- a/src/api/integrations/chatbot/chatwoot/services/chatwoot.service.ts
+++ b/src/api/integrations/chatbot/chatwoot/services/chatwoot.service.ts
@@ -1546,7 +1546,7 @@ export class ChatwootService {
           const lastMessage = await this.prismaRepository.message.findFirst({
             where: {
               key: {
-                path: ['fromMe'],
+                path: '$.fromMe',
                 equals: false,
               },
               instanceId: instance.instanceId,
@@ -1576,7 +1576,7 @@ export class ChatwootService {
               where: {
                 instanceId: instance.instanceId,
                 key: {
-                  path: ['id'],
+                  path: '$.id',
                   equals: key.id,
                 },
               },
@@ -2025,7 +2025,7 @@ export class ChatwootService {
           quotedMsg = await this.prismaRepository.message.findFirst({
             where: {
               key: {
-                path: ['id'],
+                path: '$.id',
                 equals: quotedId,
               },
               chatwootMessageId: {
@@ -2337,7 +2337,7 @@ export class ChatwootService {
             await this.prismaRepository.message.deleteMany({
               where: {
                 key: {
-                  path: ['id'],
+                  path: '$.id',
                   equals: body.key.id,
                 },
                 instanceId: instance.instanceId,

--- a/src/api/services/channel.service.ts
+++ b/src/api/services/channel.service.ts
@@ -623,10 +623,10 @@ export class ChannelStartupService {
         messageType: query?.where?.messageType,
         ...timestampFilter,
         AND: [
-          keyFilters?.id ? { key: { path: ['id'], equals: keyFilters?.id } } : {},
-          keyFilters?.fromMe ? { key: { path: ['fromMe'], equals: keyFilters?.fromMe } } : {},
-          keyFilters?.remoteJid ? { key: { path: ['remoteJid'], equals: keyFilters?.remoteJid } } : {},
-          keyFilters?.participants ? { key: { path: ['participants'], equals: keyFilters?.participants } } : {},
+          keyFilters?.id ? { key: { path: '$.id', equals: keyFilters?.id } } : {},
+          keyFilters?.fromMe ? { key: { path: '$.fromMe', equals: keyFilters?.fromMe } } : {},
+          keyFilters?.remoteJid ? { key: { path: '$.remoteJid', equals: keyFilters?.remoteJid } } : {},
+          keyFilters?.participants ? { key: { path: '$.participants', equals: keyFilters?.participants } } : {},
         ],
       },
     });
@@ -647,10 +647,10 @@ export class ChannelStartupService {
         messageType: query?.where?.messageType,
         ...timestampFilter,
         AND: [
-          keyFilters?.id ? { key: { path: ['id'], equals: keyFilters?.id } } : {},
-          keyFilters?.fromMe ? { key: { path: ['fromMe'], equals: keyFilters?.fromMe } } : {},
-          keyFilters?.remoteJid ? { key: { path: ['remoteJid'], equals: keyFilters?.remoteJid } } : {},
-          keyFilters?.participants ? { key: { path: ['participants'], equals: keyFilters?.participants } } : {},
+          keyFilters?.id ? { key: { path: '$.id', equals: keyFilters?.id } } : {},
+          keyFilters?.fromMe ? { key: { path: '$.fromMe', equals: keyFilters?.fromMe } } : {},
+          keyFilters?.remoteJid ? { key: { path: '$.remoteJid', equals: keyFilters?.remoteJid } } : {},
+          keyFilters?.participants ? { key: { path: '$.participants', equals: keyFilters?.participants } } : {},
         ],
       },
       orderBy: {

--- a/src/utils/onWhatsappCache.ts
+++ b/src/utils/onWhatsappCache.ts
@@ -126,12 +126,9 @@ export async function saveOnWhatsappCache(data: ISaveOnWhatsappCacheParams[]) {
       // Ordena os JIDs para garantir consistência na string final
       const sortedJidOptions = [...finalJidOptions].sort();
       const newJidOptionsString = sortedJidOptions.join(',');
-      const newLid = item.lid === 'lid' || item.remoteJid?.includes('@lid') ? 'lid' : null;
-
       const dataPayload = {
         remoteJid: remoteJid,
         jidOptions: newJidOptionsString,
-        lid: newLid,
       };
 
       // 4. Decide entre Criar ou Atualizar
@@ -142,9 +139,7 @@ export async function saveOnWhatsappCache(data: ISaveOnWhatsappCacheParams[]) {
           : '';
 
         const isDataSame =
-          existingRecord.remoteJid === dataPayload.remoteJid &&
-          existingJidOptionsString === dataPayload.jidOptions &&
-          existingRecord.lid === dataPayload.lid;
+          existingRecord.remoteJid === dataPayload.remoteJid && existingJidOptionsString === dataPayload.jidOptions;
 
         if (isDataSame) {
           logger.verbose(`[saveOnWhatsappCache] Data for ${remoteJid} is already up-to-date. Skipping update.`);
@@ -153,7 +148,7 @@ export async function saveOnWhatsappCache(data: ISaveOnWhatsappCacheParams[]) {
 
         // Os dados são diferentes, então atualiza
         logger.verbose(
-          `[saveOnWhatsappCache] Register exists, updating: remoteJid=${remoteJid}, jidOptions=${dataPayload.jidOptions}, lid=${dataPayload.lid}`,
+          `[saveOnWhatsappCache] Register exists, updating: remoteJid=${remoteJid}, jidOptions=${dataPayload.jidOptions}`,
         );
         await prismaRepository.isOnWhatsapp.update({
           where: { id: existingRecord.id },
@@ -162,7 +157,7 @@ export async function saveOnWhatsappCache(data: ISaveOnWhatsappCacheParams[]) {
       } else {
         // Cria nova entrada
         logger.verbose(
-          `[saveOnWhatsappCache] Register does not exist, creating: remoteJid=${remoteJid}, jidOptions=${dataPayload.jidOptions}, lid=${dataPayload.lid}`,
+          `[saveOnWhatsappCache] Register does not exist, creating: remoteJid=${remoteJid}, jidOptions=${dataPayload.jidOptions}`,
         );
         await prismaRepository.isOnWhatsapp.create({
           data: dataPayload,
@@ -203,7 +198,7 @@ export async function getOnWhatsappCache(remoteJids: string[]) {
       remoteJid: item.remoteJid,
       number: item.remoteJid.split('@')[0],
       jidOptions: item.jidOptions.split(','),
-      lid: item.lid,
+      lid: (item as any).lid || (item.remoteJid.includes('@lid') ? 'lid' : undefined),
     }));
   }
 


### PR DESCRIPTION
## 📋 Description
<!-- Describe your changes in detail -->

## 🔗 Related Issue
<!-- Link to the issue this PR addresses -->
Closes #(issue_number)

## 🧪 Type of Change
<!-- Mark with an `x` all the checkboxes that apply -->
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔧 Refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] 🧹 Code cleanup
- [ ] 🔒 Security fix

## 🧪 Testing
<!-- Describe the testing you performed to verify your changes -->
- [ ] Manual testing completed
- [ ] Functionality verified in development environment
- [ ] No breaking changes introduced
- [ ] Tested with different connection types (if applicable)

## 📸 Screenshots (if applicable)
<!-- Add screenshots to help explain your changes -->

## ✅ Checklist
<!-- Mark with an `x` all the checkboxes that apply -->
- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have manually tested my changes thoroughly
- [ ] I have verified the changes work with different scenarios
- [ ] Any dependent changes have been merged and published

## 📝 Additional Notes
<!-- Any additional information, concerns, or questions -->

## Summary by Sourcery

Align message JSON path queries and label persistence with database requirements, and update tooling configuration for linting and Nx integration.

Bug Fixes:
- Fix label deletion and update logic to use primary key IDs instead of composite keys, preventing inconsistencies when labels change.
- Correct Prisma JSON path usage for message key filters to use string JSONPath expressions, avoiding JSON path type issues across databases.
- Ensure unread message counters and read-status updates work for both Postgres and MySQL by adjusting raw SQL to the appropriate JSON functions and syntax.
- Restore compatibility of on-whatsapp cache behavior by deriving the lid field at read-time instead of storing and comparing it in the cache.

Enhancements:
- Add an explicit return type to the WhatsApp Baileys fetchMessages method to satisfy typing expectations.
- Introduce an Nx project.json for the engine app to define serve, build and database-related targets.

Build:
- Set ESLINT_USE_FLAT_CONFIG in lint and lint-staged commands to avoid flat-config resolution issues with eslint.