### PR TITLE
feat(chat): add fetchLid endpoint for PN to LID resolution

### DIFF
--- a/src/api/controllers/chat.controller.ts
+++ b/src/api/controllers/chat.controller.ts
@@ -50,6 +50,10 @@ export class ChatController {
     return await this.waMonitor.waInstances[instanceName].fetchProfile(instanceName, data.number);
   }
 
+  public async fetchLid({ instanceName }: InstanceDto, data: NumberDto) {
+    return await this.waMonitor.waInstances[instanceName].getLid(data.number);
+  }
+
   public async fetchContacts({ instanceName }: InstanceDto, query: Query<Contact>) {
     return await this.waMonitor.waInstances[instanceName].fetchContacts(query);
   }

--- a/src/api/integrations/channel/whatsapp/whatsapp.baileys.service.ts
+++ b/src/api/integrations/channel/whatsapp/whatsapp.baileys.service.ts
@@ -2054,6 +2054,21 @@ export class BaileysStartupService extends ChannelStartupService {
     }
   }
 
+  public async getLid(number: string) {
+    const jid = createJid(number);
+
+    if (!this.client?.signalRepository) {
+      return { wuid: jid, lid: null };
+    }
+
+    try {
+      const lid = await this.client.signalRepository.lidMapping.getLIDForPN(jid);
+      return { wuid: jid, lid: lid || null };
+    } catch {
+      return { wuid: jid, lid: null };
+    }
+  }
+
   public async getStatus(number: string) {
     const jid = createJid(number);
 

--- a/src/api/integrations/channel/whatsapp/whatsapp.baileys.service.ts
+++ b/src/api/integrations/channel/whatsapp/whatsapp.baileys.service.ts
@@ -2064,7 +2064,8 @@ export class BaileysStartupService extends ChannelStartupService {
     try {
       const lid = await this.client.signalRepository.lidMapping.getLIDForPN(jid);
       return { wuid: jid, lid: lid || null };
-    } catch {
+    } catch (error) {
+      console.error(`Failed to fetch LID for ${jid}:`, error);
       return { wuid: jid, lid: null };
     }
   }

--- a/src/api/routes/chat.router.ts
+++ b/src/api/routes/chat.router.ts
@@ -24,6 +24,7 @@ import {
   blockUserSchema,
   contactValidateSchema,
   deleteMessageSchema,
+  fetchLidSchema,
   markChatUnreadSchema,
   messageUpSchema,
   messageValidateSchema,
@@ -218,6 +219,16 @@ export class ChatRouter extends RouterBroker {
           schema: profileSchema,
           ClassRef: NumberDto,
           execute: (instance, data) => chatController.fetchProfile(instance, data),
+        });
+
+        return res.status(HttpStatus.OK).json(response);
+      })
+      .post(this.routerPath('fetchLid'), ...guards, async (req, res) => {
+        const response = await this.dataValidate<NumberDto>({
+          request: req,
+          schema: fetchLidSchema,
+          ClassRef: NumberDto,
+          execute: (instance, data) => chatController.fetchLid(instance, data),
         });
 
         return res.status(HttpStatus.OK).json(response);

--- a/src/validate/chat.schema.ts
+++ b/src/validate/chat.schema.ts
@@ -316,3 +316,12 @@ export const profileSchema: JSONSchema7 = {
     isBusiness: { type: 'boolean' },
   },
 };
+
+export const fetchLidSchema: JSONSchema7 = {
+  $id: v4(),
+  type: 'object',
+  properties: {
+    number: { type: 'string' },
+  },
+  required: ['number'],
+};


### PR DESCRIPTION
## Description
This PR introduces a new endpoint `/fetchLid` that allows retrieving a user's `lid` using their phone number.

## Motivation and Context
I am currently transitioning the system's core logic to rely primarily on `lid` rather than phone numbers, as `lid` has proven to be more consistent and reliable across various WhatsApp events. 

However, in certain scenarios (such as specific incoming messages), the system might only receive the phone number. This new endpoint serves as a bridge, allowing us to fetch the corresponding `lid` via Baileys' `signalRepository.lidMapping`. This ensures that our `lid`-based processing remains robust and uninterrupted even when initially provided with just a phone number.

## Changes Included
- **Service:** Added `getLid(number)` in `whatsapp.baileys.service.ts` to query the signal repository for the LID.
- **Controller:** Added `fetchLid` method in `chat.controller.ts`.
- **Router:** Registered `POST /fetchLid` route in `chat.router.ts`.
- **Validation:** Added `fetchLidSchema` in `chat.schema.ts` to validate the incoming `number` payload.

## Summary by Sourcery

Add a new chat endpoint to resolve a WhatsApp LID from a phone number and expose the corresponding Baileys service method.

New Features:
- Introduce Baileys service method to retrieve a user's LID and WhatsApp JID from a phone number.
- Expose a POST /fetchLid chat API endpoint wired through the chat controller to return LID resolution results.
- Add JSON schema validation for the fetchLid request payload requiring a phone number string.