### PR TITLE
fix: Correção reconexão após logout — isDeleting e qrcode.count não resetados

### DIFF
--- a/src/api/integrations/channel/whatsapp/whatsapp.baileys.service.ts
+++ b/src/api/integrations/channel/whatsapp/whatsapp.baileys.service.ts
@@ -354,6 +354,8 @@ export class BaileysStartupService extends ChannelStartupService {
       where: { id: this.instanceId },
       data: { connectionStatus: 'close' },
     });
+
+    this.instance.qrcode = { count: 0 };
   }
 
   public async getProfileName() {
@@ -805,6 +807,7 @@ export class BaileysStartupService extends ChannelStartupService {
     };
 
     this.endSession = false;
+    this.isDeleting = false;
 
     this.client = makeWASocket(socketConfig);
 


### PR DESCRIPTION
## Descrição

### Problema

Após chamar `POST /instance/logout` e em seguida `POST /instance/connect`, o QR code era exibido mas a conexão nunca se completava ao escanear. O fluxo só funcionava corretamente se a instância fosse deletada (`/instance/delete`) e recriada (`/instance/create`).

---

### Bug 1 — `isDeleting` nunca era resetado após logout

**Arquivo:** `src/api/integrations/channel/whatsapp/whatsapp.baileys.service.ts`

`logoutInstance()` seta `this.isDeleting = true` para bloquear reconexões automáticas durante o processo de logout. O problema é que essa flag nunca voltava para `false`.

Quando o usuário chamava `/instance/connect` em seguida, o socket do Baileys era criado normalmente e o QR era gerado — mas ao escanear o QR com o celular, o Baileys emite um evento `connection.update` com `connection === 'close'` como parte do handshake de autenticação. O handler via `isDeleting === true` e abortava silenciosamente:

```typescript
if (this.isDeleting || this.endSession) {
  this.logger.info('Instance is being deleted/ended, skipping reconnection attempt');
  return; // ← autenticação do celular era descartada aqui
}
```

**Correção:** resetar `this.isDeleting = false` em `createClient()`, junto com o já existente `this.endSession = false`, antes de instanciar o socket:

```typescript
this.endSession = false;
this.isDeleting = false; // ← adicionado
this.client = makeWASocket(socketConfig);
```

O reset foi feito em `createClient()` (e não em `connectToWhatsapp()`) porque `createClient()` é o ponto de entrada real da criação do socket, cobrindo também `reloadConnection()` — chamado após operações como `updatePrivacySettings` e `updateProfilePicture`.

---

### Bug 2 — `qrcode.count` acumulava entre sessões

**Arquivo:** `src/api/integrations/channel/whatsapp/whatsapp.baileys.service.ts`

O contador de QR codes (`this.instance.qrcode.count`) era zerado no construtor da classe e pelo handler do evento `no.connection` (quando o limite era atingido), mas **não era resetado no logout**. Isso fazia com que sessões consecutivas de logout + connect consumissem o limite de QR codes mais rapidamente, podendo resultar no disparo prematuro do evento `no.connection` e bloqueio do fluxo.

**Correção:** resetar o contador ao final de `logoutInstance()`, após a atualização do status no banco:

```typescript
await this.prismaRepository.instance.update({
  where: { id: this.instanceId },
  data: { connectionStatus: 'close' },
});

this.instance.qrcode = { count: 0 }; // ← adicionado
```

O reset foi colocado em `logoutInstance()` (e não em `connectToWhatsapp()`) porque `connectToWhatsapp()` também é invocado pelo loop de auto-reconexão interna — resetar o contador nesse ponto burlaria o limite de QR codes em reconexões inesperadas.

---

### Por que `delete + create` funcionava

O `delete` destrói o objeto da instância em memória (`delete waInstances[instanceName]`). O `create` instancia um objeto completamente novo, com todos os valores padrão da classe (`isDeleting = false`, `qrcode.count = 0`). As correções reproduzem esse estado limpo sem exigir a destruição e recriação do objeto.

---

### Arquivos alterados

- `src/api/integrations/channel/whatsapp/whatsapp.baileys.service.ts`

## Summary by Sourcery

Reset WhatsApp Baileys instance state on reconnect to ensure clean sessions after logout.

Bug Fixes:
- Reset the isDeleting flag when creating a new WhatsApp client so reconnections after logout can complete successfully.
- Reset the QR code counter on logout so QR usage does not accumulate across sessions and prematurely trigger connection blocking.