### PR TITLE
Fix: corrigir controle do evolutionBot por variavel de ambiente

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -315,6 +315,9 @@ QRCODE_LIMIT=30
 # Color of the QRCode on base64
 QRCODE_COLOR='#175197'
 
+# EvolutionBot - Environment variables
+EVOLUTIONBOT_ENABLED=false
+
 # Typebot - Environment variables
 TYPEBOT_ENABLED=false
 # old | latest

--- a/env.example
+++ b/env.example
@@ -203,6 +203,9 @@ QRCODE_COLOR=#198754
 # INTEGRAÇÕES
 # ===========================================
 
+# EvolutionBot
+EVOLUTIONBOT_ENABLED=false
+
 # Typebot
 TYPEBOT_ENABLED=false
 TYPEBOT_API_VERSION=old

--- a/src/api/integrations/chatbot/evolutionBot/controllers/evolutionBot.controller.ts
+++ b/src/api/integrations/chatbot/evolutionBot/controllers/evolutionBot.controller.ts
@@ -24,7 +24,7 @@ export class EvolutionBotController extends BaseChatbotController<EvolutionBot, 
   public readonly logger = new Logger('EvolutionBotController');
   protected readonly integrationName = 'EvolutionBot';
 
-  integrationEnabled = configService.get<EvolutionBotConfig>('EVOLUTIONBOT').ENABLED;
+  integrationEnabled = configService.get<EvolutionBotConfig>('EVOLUTIONBOT').ENABLED ?? true;
   botRepository: any;
   settingsRepository: any;
   sessionRepository: any;

--- a/src/api/integrations/chatbot/evolutionBot/controllers/evolutionBot.controller.ts
+++ b/src/api/integrations/chatbot/evolutionBot/controllers/evolutionBot.controller.ts
@@ -1,5 +1,6 @@
 import { PrismaRepository } from '@api/repository/repository.service';
 import { WAMonitoringService } from '@api/services/monitor.service';
+import { configService, EvolutionBot as EvolutionBotConfig } from '@config/env.config';
 import { Logger } from '@config/logger.config';
 import { EvolutionBot, IntegrationSession } from '@prisma/client';
 
@@ -23,7 +24,7 @@ export class EvolutionBotController extends BaseChatbotController<EvolutionBot, 
   public readonly logger = new Logger('EvolutionBotController');
   protected readonly integrationName = 'EvolutionBot';
 
-  integrationEnabled = true; // Set to true by default or use config value if available
+  integrationEnabled = configService.get<EvolutionBotConfig>('EVOLUTIONBOT').ENABLED;
   botRepository: any;
   settingsRepository: any;
   sessionRepository: any;

--- a/src/config/env.config.ts
+++ b/src/config/env.config.ts
@@ -314,6 +314,7 @@ export type Webhook = {
 export type Pusher = { ENABLED: boolean; GLOBAL?: GlobalPusher; EVENTS: EventsPusher };
 export type ConfigSessionPhone = { CLIENT: string; NAME: string };
 export type QrCode = { LIMIT: number; COLOR: string };
+export type EvolutionBot = { ENABLED: boolean };
 export type Typebot = { ENABLED: boolean; API_VERSION: string; SEND_MEDIA_BASE64: boolean };
 export type Chatwoot = {
   ENABLED: boolean;
@@ -411,6 +412,7 @@ export interface Env {
   PUSHER: Pusher;
   CONFIG_SESSION_PHONE: ConfigSessionPhone;
   QRCODE: QrCode;
+  EVOLUTIONBOT: EvolutionBot;
   TYPEBOT: Typebot;
   CHATWOOT: Chatwoot;
   OPENAI: Openai;
@@ -803,6 +805,9 @@ export class ConfigService {
       QRCODE: {
         LIMIT: Number.parseInt(process.env.QRCODE_LIMIT) || 30,
         COLOR: process.env.QRCODE_COLOR || '#198754',
+      },
+      EVOLUTIONBOT: {
+        ENABLED: process.env?.EVOLUTIONBOT_ENABLED === 'true',
       },
       TYPEBOT: {
         ENABLED: process.env?.TYPEBOT_ENABLED === 'true',


### PR DESCRIPTION
## 📋 Descrição
Durante a análise de alguns erros relacionado a pool de conexão identifiquei uma chuva de conexões do prisma a cada nova mensagem sendo recebida no whatsapp, mesmo o tipo da Instancia sendo Baileys e não Evolution.

No controller do evolutionBot o integrationEnabled está  hardcoded como TRUE, sem variável de ambiente de controle para os casos em que nenhum tipo de bot é utilizado, como é o meu caso de disparo de mensagens apenas, logo, mesmo com todos os chatbots desabilitados no .env (TypeBot, Dify, etc), o EvolutionBot sempre executa ~10 queries por mensagem recebida (busca de configurações, sessão, gatilhos por tipo, fallback) por estar true.

## 📸 Screenshots (if applicable)

<img width="1539" height="459" alt="image" src="https://github.com/user-attachments/assets/29cfbcfc-a441-466a-bf5e-66aae27bea9f" />

## 📝 Notas Adicionais
O tratamento aplicado foi criar uma variável de ambiente de controle do EvolutionBot assim como já existem para os demais tipos de integrações. Desta forma, caso quem não utilize nenhuma integração e usa apenas disparos de mensagens não é afetado pelas  infinitas requisições feitas sem necessidade, estourando pool de conexões quando a muitas instâncias (meu caso).

## Summary by Sourcery

Gate EvolutionBot integration behind environment-based configuration to avoid unnecessary processing when not in use.

New Features:
- Introduce EVOLUTIONBOT environment configuration with an ENABLED flag to control EvolutionBot integration.

Enhancements:
- Wire EvolutionBot controller to respect the EVOLUTIONBOT_ENABLED flag instead of always running.

Documentation:
- Document the EVOLUTIONBOT_ENABLED environment variable in example env files.