### PR TITLE
fix: Melhoria de desempenho com uso de indices no endpoint fetchInstance

### DIFF
--- a/prisma/mysql-migrations/20260527000000_add_index_instance_client_name_token_number/migration.sql
+++ b/prisma/mysql-migrations/20260527000000_add_index_instance_client_name_token_number/migration.sql
@@ -1,0 +1,8 @@
+-- CreateIndex
+CREATE INDEX `Instance_clientName_idx` ON `Instance`(`clientName`);
+
+-- CreateIndex
+CREATE INDEX `Instance_token_idx` ON `Instance`(`token`);
+
+-- CreateIndex
+CREATE INDEX `Instance_number_idx` ON `Instance`(`number`);

--- a/prisma/mysql-migrations/20260527000000_add_index_instance_client_name_token_number/migration.sql
+++ b/prisma/mysql-migrations/20260527000000_add_index_instance_client_name_token_number/migration.sql
@@ -1,8 +1,8 @@
 -- CreateIndex
-CREATE INDEX `Instance_clientName_idx` ON `Instance`(`clientName`);
+CREATE UNIQUE INDEX `Instance_clientName_idx` ON `Instance`(`clientName`);
 
 -- CreateIndex
-CREATE INDEX `Instance_token_idx` ON `Instance`(`token`);
+CREATE UNIQUE INDEX `Instance_token_idx` ON `Instance`(`token`);
 
 -- CreateIndex
-CREATE INDEX `Instance_number_idx` ON `Instance`(`number`);
+CREATE UNIQUE INDEX `Instance_number_idx` ON `Instance`(`number`);

--- a/prisma/mysql-migrations/20260527000000_add_index_instance_client_name_token_number/migration.sql
+++ b/prisma/mysql-migrations/20260527000000_add_index_instance_client_name_token_number/migration.sql
@@ -1,8 +1,8 @@
 -- CreateIndex
-CREATE UNIQUE INDEX `Instance_clientName_idx` ON `Instance`(`clientName`);
+CREATE INDEX `Instance_clientName_idx` ON `Instance`(`clientName`);
 
 -- CreateIndex
-CREATE UNIQUE INDEX `Instance_token_idx` ON `Instance`(`token`);
+CREATE INDEX `Instance_token_idx` ON `Instance`(`token`);
 
 -- CreateIndex
-CREATE UNIQUE INDEX `Instance_number_idx` ON `Instance`(`number`);
+CREATE INDEX `Instance_number_idx` ON `Instance`(`number`);

--- a/prisma/postgresql-migrations/20260527000000_add_index_instance_client_name_token_number/migration.sql
+++ b/prisma/postgresql-migrations/20260527000000_add_index_instance_client_name_token_number/migration.sql
@@ -1,0 +1,8 @@
+-- CreateIndex
+CREATE INDEX IF NOT EXISTS "Instance_clientName_idx" ON "Instance"("clientName");
+
+-- CreateIndex
+CREATE INDEX IF NOT EXISTS "Instance_token_idx" ON "Instance"("token");
+
+-- CreateIndex
+CREATE INDEX IF NOT EXISTS "Instance_number_idx" ON "Instance"("number");

--- a/prisma/postgresql-migrations/20260527000000_add_index_instance_client_name_token_number/migration.sql
+++ b/prisma/postgresql-migrations/20260527000000_add_index_instance_client_name_token_number/migration.sql
@@ -1,8 +1,8 @@
 -- CreateIndex
-CREATE INDEX IF NOT EXISTS "Instance_clientName_idx" ON "Instance"("clientName");
+CREATE UNIQUE INDEX "Instance_clientName_idx" ON "Instance"("clientName");
 
 -- CreateIndex
-CREATE INDEX IF NOT EXISTS "Instance_token_idx" ON "Instance"("token");
+CREATE UNIQUE INDEX "Instance_token_idx" ON "Instance"("token");
 
 -- CreateIndex
-CREATE INDEX IF NOT EXISTS "Instance_number_idx" ON "Instance"("number");
+CREATE UNIQUE INDEX "Instance_number_idx" ON "Instance"("number");

--- a/prisma/postgresql-migrations/20260527000000_add_index_instance_client_name_token_number/migration.sql
+++ b/prisma/postgresql-migrations/20260527000000_add_index_instance_client_name_token_number/migration.sql
@@ -1,8 +1,8 @@
 -- CreateIndex
-CREATE UNIQUE INDEX "Instance_clientName_idx" ON "Instance"("clientName");
+CREATE INDEX "Instance_clientName_idx" ON "Instance"("clientName");
 
 -- CreateIndex
-CREATE UNIQUE INDEX "Instance_token_idx" ON "Instance"("token");
+CREATE INDEX "Instance_token_idx" ON "Instance"("token");
 
 -- CreateIndex
-CREATE UNIQUE INDEX "Instance_number_idx" ON "Instance"("number");
+CREATE INDEX "Instance_number_idx" ON "Instance"("number");


### PR DESCRIPTION
### Resumo

Adiciona três índices ausentes na tabela `Instance` que são consultados em caminhos críticos da aplicação, mas estavam executando varredura sequencial completa na tabela.

- **`clientName`** — filtrado em toda **inicialização do servidor** (`loadInstancesFromDatabasePostgres`) e em cada chamada a `fetchInstances` sem instância específica
- **`token`** — filtrado em **toda requisição autenticada** a `/instance/fetchInstances` quando utilizado token de instância ao invés da chave global (`auth.guard.ts` + `instance.controller.ts`)
- **`number`** — filtrado nas buscas via `instanceInfoById` por número de telefone

Sem esses índices, cada uma dessas queries executa um full scan na tabela `Instance`. Em ambientes multi-tenant com centenas ou milhares de instâncias compartilhando o mesmo banco, isso impacta diretamente o tempo de inicialização, a latência de autenticação e o tempo de resposta das buscas de instância.

### Alterações

- `prisma/postgresql-migrations/20260527000000_add_index_instance_client_name_token_number/migration.sql`
- `prisma/mysql-migrations/20260527000000_add_index_instance_client_name_token_number/migration.sql`

### Verificação

Após aplicar a migration, use `EXPLAIN ANALYZE` (PostgreSQL) ou `EXPLAIN` (MySQL) para confirmar que os índices estão sendo utilizados:

```sql
-- PostgreSQL
EXPLAIN ANALYZE SELECT * FROM "Instance" WHERE "clientName" = 'seu-client';
EXPLAIN ANALYZE SELECT * FROM "Instance" WHERE "token" = 'seu-token';
EXPLAIN ANALYZE SELECT * FROM "Instance" WHERE "number" = 'seu-numero';

-- MySQL
EXPLAIN SELECT * FROM `Instance` WHERE `clientName` = 'seu-client';
EXPLAIN SELECT * FROM `Instance` WHERE `token` = 'seu-token';
EXPLAIN SELECT * FROM `Instance` WHERE `number` = 'seu-numero';
```

## Summary by Sourcery

Add database indexes to improve query performance for instance lookups by client name, token, and phone number.

Build:
- Add MySQL migration to create indexes on Instance.clientName, Instance.token, and Instance.number.
- Add PostgreSQL migration to create indexes on Instance.clientName, Instance.token, and Instance.number if they do not already exist.