### PR TITLE
fix: preserve unreadCount when inserting chats via messaging-history.set

### DIFF
--- a/src/api/integrations/channel/whatsapp/whatsapp.baileys.service.ts
+++ b/src/api/integrations/channel/whatsapp/whatsapp.baileys.service.ts
@@ -1116,7 +1116,7 @@ export class BaileysStartupService extends ChannelStartupService {
           contactsMapLidJid.set(contact.id, { jid });
         }
 
-        const chatsRaw: { remoteJid: string; remoteLid: string; instanceId: string; name?: string }[] = [];
+        const chatsRaw: { remoteJid: string; remoteLid: string; instanceId: string; name?: string; unreadMessages?: number }[] = [];
         const chatsRepository = new Set(
           (await this.prismaRepository.chat.findMany({ where: { instanceId: this.instanceId } })).map(
             (chat) => chat.remoteJid,
@@ -1149,7 +1149,7 @@ export class BaileysStartupService extends ChannelStartupService {
             remoteJid = chat.id;
           }
 
-          chatsRaw.push({ remoteJid, remoteLid, instanceId: this.instanceId, name: chat.name });
+          chatsRaw.push({ remoteJid, remoteLid, instanceId: this.instanceId, name: chat.name, unreadMessages: chat.unreadCount ?? 0 });
         }
 
         if (this.configService.get<Database>('DATABASE').SAVE_DATA.HISTORIC) {

--- a/src/api/integrations/channel/whatsapp/whatsapp.baileys.service.ts
+++ b/src/api/integrations/channel/whatsapp/whatsapp.baileys.service.ts
@@ -168,6 +168,13 @@ export interface ExtendedIMessageKey extends proto.IMessageKey {
   isViewOnce?: boolean;
 }
 
+export type ChatRaw = {
+  remoteJid: string;
+  instanceId: string;
+  name?: string;
+  unreadMessages?: number;
+};
+
 const groupMetadataCache = new CacheService(new CacheEngine(configService, 'groups').getEngine());
 
 // Adicione a função getVideoDuration no início do arquivo
@@ -874,13 +881,13 @@ export class BaileysStartupService extends ChannelStartupService {
 
       const existingChatIdSet = new Set(existingChatIds.map((chat) => chat.remoteJid));
 
-      const chatsToInsert = chats
+      const chatsToInsert: ChatRaw[] = chats
         .filter((chat) => !existingChatIdSet?.has(chat.id))
         .map((chat) => ({
           remoteJid: chat.id,
           instanceId: this.instanceId,
           name: chat.name,
-          unreadMessages: chat.unreadCount !== undefined ? chat.unreadCount : 0,
+          unreadMessages: chat.unreadCount,
         }));
 
       this.sendDataWebhook(Events.CHATS_UPSERT, chatsToInsert);
@@ -1116,7 +1123,7 @@ export class BaileysStartupService extends ChannelStartupService {
           contactsMapLidJid.set(contact.id, { jid });
         }
 
-        const chatsRaw: { remoteJid: string; remoteLid: string; instanceId: string; name?: string; unreadMessages?: number }[] = [];
+        const chatsRaw: (ChatRaw & { remoteLid: string })[] = [];
         const chatsRepository = new Set(
           (await this.prismaRepository.chat.findMany({ where: { instanceId: this.instanceId } })).map(
             (chat) => chat.remoteJid,
@@ -1149,7 +1156,7 @@ export class BaileysStartupService extends ChannelStartupService {
             remoteJid = chat.id;
           }
 
-          chatsRaw.push({ remoteJid, remoteLid, instanceId: this.instanceId, name: chat.name, unreadMessages: chat.unreadCount ?? 0 });
+          chatsRaw.push({ remoteJid, remoteLid, instanceId: this.instanceId, name: chat.name, unreadMessages: chat.unreadCount });
         }
 
         if (this.configService.get<Database>('DATABASE').SAVE_DATA.HISTORIC) {


### PR DESCRIPTION
## Problem

When a new instance connects and Baileys fires `messaging-history.set` to bulk-import chat history, the `chatsRaw` entries are built with only `remoteJid`, `remoteLid`, `instanceId`, and `name`. The `chat.unreadCount` field — which WhatsApp's server sends in the history sync payload (`Conversation.unreadCount`, protobuf field #6) — is silently dropped.

As a result, every chat inserted through this path gets `unreadMessages = 0` (the Prisma column default), regardless of the actual unread state on the server. The `findChats` endpoint then returns `unreadCount: 0` for all historically-synced chats, even when the user has genuine unread messages.

## Root cause

The `CHATS_UPSERT` insert path mapped the field (coercing missing values to `0`):

```ts
unreadMessages: chat.unreadCount !== undefined ? chat.unreadCount : 0,
```

The `messaging-history.set` handler simply never included the equivalent mapping, so `chat.unreadCount` was dropped for every historically-synced chat.

## Fix

- Extract a shared `ChatRaw` type so the raw chat objects built for both insert paths stay in sync as fields are added.
- In the `messaging-history.set` handler, include `unreadMessages: chat.unreadCount` in the `chatsRaw.push(...)` call (previously dropped).
- Align the `CHATS_UPSERT` insert path to the same `chat.unreadCount` form: pass the value through as-is — i.e. `undefined` when the server didn't send a count — and let the Prisma column default apply, rather than coercing to `0`. This keeps both paths consistent and preserves the distinction between "server explicitly reported 0 unread" and "no unread count provided".

## Testing

1. Create a fresh instance and scan QR code
2. Let `messaging-history.set` fire during initial sync
3. Call `POST /chat/findChats/{instance}` — chats should now reflect the server-side unread counts instead of all returning `unreadCount: 0`

## Summary by Sourcery

Bug Fixes:
- Include unread message count from Conversation.unreadCount when building chats inserted during history sync, instead of defaulting all imported chats to zero unread messages.
