### PR TITLE
fix(whatsapp): allow @lid contacts to bypass onWhatsApp validation

### DIFF
--- a/src/api/integrations/channel/whatsapp/whatsapp.baileys.service.ts
+++ b/src/api/integrations/channel/whatsapp/whatsapp.baileys.service.ts
@@ -2096,7 +2096,7 @@ export class BaileysStartupService extends ChannelStartupService {
   ) {
     const isWA = (await this.whatsappNumber({ numbers: [number] }))?.shift();
 
-    if (!isWA.exists && !isJidGroup(isWA.jid) && !isWA.jid.includes('@broadcast')) {
+    if (!isWA.exists && !isJidGroup(isWA.jid) && !isWA.jid.includes('@broadcast') && !isWA.jid.includes('@lid')) {
       throw new BadRequestException(isWA);
     }
 
@@ -2344,7 +2344,7 @@ export class BaileysStartupService extends ChannelStartupService {
 
       const isWA = (await this.whatsappNumber({ numbers: [number] }))?.shift();
 
-      if (!isWA.exists && !isJidGroup(isWA.jid) && !isWA.jid.includes('@broadcast')) {
+      if (!isWA.exists && !isJidGroup(isWA.jid) && !isWA.jid.includes('@broadcast') && !isWA.jid.includes('@lid')) {
         throw new BadRequestException(isWA);
       }
 


### PR DESCRIPTION
## Problem

After WhatsApp's LID (Linked Identity) migration, contacts that resolve to `@lid` JIDs are rejected by `sendMessageWithTyping` and `sendPresence` because `onWhatsApp` returns `exists: false` for LID-based identifiers. This causes a `BadRequestException` for any DM to an `@lid` contact.

The existing validation already whitelists `@broadcast` JIDs but does not account for `@lid`.

## Fix

Add `&& !isWA.jid.includes('@lid')` to the validation checks in both:
- `sendMessageWithTyping` (line 2099)
- `sendPresence` (line 2347)

This mirrors the existing `@broadcast` bypass logic.

## Related

This fix works in conjunction with a corresponding Baileys fix ([evolution-foundation/Baileys#8](https://github.com/evolution-foundation/Baileys/pull/8)) that preserves per-participant JID domains in group message encryption.

## Testing

Tested with Evolution API v2.2.3 and WhatsApp accounts that have undergone the LID migration. DMs to `@lid` contacts now succeed without throwing BadRequestException.

## Summary by Sourcery

Bug Fixes:
- Prevent BadRequestException errors when sending messages or presence updates to @lid WhatsApp contacts by exempting them from onWhatsApp existence checks.