### PR TITLE
fix(chatwoot): deliver bot QR when conversation is resolved

### DIFF
--- a/src/api/integrations/chatbot/chatwoot/services/chatwoot.service.ts
+++ b/src/api/integrations/chatbot/chatwoot/services/chatwoot.service.ts
@@ -979,9 +979,15 @@ export class ChatwootService {
       return null;
     }
 
+    const contactId = contact.id || (contact as any)?.payload?.contact?.id;
+    if (!contactId) {
+      this.logger.warn('contact id not found');
+      return null;
+    }
+
     const conversations = (await client.contacts.listConversations({
       accountId: this.provider.accountId,
-      id: contact.id,
+      id: contactId,
     })) as any;
 
     return (
@@ -989,6 +995,81 @@ export class ChatwootService {
         (conversation) => conversation.inbox_id === inbox.id && conversation.status === 'open',
       ) || undefined
     );
+  }
+
+  /**
+   * Resolves the bot contact conversation used for QR/status commands.
+   * Reopens the latest inbox conversation when automations resolve it after init.
+   */
+  public async getOrOpenBotConversation(
+    instance: InstanceDto,
+    inbox: inbox,
+    contact: generic_id & contact,
+  ): Promise<conversation | null> {
+    const openConversation = await this.getOpenConversationByContact(instance, inbox, contact);
+    if (openConversation) {
+      return openConversation;
+    }
+
+    const client = await this.clientCw(instance);
+    if (!client) {
+      this.logger.warn('client not found');
+      return null;
+    }
+
+    const contactId = contact.id || (contact as any)?.payload?.contact?.id;
+    if (!contactId) {
+      this.logger.warn('contact id not found');
+      return null;
+    }
+
+    const conversations = (await client.contacts.listConversations({
+      accountId: this.provider.accountId,
+      id: contactId,
+    })) as any;
+
+    const inboxConversations = (conversations?.payload ?? [])
+      .filter((conversation: conversation) => conversation.inbox_id === inbox.id)
+      .sort((a: conversation, b: conversation) => b.id - a.id);
+
+    const latestConversation = inboxConversations[0];
+
+    if (latestConversation) {
+      if (latestConversation.status !== 'open') {
+        await client.conversations.toggleStatus({
+          accountId: this.provider.accountId,
+          conversationId: latestConversation.id,
+          data: {
+            status: 'open',
+          },
+        });
+        latestConversation.status = 'open';
+      }
+
+      this.logger.log(`Reopened bot conversation ID: ${latestConversation.id} for ${instance.instanceName}`);
+      return latestConversation;
+    }
+
+    const created = await client.conversations.create({
+      accountId: this.provider.accountId,
+      data: {
+        contact_id: contactId.toString(),
+        inbox_id: inbox.id.toString(),
+      },
+    });
+
+    if (!created) {
+      this.logger.warn('bot conversation could not be created');
+      return null;
+    }
+
+    this.logger.log(`Created bot conversation ID: ${created.id} for ${instance.instanceName}`);
+    return created;
+  }
+
+  private isBotInitCommand(command: string): boolean {
+    const normalized = command.trim().toLowerCase();
+    return normalized === 'init' || normalized === 'iniciar' || normalized.startsWith('init:');
   }
 
   public async createBotMessage(
@@ -1022,10 +1103,10 @@ export class ChatwootService {
       return null;
     }
 
-    const conversation = await this.getOpenConversationByContact(instance, filterInbox, contact);
+    const conversation = await this.getOrOpenBotConversation(instance, filterInbox, contact);
 
     if (!conversation) {
-      this.logger.warn('conversation not found');
+      this.logger.warn('bot conversation not found');
       return;
     }
 
@@ -1152,10 +1233,10 @@ export class ChatwootService {
       return null;
     }
 
-    const conversation = await this.getOpenConversationByContact(instance, filterInbox, contact);
+    const conversation = await this.getOrOpenBotConversation(instance, filterInbox, contact);
 
     if (!conversation) {
-      this.logger.warn('conversation not found');
+      this.logger.warn('bot conversation not found');
       return;
     }
 
@@ -1346,6 +1427,12 @@ export class ChatwootService {
 
       const senderName = body?.conversation?.messages[0]?.sender?.available_name || body?.sender?.name;
       const waInstance = this.waMonitor.waInstances[instance.instanceName];
+
+      if (!waInstance) {
+        this.logger.warn(`wa instance not found: ${instance.instanceName}`);
+        return { message: 'bot' };
+      }
+
       instance.instanceId = waInstance.instanceId;
 
       if (body.event === 'message_updated' && body.content_attributes?.deleted) {
@@ -1376,7 +1463,7 @@ export class ChatwootService {
       if (chatId === '123456' && body.message_type === 'outgoing') {
         const command = messageReceived.replace('/', '');
 
-        if (cwBotContact && (command.includes('init') || command.includes('iniciar'))) {
+        if (cwBotContact && this.isBotInitCommand(command)) {
           const state = waInstance?.connectionStatus?.state;
 
           if (state !== 'open') {
@@ -2500,14 +2587,6 @@ export class ChatwootService {
           fileStream.push(fileData);
           fileStream.push(null);
 
-          await this.createBotQr(
-            instance,
-            i18next.t('qrgeneratedsuccesfully'),
-            'incoming',
-            fileStream,
-            `${instance.instanceName}.png`,
-          );
-
           let msgQrCode = `⚡️${i18next.t('qrgeneratedsuccesfully')}\n\n${i18next.t('scanqr')}`;
 
           if (body?.qrcode?.pairingCode) {
@@ -2519,7 +2598,7 @@ export class ChatwootService {
               )}`;
           }
 
-          await this.createBotMessage(instance, msgQrCode, 'incoming');
+          await this.createBotQr(instance, msgQrCode, 'incoming', fileStream, `${instance.instanceName}.png`);
         }
       }
     } catch (error) {


### PR DESCRIPTION
## Summary

Fixes a production issue where WhatsApp QR codes are generated by Baileys but never reach the Chatwoot bot conversation after users send `init`.

**Root cause:** `createBotMessage` and `createBotQr` only post to conversations with `status === 'open'`. Chatwoot automations frequently resolve the bot thread (`+123456`) right after `init`, so Evolution logs `conversation not found` and silently drops the QR. Instances can remain stuck in `connecting` until `QRCODE_LIMIT` is reached.

## Changes

- Add `getOrOpenBotConversation()` to reopen the latest bot inbox conversation or create a new one before sending bot messages
- Use the helper in `createBotMessage` and `createBotQr`
- Match `init` commands exactly (`init`, `init:<number>`, `iniciar`) instead of `includes('init')`
- Guard `receiveWebhook` when the WA instance is not loaded in memory
- Send QR image + scan instructions in a single bot message (avoid duplicate QR posts per refresh)

## Reproduction (before fix)

1. Enable `CHATWOOT_BOT_CONTACT=true`
2. Create/connect instance with Chatwoot integration
3. Send `init` in bot conversation (`+123456`)
4. Let Chatwoot automation resolve the conversation
5. Baileys generates QR → Evolution logs `WARN conversation not found` → user never receives QR in Chatwoot

## Test plan

- [ ] Send `init` in bot conversation with a resolved thread → conversation reopens and QR image arrives
- [ ] Send `init` when no bot conversation exists → conversation is created and QR arrives
- [ ] Commands `init:5511999999999` and `iniciar` still trigger connection
- [ ] Commands like `definition` no longer trigger connection
- [ ] QR limit message is delivered when `QRCODE_LIMIT` is reached
- [ ] Normal Chatwoot ↔ WhatsApp customer conversations are unaffected


Made with [Cursor](https://cursor.com)

## Summary by Sourcery

Ensure Chatwoot bot conversations are reopened or created before delivering QR and status messages, and tighten handling of bot init commands and WhatsApp instance availability.

Bug Fixes:
- Prevent WhatsApp QR codes from being dropped when the bot conversation has been auto-resolved by reopening or creating the bot inbox conversation before sending messages.
- Avoid failures when Chatwoot contact payloads lack a top-level ID by safely deriving the contact ID from nested payload data.
- Stop triggering bot initialization on messages that merely contain the substring 'init' by matching specific init-style commands only.
- Prevent processing of bot webhooks when the corresponding WhatsApp instance is not loaded in memory.

Enhancements:
- Send WhatsApp QR images and scan instructions in a single bot message to avoid duplicate QR posts per refresh and improve user experience.