### PR TITLE
feat: support native GIF sending without video conversion

### DIFF
--- a/src/api/dto/sendMessage.dto.ts
+++ b/src/api/dto/sendMessage.dto.ts
@@ -25,6 +25,8 @@ export class MediaMessage {
   fileName?: string;
   // url or base64
   media: string;
+  gifPlayback?: boolean | string;
+  gifAttribution?: number | string;
 }
 
 export class StatusMessage {
@@ -83,6 +85,8 @@ export class SendMediaDto extends Metadata {
   fileName?: string;
   // url or base64
   media: string;
+  gifPlayback?: boolean | string;
+  gifAttribution?: number | string;
 }
 
 export class SendPtvDto extends Metadata {

--- a/src/api/integrations/channel/whatsapp/whatsapp.baileys.service.ts
+++ b/src/api/integrations/channel/whatsapp/whatsapp.baileys.service.ts
@@ -3160,7 +3160,10 @@ export class BaileysStartupService extends ChannelStartupService {
         prepareMedia[mediaType].gifPlayback = mediaMessage.gifPlayback === true || mediaMessage.gifPlayback === 'true';
 
         if (mediaMessage.gifAttribution !== undefined) {
-          prepareMedia[mediaType].gifAttribution = Number(mediaMessage.gifAttribution);
+          const gifAttribution = Number(mediaMessage.gifAttribution);
+          if (gifAttribution === 0 || gifAttribution === 1 || gifAttribution === 2) {
+            prepareMedia[mediaType].gifAttribution = gifAttribution;
+          }
         }
       }
 

--- a/src/api/integrations/channel/whatsapp/whatsapp.baileys.service.ts
+++ b/src/api/integrations/channel/whatsapp/whatsapp.baileys.service.ts
@@ -3157,7 +3157,11 @@ export class BaileysStartupService extends ChannelStartupService {
       prepareMedia[mediaType].fileName = mediaMessage.fileName;
 
       if (mediaMessage.mediatype === 'video') {
-        prepareMedia[mediaType].gifPlayback = false;
+        prepareMedia[mediaType].gifPlayback = mediaMessage.gifPlayback === true || mediaMessage.gifPlayback === 'true';
+
+        if (mediaMessage.gifAttribution !== undefined) {
+          prepareMedia[mediaType].gifAttribution = Number(mediaMessage.gifAttribution);
+        }
       }
 
       return generateWAMessageFromContent(

--- a/src/validate/message.schema.ts
+++ b/src/validate/message.schema.ts
@@ -102,6 +102,15 @@ export const mediaMessageSchema: JSONSchema7 = {
     media: { type: 'string' },
     fileName: { type: 'string' },
     caption: { type: 'string' },
+    gifPlayback: {
+      oneOf: [{ type: 'boolean' }, { type: 'string', enum: ['true', 'false'] }],
+    },
+    gifAttribution: {
+      oneOf: [
+        { type: 'integer', enum: [0, 1, 2] },
+        { type: 'string', enum: ['0', '1', '2'] },
+      ],
+    },
     delay: {
       type: 'integer',
       description: 'Enter a value in milliseconds',


### PR DESCRIPTION
## Problem

Currently GIF files are converted to video before sending through Baileys.

This causes unnecessary FFmpeg processing and increased CPU usage.

## Solution

This PR adds native GIF support using Baileys gifPlayback and gifAttribution options,
allowing animated GIFs to be sent without video conversion.

## Changes

* Added `gifPlayback` support
* Added `gifAttribution` support
* Updated DTOs
* Updated request schema validation
* Updated media sending logic

## Benefits

* lower CPU usage
* faster sending
* avoids unnecessary transcoding
* preserves animated GIF behavior

## Compatibility

This change is backward compatible and does not affect normal video sending.

## Summary by Sourcery

Add support for sending native animated GIFs over WhatsApp by propagating gif playback and attribution options through validation, DTOs, and Baileys media preparation.

New Features:
- Allow clients to specify gifPlayback and gifAttribution when sending media messages to control animated GIF behavior.

Enhancements:
- Extend media message DTOs and validation schema to accept gifPlayback and gifAttribution as boolean/number or string values.
- Update Baileys media preparation to forward gifPlayback and gifAttribution for video media without forcing GIF-to-video conversion.