### PR TITLE
feat(chat): add markMessageAsPlayed endpoint (audio receipt)

### DIFF
--- a/src/api/controllers/chat.controller.ts
+++ b/src/api/controllers/chat.controller.ts
@@ -4,6 +4,7 @@ import {
   DeleteMessage,
   getBase64FromMediaMessageDto,
   MarkChatUnreadDto,
+  MarkMessageAsPlayedDto,
   NumberDto,
   PrivacySettingDto,
   ProfileNameDto,
@@ -28,6 +29,10 @@ export class ChatController {
 
   public async readMessage({ instanceName }: InstanceDto, data: ReadMessageDto) {
     return await this.waMonitor.waInstances[instanceName].markMessageAsRead(data);
+  }
+
+  public async markMessageAsPlayed({ instanceName }: InstanceDto, data: MarkMessageAsPlayedDto) {
+    return await this.waMonitor.waInstances[instanceName].markMessageAsPlayed(data);
   }
 
   public async archiveChat({ instanceName }: InstanceDto, data: ArchiveChatDto) {

--- a/src/api/dto/chat.dto.ts
+++ b/src/api/dto/chat.dto.ts
@@ -70,6 +70,10 @@ export class ReadMessageDto {
   readMessages: Key[];
 }
 
+export class MarkMessageAsPlayedDto {
+  playedMessages: Key[];
+}
+
 export class LastMessage {
   key: Key;
   messageTimestamp?: number;

--- a/src/api/integrations/channel/whatsapp/whatsapp.baileys.service.ts
+++ b/src/api/integrations/channel/whatsapp/whatsapp.baileys.service.ts
@@ -7,6 +7,7 @@ import {
   getBase64FromMediaMessageDto,
   LastMessage,
   MarkChatUnreadDto,
+  MarkMessageAsPlayedDto,
   NumberBusiness,
   OnWhatsAppDto,
   PrivacySettingDto,
@@ -3685,6 +3686,24 @@ export class BaileysStartupService extends ChannelStartupService {
       return { message: 'Read messages', read: 'success' };
     } catch (error) {
       throw new InternalServerErrorException('Read messages fail', error.toString());
+    }
+  }
+
+  public async markMessageAsPlayed(data: MarkMessageAsPlayedDto) {
+    try {
+      const keys: proto.IMessageKey[] = [];
+      data.playedMessages.forEach((played) => {
+        if (isJidGroup(played.remoteJid) || isPnUser(played.remoteJid)) {
+          keys.push({ remoteJid: played.remoteJid, fromMe: played.fromMe, id: played.id });
+        }
+      });
+      // Baileys exposes sendReceipts(keys, type) where type='played' triggers the
+      // PLAYED ack (blue microphone). Used when an agent plays back an audio
+      // message received from a contact, mirroring the contact's view in WhatsApp.
+      await this.client.sendReceipts(keys, 'played');
+      return { message: 'Played messages', played: 'success' };
+    } catch (error) {
+      throw new InternalServerErrorException('Mark messages as played fail', error.toString());
     }
   }
 

--- a/src/api/routes/chat.router.ts
+++ b/src/api/routes/chat.router.ts
@@ -5,6 +5,7 @@ import {
   DeleteMessage,
   getBase64FromMediaMessageDto,
   MarkChatUnreadDto,
+  MarkMessageAsPlayedDto,
   NumberDto,
   PrivacySettingDto,
   ProfileNameDto,
@@ -25,6 +26,7 @@ import {
   contactValidateSchema,
   deleteMessageSchema,
   markChatUnreadSchema,
+  markMessageAsPlayedSchema,
   messageUpSchema,
   messageValidateSchema,
   presenceSchema,
@@ -66,6 +68,16 @@ export class ChatRouter extends RouterBroker {
           schema: readMessageSchema,
           ClassRef: ReadMessageDto,
           execute: (instance, data) => chatController.readMessage(instance, data),
+        });
+
+        return res.status(HttpStatus.CREATED).json(response);
+      })
+      .post(this.routerPath('markMessageAsPlayed'), ...guards, async (req, res) => {
+        const response = await this.dataValidate<MarkMessageAsPlayedDto>({
+          request: req,
+          schema: markMessageAsPlayedSchema,
+          ClassRef: MarkMessageAsPlayedDto,
+          execute: (instance, data) => chatController.markMessageAsPlayed(instance, data),
         });
 
         return res.status(HttpStatus.CREATED).json(response);

--- a/src/validate/chat.schema.ts
+++ b/src/validate/chat.schema.ts
@@ -63,6 +63,28 @@ export const readMessageSchema: JSONSchema7 = {
   required: ['readMessages'],
 };
 
+export const markMessageAsPlayedSchema: JSONSchema7 = {
+  $id: v4(),
+  type: 'object',
+  properties: {
+    playedMessages: {
+      type: 'array',
+      minItems: 1,
+      uniqueItems: true,
+      items: {
+        properties: {
+          id: { type: 'string' },
+          fromMe: { type: 'boolean', enum: [true, false] },
+          remoteJid: { type: 'string' },
+        },
+        required: ['id', 'fromMe', 'remoteJid'],
+        ...isNotEmpty('id', 'remoteJid'),
+      },
+    },
+  },
+  required: ['playedMessages'],
+};
+
 export const archiveChatSchema: JSONSchema7 = {
   $id: v4(),
   type: 'object',


### PR DESCRIPTION
## 📋 Description

Adds `POST /chat/markMessageAsPlayed/{instance}` for marking received audio messages as played (the blue microphone indicator in WhatsApp), mirroring the existing `markMessageAsRead` pattern.

Baileys natively exposes `sock.sendReceipts(keys, 'played')`, but Evolution currently only exposes the `'read'` receipt type via `/chat/markMessageAsRead`. CRMs and dashboards that play back voice notes received from contacts have no way to send the played ack — this endpoint fills that gap with the same DTO/schema shape (`key`: `id`, `fromMe`, `remoteJid`) under a `playedMessages` array.

The implementation is fully symmetric to `markMessageAsRead`:

- **DTO**: `MarkMessageAsPlayedDto` with `playedMessages: Key[]` (mirrors `ReadMessageDto`)
- **Schema**: `markMessageAsPlayedSchema` (JSONSchema7, mirrors `readMessageSchema`)
- **Service**: `markMessageAsPlayed` → `client.sendReceipts(keys, 'played')`
- **Controller**: `markMessageAsPlayed` → `waMonitor` delegation
- **Router**: `POST routerPath('markMessageAsPlayed')`

## 🔗 Related Issue

N/A — this is a new endpoint extension. Happy to open a tracking issue if maintainers prefer.

## 🧪 Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)

## 🧪 Testing

- [x] Manual testing completed
- [x] Functionality verified in development environment
- [x] No breaking changes introduced
- [x] Tested with Baileys connection (WhatsApp Web)

Smoke test against a running instance (Baileys, WhatsApp Web): `POST /chat/markMessageAsPlayed/{instance}` with a valid `{ playedMessages: [{ id, fromMe: false, remoteJid }] }` body returns `201 { message: "Played messages", played: "success" }`. The blue microphone indicator appears on the contact's WhatsApp client (verified on Android and iOS).

Without a valid API key it returns `401`, matching the behavior of `markMessageAsRead` (confirms the route is registered and guarded correctly).

## 📝 Additional Notes

**Use case**: agent CRMs / customer support platforms (e.g. Chatwoot-like dashboards) that present audio messages from contacts with a play button. When the agent plays back the audio in the dashboard, the played receipt is forwarded to the contact's WhatsApp — same UX they get from a real WhatsApp client.

We've been running this in production on a self-hosted Coolify deployment for ~24h and confirmed it works end-to-end with no observed issues. Happy to address any review feedback.

## ✅ Checklist

- [x] My code follows the project's style guidelines (RouterBroker `dataValidate`, JSONSchema7 validation, Service Object pattern)
- [x] I have performed a self-review of my code
- [x] I have commented my code where helpful (Baileys `sendReceipts` semantics)
- [x] My changes generate no new warnings
- [x] I have manually tested my changes thoroughly
- [x] No dependent changes — pure addition, mirrors existing pattern
