### PR TITLE
fix(baileys): prevent healthy instances from being killed after stream:error 515

### DIFF
--- a/src/api/integrations/channel/whatsapp/whatsapp.baileys.service.ts
+++ b/src/api/integrations/channel/whatsapp/whatsapp.baileys.service.ts
@@ -264,6 +264,7 @@ export class BaileysStartupService extends ChannelStartupService {
   private isDeleting = false; // Flag to prevent reconnection during deletion
   private logBaileys = this.configService.get<Log>('LOG').BAILEYS;
   private eventProcessingQueue: Promise<void> = Promise.resolve();
+  private _lastStream515At = 0;
 
   // Cumulative history sync counters (reset on new sync or completion)
   private historySyncMessageCount = 0;
@@ -506,7 +507,12 @@ export class BaileysStartupService extends ChannelStartupService {
         return;
       }
 
-      const shouldReconnect = !codesToNotReconnect.includes(statusCode);
+      // If a stream:error 515 (Baileys' "restart needed" handshake) just fired,
+      // a follow-up loggedOut is the expected restart signal — not an actual
+      // logout — so reconnect anyway.
+      const recentStream515 = Date.now() - this._lastStream515At < 30_000;
+      const shouldReconnect =
+        !codesToNotReconnect.includes(statusCode) || (statusCode === DisconnectReason.loggedOut && recentStream515);
 
       this.logger.info({
         message: 'Connection closed, evaluating reconnection',
@@ -514,6 +520,7 @@ export class BaileysStartupService extends ChannelStartupService {
         shouldReconnect,
         instanceName: this.instance.name,
       });
+
 
       if (shouldReconnect) {
         // Add 3 second delay before reconnection to prevent rapid reconnection loops
@@ -811,6 +818,12 @@ export class BaileysStartupService extends ChannelStartupService {
       console.log('CB:ack,class:call', packet);
       const payload = { event: 'CB:ack,class:call', packet: packet };
       this.sendDataWebhook(Events.CALL, payload, true, ['websocket']);
+    });
+
+    this.client.ws.on('CB:stream:error', (node: any) => {
+      if (node?.attrs?.code === '515') {
+        this._lastStream515At = Date.now();
+      }
     });
 
     this.phoneNumber = number;

--- a/src/api/integrations/channel/whatsapp/whatsapp.baileys.service.ts
+++ b/src/api/integrations/channel/whatsapp/whatsapp.baileys.service.ts
@@ -276,6 +276,13 @@ export class BaileysStartupService extends ChannelStartupService {
   private readonly MESSAGE_CACHE_TTL_SECONDS = 5 * 60; // 5 minutes - avoid duplicate message processing
   private readonly UPDATE_CACHE_TTL_SECONDS = 30 * 60; // 30 minutes - avoid duplicate status updates
 
+  // Reconnect behaviour for the Baileys "stream:error 515" sequence.
+  // After WhatsApp emits 515 it usually closes with `loggedOut`; that close is *not* a real logout
+  // and we should reconnect. We treat any close arriving within this grace window as 515-driven.
+  private static readonly STREAM_515_RECONNECT_GRACE_MS = 30_000;
+  // The numeric WhatsApp stream-error code that triggers the grace-period reconnect above.
+  private static readonly STREAM_ERROR_CODE_RECONNECT = '515';
+
   public stateConnection: wa.StateConnection = { state: 'close' };
 
   public phoneNumber: string;
@@ -510,7 +517,8 @@ export class BaileysStartupService extends ChannelStartupService {
       // If a stream:error 515 (Baileys' "restart needed" handshake) just fired,
       // a follow-up loggedOut is the expected restart signal — not an actual
       // logout — so reconnect anyway.
-      const recentStream515 = Date.now() - this._lastStream515At < 30_000;
+      const recentStream515 =
+        Date.now() - this._lastStream515At < BaileysStartupService.STREAM_515_RECONNECT_GRACE_MS;
       const shouldReconnect =
         !codesToNotReconnect.includes(statusCode) || (statusCode === DisconnectReason.loggedOut && recentStream515);
 
@@ -820,8 +828,8 @@ export class BaileysStartupService extends ChannelStartupService {
       this.sendDataWebhook(Events.CALL, payload, true, ['websocket']);
     });
 
-    this.client.ws.on('CB:stream:error', (node: any) => {
-      if (node?.attrs?.code === '515') {
+    this.client.ws.on('CB:stream:error', (node: { attrs?: { code?: string | number } }) => {
+      if (String(node?.attrs?.code) === BaileysStartupService.STREAM_ERROR_CODE_RECONNECT) {
         this._lastStream515At = Date.now();
       }
     });

--- a/src/api/integrations/channel/whatsapp/whatsapp.baileys.service.ts
+++ b/src/api/integrations/channel/whatsapp/whatsapp.baileys.service.ts
@@ -517,8 +517,7 @@ export class BaileysStartupService extends ChannelStartupService {
       // If a stream:error 515 (Baileys' "restart needed" handshake) just fired,
       // a follow-up loggedOut is the expected restart signal — not an actual
       // logout — so reconnect anyway.
-      const recentStream515 =
-        Date.now() - this._lastStream515At < BaileysStartupService.STREAM_515_RECONNECT_GRACE_MS;
+      const recentStream515 = Date.now() - this._lastStream515At < BaileysStartupService.STREAM_515_RECONNECT_GRACE_MS;
       const shouldReconnect =
         !codesToNotReconnect.includes(statusCode) || (statusCode === DisconnectReason.loggedOut && recentStream515);
 


### PR DESCRIPTION
Fixes #2498

## Problem

When WhatsApp sends `stream:error code=515` (Connection Replaced — normal multi-device protocol behavior), Baileys handles the reconnect correctly and fires `connection.update` with `state='open'`. However, WhatsApp then sends a `401 loggedOut` message to clean up the old session slot. Evolution API's close handler incorrectly treated this 401 as a real logout, killing the newly-connected healthy instance.

Sequence of events that triggered the bug:
1. `stream:error code=515` — WhatsApp notifies of connection replacement
2. Baileys reconnects automatically (~5s)
3. `CONNECTED TO WHATSAPP ✓` — session is open, webhook fires `state='open'`
4. WhatsApp sends `401 loggedOut` to clean up old session slot
5. Evolution API sees 401 → triggers `logout.instance` → **REMOVED** ← bug

## Solution

Track when a `stream:error 515` node arrives via the `CB:stream:error` WebSocket event using a class-level timestamp (`_lastStream515At`). In the connection close handler, if a `loggedOut (401)` event fires within 30 seconds of a 515, treat it as a transient reconnect side-effect rather than a real logout and call `connectToWhatsapp()` instead of destroying the instance.

Changes:
- Added `private _lastStream515At = 0;` class property to track when 515 last occurred
- Added `CB:stream:error` WebSocket handler in `createClient()` to record the timestamp when code is `'515'`
- Updated `shouldReconnect` logic in the connection close handler to allow reconnect when a loggedOut follows within 30s of a 515

## Testing

The fix can be validated by:
1. Connecting a WhatsApp instance via QR code
2. Observing Docker logs: if `stream:error code=515` appears followed by `CONNECTED TO WHATSAPP ✓`, the instance should remain connected instead of being removed
3. Confirming no `WAMonitoringService: REMOVED`/`LOGOUT` appears after a successful reconnect

## Summary by Sourcery

Bug Fixes:
- Prevent instances from being destroyed when a loggedOut (401) event occurs shortly after a WhatsApp stream:error 515 reconnect sequence.