### PR TITLE
fix(instance.controller): emit remove.instance even when logout fails (zombie cleanup)

### DIFF
--- a/src/api/controllers/instance.controller.ts
+++ b/src/api/controllers/instance.controller.ts
@@ -456,7 +456,18 @@ export class InstanceController {
       if (this.configService.get<Chatwoot>('CHATWOOT').ENABLED) waInstances?.clearCacheChatwoot();
 
       if (instance.state === 'connecting' || instance.state === 'open') {
-        await this.logout({ instanceName });
+        try {
+          await this.logout({ instanceName });
+        } catch (logoutError) {
+          // RIGARR PATCH: zombie instance cleanup.
+          // When a Baileys socket is dead but waInstances[name] still exists,
+          // logout() throws "Connection Closed". Without this catch, the
+          // remove.instance emit below never runs, leaving the zombie in memory
+          // forever (only fixable by restarting the entire container).
+          this.logger.warn(
+            `[ZOMBIE-CLEANUP] logout failed for "${instanceName}" (likely zombie socket): ${logoutError?.toString?.() || logoutError}. Proceeding with cleanup.`,
+          );
+        }
       }
 
       try {

--- a/src/api/controllers/instance.controller.ts
+++ b/src/api/controllers/instance.controller.ts
@@ -458,15 +458,18 @@ export class InstanceController {
       if (instance.state === 'connecting' || instance.state === 'open') {
         try {
           await this.logout({ instanceName });
-        } catch (logoutError) {
-          // RIGARR PATCH: zombie instance cleanup.
-          // When a Baileys socket is dead but waInstances[name] still exists,
-          // logout() throws "Connection Closed". Without this catch, the
-          // remove.instance emit below never runs, leaving the zombie in memory
-          // forever (only fixable by restarting the entire container).
-          this.logger.warn(
-            `[ZOMBIE-CLEANUP] logout failed for "${instanceName}" (likely zombie socket): ${logoutError?.toString?.() || logoutError}. Proceeding with cleanup.`,
-          );
+        } catch (error) {
+          // logout can throw "Connection Closed" when the underlying Baileys
+          // socket is already dead but waInstances[name] still exists. We
+          // must continue to the remove.instance emit below — that is the
+          // only path that purges the in-memory entry and runs cleaningUp().
+          // Without this catch, the stale entry persists until the entire
+          // process restarts.
+          this.logger.warn({
+            message: 'logout failed during deleteInstance — proceeding with cleanup',
+            instanceName,
+            error,
+          });
         }
       }
 


### PR DESCRIPTION
## Summary

When a Baileys WebSocket dies but the in-memory `waInstances[name]` entry still exists (a "zombie" instance), `deleteInstance()` in `src/api/controllers/instance.controller.ts` calls `await this.logout()` which throws `Connection Closed`. The outer `try/catch` then propagates a `BadRequestException` and **`eventEmitter.emit('remove.instance')` is never reached** — leaving the zombie in `waInstances` forever, only fixable by restarting the entire process.

This is the practical reason behind several long-standing reports about reconnect/sync issues:

- #693  — `instance/restart` closes the session
- #1286 — Connection Closed (v2.2.3)
- #2026 — Sync lost after reboot
- #2027 — Loss of synchronization on reboot

In production, operators today have **no per-instance recovery** when a Baileys socket dies in a way that prevents `logout()` from completing. Their only escape is `docker restart`, which kicks every connected user off the host and forces a full QR re-scan for everyone.

## Fix

Wrap the inner `await this.logout(...)` call in its own try/catch. Log the failure but proceed to the cleanup emit so `remove.instance` always fires. The in-memory entry **must** be purged regardless of whether logout completed cleanly — `cleaningUp()` (DB / Session / cache) and `delete this.waInstances[name]` both happen inside the `remove.instance` handler in `monitor.service.ts`.

```diff
       if (instance.state === 'connecting' || instance.state === 'open') {
-        await this.logout({ instanceName });
+        try {
+          await this.logout({ instanceName });
+        } catch (logoutError) {
+          this.logger.warn(
+            `[ZOMBIE-CLEANUP] logout failed for "${instanceName}" (likely zombie socket): ${logoutError?.toString?.() || logoutError}. Proceeding with cleanup.`,
+          );
+        }
       }
```

12 added, 1 changed line. No public API change. `DELETE /instance/:name` becomes idempotent against zombies: a caller can always recover a single instance without affecting other instances on the same host.

## Why this is safe

`remove.instance` is the canonical, internal cleanup path. The handler in `monitor.service.ts` already runs `cleaningUp()` (deletes the `Session` row, sets `connectionStatus='close'` in `Instance`, `rmSync` of the on-disk session dir, clears Redis cache, removes provider session). All of that is independent of whether `logout()` completed gracefully on the WhatsApp side. If the socket is truly dead, talking to WhatsApp wasn't going to happen anyway — what we need is the local cleanup, and this fix unblocks it.

## Tested

Patch deployed in production at Rigarr (Brazilian distributor, 14 active vendor instances, ~25k msgs/day) via Docker image overlay on v2.3.7:

- Before: a single dead Baileys socket forced `docker restart evo2_api` (~30s downtime, all 14 vendors needed to re-scan QR).
- After: `DELETE /instance/:name` returns `{"status":"SUCCESS","response":{"message":"Instance deleted"}}` even when the underlying socket is dead. Other vendors stay connected.

Smoke test before submitting: applied patch on `2.3.7` clone, ran `npm ci && npm run build`, no compile errors. Container boots cleanly. Tested DELETE on a known-zombie instance (`pedro-rca340-sp`, ~115h idle) — instance was correctly removed from memory (`Instance "X" - REMOVED` log line) and from `Instance` table.

## Related context

We're maintaining a downstream Docker overlay (`ghcr.io/inovacaoecrescimento/evolution-api-rigarr:2.3.7-zombiefix-1`) until this lands upstream. We'd love to drop the overlay and go back to using the official image — happy to address review feedback or split the change differently if useful.

Refs:
- ADR (Portuguese): https://github.com/inovacaoecrescimento/command-center/blob/main/decisions/016-zombie-recovery-evolution-patch.md
- Build & overlay repo: https://github.com/inovacaoecrescimento/evolution-api-rigarr

Signed-off-by: Bruno Cavalcante Sgarbi

## Summary by Sourcery

Bug Fixes:
- Prevent zombie instances from remaining in memory by continuing deletion and cleanup even if the logout operation throws due to a dead socket.