### PR TITLE
fix: use correct Prisma JSON path filter in getLastMessage

### DIFF
--- a/src/api/integrations/channel/whatsapp/whatsapp.baileys.service.ts
+++ b/src/api/integrations/channel/whatsapp/whatsapp.baileys.service.ts
@@ -3689,7 +3689,7 @@ export class BaileysStartupService extends ChannelStartupService {
   }
 
   public async getLastMessage(number: string) {
-    const where: any = { key: { remoteJid: number }, instanceId: this.instance.id };
+    const where: any = { key: { path: ['remoteJid'], equals: number }, instanceId: this.instanceId };
 
     const messages = await this.prismaRepository.message.findMany({
       where,


### PR DESCRIPTION
Fixes #2495

## Problem

`POST /chat/archiveChat/{instance}` (and `markChatUnread`) always returns HTTP 500 with a `PrismaClientValidationError` when called with a `chat` string (no `lastMessage` provided).

The `getLastMessage` helper was building the Prisma `where` clause as:

```typescript
{ key: { remoteJid: number }, instanceId: this.instance.id }
```

The `key` column is a `Json`/`JsonB` field. Prisma does **not** accept nested object syntax (`{ remoteJid: value }`) to filter inside a JSON column; it requires the explicit path form:

```typescript
{ key: { path: ['remoteJid'], equals: value } }
```

Using the wrong form caused Prisma to throw `PrismaClientValidationError: Unknown argument 'remoteJid'`.

## Solution

Changed the `where` clause in `getLastMessage` to use the correct Prisma JSON path filter:

```typescript
const where: any = { key: { path: ['remoteJid'], equals: number }, instanceId: this.instanceId };
```

This matches the pattern already used elsewhere in the codebase (e.g. lines 5060-5061).

## Testing

The fix aligns with the established Prisma JSON filtering pattern used throughout the file. `archiveChat` with `{"chat": "<jid>", "archive": true}` will now correctly resolve the last message instead of throwing a validation error.

## Summary by Sourcery

Bug Fixes:
- Correct JSON path filter in getLastMessage so chat archiving and unread-marking no longer fail with PrismaClientValidationError when only a chat JID is provided.