### PR TITLE
fix: pass quoted option in audioWhatsapp to support replies

### DIFF
--- a/src/api/integrations/channel/whatsapp/whatsapp.baileys.service.ts
+++ b/src/api/integrations/channel/whatsapp/whatsapp.baileys.service.ts
@@ -3562,7 +3562,7 @@ export class BaileysStartupService extends ChannelStartupService {
         const result = this.sendMessageWithTyping<AnyMessageContent>(
           data.number,
           messageContent as any,
-          { presence: 'recording', delay: data?.delay },
+          { presence: 'recording', delay: data?.delay, quoted: data?.quoted },
           isIntegration,
         );
 
@@ -3588,7 +3588,7 @@ export class BaileysStartupService extends ChannelStartupService {
         mimetype: 'audio/ogg; codecs=opus',
         ...(metadata && { seconds: metadata.seconds, waveform: metadata.waveform }),
       },
-      { presence: 'recording', delay: data?.delay },
+      { presence: 'recording', delay: data?.delay, quoted: data?.quoted },
       isIntegration,
     );
   }


### PR DESCRIPTION
Fixes #2485

## Problem

When sending audio with `sendWhatsAppAudio` and a `quoted` key in the payload:

```json
{
  "number": "55489999999999",
  "audio": "<base64>",
  "quoted": {
    "key": {
      "id": "3EB0006934B47898977C8C"
    }
  }
}
```

The audio was delivered as a standalone message rather than as a reply. The `quoted` field was ignored.

## Root Cause

The `audioWhatsapp` method built the options object passed to `sendMessageWithTyping` as:

```typescript
{ presence: 'recording', delay: data?.delay }
```

The `quoted` field from `data` was never forwarded, unlike every other message-sending method (`textMessage`, `pollMessage`, `mediaMessage`, etc.) which all pass `quoted: data?.quoted`.

## Solution

Added `quoted: data?.quoted` to the options in both `sendMessageWithTyping` call sites inside `audioWhatsapp` (the encoding path and the direct path).

## Testing

Send a `POST /message/sendWhatsAppAudio/{instance}` request with a valid `quoted.key.id`. The audio message will now appear as a reply to the referenced message in WhatsApp.

## Summary by Sourcery

Bug Fixes:
- Forward the quoted message reference when sending WhatsApp audio so replies are delivered as threaded responses instead of standalone messages.