### PR TITLE
fix: handle undefined ephemeralMessage for iOS PTT audio messages

### DIFF
--- a/src/api/integrations/channel/whatsapp/whatsapp.baileys.service.ts
+++ b/src/api/integrations/channel/whatsapp/whatsapp.baileys.service.ts
@@ -4396,12 +4396,12 @@ export class BaileysStartupService extends ChannelStartupService {
 
       const msg = m?.message ? m : ((await this.getMessage(m.key, true)) as proto.IWebMessageInfo);
 
-      if (!msg) {
+      if (!msg?.message) {
         throw 'Message not found';
       }
 
       for (const subtype of MessageSubtype) {
-        if (msg.message[subtype]) {
+        if (msg.message[subtype]?.message) {
           msg.message = msg.message[subtype].message;
         }
       }


### PR DESCRIPTION
## Summary

Fix a crash in `POST /chat/getBase64FromMediaMessage/{instance}` when processing iOS audio messages wrapped in `ephemeralMessage` without the expected `.message` property.

## Problem

When an iPhone sends an audio message, the Baileys `messages.upsert` event delivers it wrapped in an `ephemeralMessage` container. The service iterates over known `MessageSubtype` values and unwraps them:

```typescript
for (const subtype of MessageSubtype) {
  if (msg.message[subtype]) {
    msg.message = msg.message[subtype].message; // crash
  }
}
```

iOS ephemeral messages can have `ephemeralMessage` as a truthy object **without** a standard `.message` property inside. When that happens:

1. `msg.message = undefined` (`.message` doesn't exist on the subtype)
2. Next loop iteration tries `msg.message[subtype]` -> `TypeError: Cannot read properties of undefined (reading 'ephemeralMessage')`

This also crashes when `msg.message` itself is `undefined` (e.g., passing a message object without valid content).

### Error response
```json
{"status":400,"error":"Bad Request","response":{"message":["TypeError: Cannot read properties of undefined (reading 'ephemeralMessage')"]}}
```

## Changes

**File:** `src/api/integrations/channel/whatsapp/whatsapp.baileys.service.ts`

- **Guard against falsy `msg.message`** -- returns `"Message not found"` instead of crashing
- **Safe optional chaining in subtype loop** -- `msg.message[subtype]?.message` ensures unwrapping only happens when `.message` actually exists, preventing `msg.message` from being set to `undefined`

```diff
+ if (!msg.message) {
+   throw 'Message not found';
+ }
+
  for (const subtype of MessageSubtype) {
-   if (msg.message[subtype]) {
+   if (msg.message[subtype]?.message) {
      msg.message = msg.message[subtype].message;
    }
  }
```

## Testing

### Scenarios verified

| Input | Before | After |
|---|---|---|
| `ephemeralMessage` sem `.message` | TypeError crash | `"The message is not of the media type"` |
| `message: null` | TypeError crash | `"Message not found"` |
| `messageContextInfo` apenas | TypeError crash | `null` (skip) |
| Objeto vazio / string | TypeError crash | `"Message not found"` |
| `ephemeralMessage` com audio valido | works | works |
| `audioMessage` direto (DB format) | works | works |

### Checks
- [x] Lint -- `npm run lint:check` clean
- [x] TypeScript -- `tsc --noEmit` clean
- [x] Pre-commit hooks passed

Closes #2550

## Summary by Sourcery

Bug Fixes:
- Prevent crashes when processing iOS WhatsApp audio messages wrapped in ephemeral containers without a nested message object by guarding against falsy msg.message and safely unwrapping subtypes.