### PR TITLE
fix: delete instance cleanup on baileys failure

### DIFF
--- a/src/api/controllers/instance.controller.ts
+++ b/src/api/controllers/instance.controller.ts
@@ -345,7 +345,7 @@ export class InstanceController {
       };
     } catch (error) {
       this.logger.error(error);
-      return { error: true, message: error.toString() };
+      return { error: true, message: error?.message ?? String(error) };
     }
   }
 
@@ -392,7 +392,7 @@ export class InstanceController {
       };
     } catch (error) {
       this.logger.error(error);
-      return { error: true, message: error.toString() };
+      return { error: true, message: error?.message ?? String(error) };
     }
   }
 
@@ -453,47 +453,41 @@ export class InstanceController {
 
       return { status: 'SUCCESS', error: false, response: { message: 'Instance logged out' } };
     } catch (error) {
-      throw new InternalServerErrorException(error.toString());
+      throw new InternalServerErrorException(error?.message ?? String(error));
     }
   }
 
   public async deleteInstance({ instanceName }: InstanceDto) {
     const { instance } = await this.connectionState({ instanceName });
+
+    const waInstances = this.waMonitor.waInstances[instanceName];
+
     try {
-      const waInstances = this.waMonitor.waInstances[instanceName];
       if (this.configService.get<Chatwoot>('CHATWOOT').ENABLED) waInstances?.clearCacheChatwoot();
-
-      if (instance.state === 'connecting' || instance.state === 'open') {
-        try {
-          await this.logout({ instanceName });
-        } catch (error) {
-          // logout can throw "Connection Closed" when the underlying Baileys
-          // socket is already dead but waInstances[name] still exists. We
-          // must continue to the remove.instance emit below — that is the
-          // only path that purges the in-memory entry and runs cleaningUp().
-          // Without this catch, the stale entry persists until the entire
-          // process restarts.
-          this.logger.warn({
-            message: 'logout failed during deleteInstance — proceeding with cleanup',
-            instanceName,
-            error,
-          });
-        }
-      }
-
-      try {
-        waInstances?.sendDataWebhook(Events.INSTANCE_DELETE, {
-          instanceName,
-          instanceId: waInstances.instanceId,
-        });
-      } catch (error) {
-        this.logger.error(error);
-      }
-
-      this.eventEmitter.emit('remove.instance', instanceName, 'inner');
-      return { status: 'SUCCESS', error: false, response: { message: 'Instance deleted' } };
     } catch (error) {
-      throw new BadRequestException(error.toString());
+      this.logger.warn(`clearCacheChatwoot failed for "${instanceName}": ${error?.message ?? String(error)}`);
     }
+
+    if (instance.state === 'connecting' || instance.state === 'open') {
+      try {
+        await this.logout({ instanceName });
+      } catch (error) {
+        this.logger.warn(
+          `Logout failed for "${instanceName}": ${error?.message ?? String(error)}. Continuing cleanup.`,
+        );
+      }
+    }
+
+    try {
+      waInstances?.sendDataWebhook(Events.INSTANCE_DELETE, {
+        instanceName,
+        instanceId: waInstances?.instanceId,
+      });
+    } catch (error) {
+      this.logger.error(error);
+    }
+
+    this.eventEmitter.emit('remove.instance', instanceName, 'inner');
+    return { status: 'SUCCESS', error: false, response: { message: 'Instance deleted' } };
   }
 }

--- a/src/api/services/monitor.service.ts
+++ b/src/api/services/monitor.service.ts
@@ -397,20 +397,29 @@ export class WAMonitoringService {
     this.eventEmitter.on('remove.instance', async (instanceName: string) => {
       try {
         await this.waInstances[instanceName]?.sendDataWebhook(Events.REMOVE_INSTANCE, null);
+      } catch (error) {
+        this.logger.warn(
+          `sendDataWebhook REMOVE_INSTANCE failed for "${instanceName}": ${error?.message ?? String(error)}`,
+        );
+      }
 
-        this.clearDelInstanceTime(instanceName);
+      this.clearDelInstanceTime(instanceName);
 
-        this.cleaningUp(instanceName);
-        this.cleaningStoreData(instanceName);
-      } finally {
-        this.logger.warn(`Instance "${instanceName}" - REMOVED`);
+      try {
+        await this.cleaningUp(instanceName);
+      } catch (error) {
+        this.logger.warn(`cleaningUp failed for "${instanceName}": ${error?.message ?? String(error)}`);
       }
 
       try {
-        delete this.waInstances[instanceName];
+        await this.cleaningStoreData(instanceName);
       } catch (error) {
-        this.logger.error(error);
+        this.logger.warn(`cleaningStoreData failed for "${instanceName}": ${error?.message ?? String(error)}`);
       }
+
+      delete this.waInstances[instanceName];
+
+      this.logger.warn(`Instance "${instanceName}" - REMOVED`);
     });
     this.eventEmitter.on('logout.instance', async (instanceName: string) => {
       try {


### PR DESCRIPTION
## 📋 Description

## 🐛 Problem

When calling `DELETE /instance/delete/{instanceName}` on a corrupted
instance (disconnected/bugged Baileys session), the API returns:

```json
{
  "status": 400,
  "error": "Bad Request",
  "response": { "message": ["[object Object]"] }
}
```

After this error, the instance name remains permanently blocked in
`waInstances` memory. Even after manually cleaning the database, Redis,
and session files, calling `POST /instance/create` with the same name
returns:

```json
{
  "status": 403,
  "message": ["This name \"agent-xxx\" is already in use."]
}
```

The only workaround was restarting the container — not viable in production environments.

---

## 🔍 Root Cause

Two bugs working together:

**1. Aborted cleanup**

* `deleteInstance()` stopped execution if `logout()` failed

**2. Bad error serialization**

* Errors returned as `[object Object]`

---

## ✅ Fix

* Split `try/catch` into isolated steps
* Ensure cleanup always runs
* Always remove instance from `waInstances`
* Fix error serialization using:

  ```
  error?.message ?? String(error)
  ```

---

## 🔗 Related Issue

Closes # (leave empty if not applicable)

---

## 🧪 Type of Change

* [x] 🐛 Bug fix (non-breaking change which fixes an issue)
* [ ] ✨ New feature
* [ ] 💥 Breaking change
* [ ] 📚 Documentation update
* [ ] 🔧 Refactoring
* [ ] ⚡ Performance improvement
* [ ] 🧹 Code cleanup
* [ ] 🔒 Security fix

---

## 🧪 Testing

* [x] Manual testing completed
* [x] Functionality verified in development environment
* [x] No breaking changes introduced
* [ ] Tested with different connection types

---

## 📸 Screenshots (if applicable)

N/A

---

## ✅ Checklist

* [x] My code follows the project's style guidelines
* [x] I have performed a self-review of my code
* [x] My changes generate no new warnings
* [x] I have manually tested my changes thoroughly
* [x] I have verified the changes work with different scenarios

---

## 📝 Additional Notes
Tested in production environment with Docker Swarm + PostgreSQL + Redis.
Fix only affects failure path — no impact on healthy instances.

---
## ⚠️ Behavior Change — Contract Documentation

The endpoint now returns `{ status: 'SUCCESS' }` even on partial failures.
Logout and webhook steps were changed from "abort on error" to `logger.warn`.
This is intentional — the cleanup is **best-effort** to ensure the instance
name is always released from `waInstances` memory, even when secondary steps fail.

Clients relying on `4xx` responses to detect cleanup failures will need to
adjust their logic.