### PR TITLE
fix: trim whitespace from instanceName on creation

### DIFF
--- a/src/api/controllers/instance.controller.ts
+++ b/src/api/controllers/instance.controller.ts
@@ -36,6 +36,8 @@ export class InstanceController {
 
   public async createInstance(instanceData: InstanceDto) {
     try {
+      instanceData.instanceName = instanceData.instanceName?.trim();
+
       const instance = channelController.init(instanceData, {
         configService: this.configService,
         eventEmitter: this.eventEmitter,


### PR DESCRIPTION
## 📋 Description

Applies `.trim()` to `instanceName` at the beginning of `createInstance` in the instance controller. This ensures that any leading or trailing whitespace is removed before the instance name is persisted to the database.

## 🔗 Related Issue

Closes #2543

## 🧪 Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## 🧪 Testing

- [x] Manual testing completed
- [x] Functionality verified in development environment
- [x] No breaking changes introduced

Steps to reproduce and verify the fix:
1. Create an instance with a trailing space in the name (e.g. `"my-instance "`)
2. Confirm the instance is stored without the whitespace
3. Call `DELETE /instance/delete/my-instance` — should return 200 instead of 404

## ✅ Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] I have manually tested my changes thoroughly
- [x] I have verified the changes work with different scenarios

## 📝 Additional Notes

The root cause was that instance names with trailing spaces were stored as-is in the database, but URL path parameters used in delete/fetch operations naturally strip that whitespace — causing a name mismatch and a 404. The fix is applied at the entry point of creation so no invalid names ever reach the database.

## Summary by Sourcery

Bug Fixes:
- Trim leading and trailing whitespace from instance names before persisting them when creating instances.