### PR TITLE
fix: use AppStateSyncKeyData.fromObject instead of .create for app-state keys

### DIFF
--- a/src/utils/use-multi-file-auth-state-prisma.ts
+++ b/src/utils/use-multi-file-auth-state-prisma.ts
@@ -182,7 +182,7 @@ export default async function useMultiFileAuthStatePrisma(
             ids.map(async (id) => {
               let value = await readData(`${type}-${id}`);
               if (type === 'app-state-sync-key' && value) {
-                value = proto.Message.AppStateSyncKeyData.create(value);
+                value = proto.Message.AppStateSyncKeyData.fromObject(value);
               }
 
               data[id] = value;

--- a/src/utils/use-multi-file-auth-state-provider-files.ts
+++ b/src/utils/use-multi-file-auth-state-provider-files.ts
@@ -116,7 +116,7 @@ export class AuthStateProvider {
               ids.map(async (id) => {
                 let value = await readData(`${type}-${id}`);
                 if (type === 'app-state-sync-key' && value) {
-                  value = proto.Message.AppStateSyncKeyData.create(value);
+                  value = proto.Message.AppStateSyncKeyData.fromObject(value);
                 }
 
                 data[id] = value;

--- a/src/utils/use-multi-file-auth-state-redis-db.ts
+++ b/src/utils/use-multi-file-auth-state-redis-db.ts
@@ -61,7 +61,7 @@ export async function useMultiFileAuthStateRedisDb(
             ids.map(async (id) => {
               let value = await readData(`${type}-${id}`);
               if (type === 'app-state-sync-key' && value) {
-                value = proto.Message.AppStateSyncKeyData.create(value);
+                value = proto.Message.AppStateSyncKeyData.fromObject(value);
               }
 
               data[id] = value;


### PR DESCRIPTION
## Problem

All three auth-state providers (Prisma, Redis, file-based) read `app-state-sync-key` data using:

```typescript
value = proto.Message.AppStateSyncKeyData.create(value);
```

This causes `error:1C800064:Provider routines::bad decrypt` on every attempt to decode app-state mutations. As a result, **no app-state events fire** (`labels.association`, `chats.update` from archives, mutes, etc.).

## Root Cause

The write path stores keys with `JSON.stringify(value, BufferJSON.replacer)` — Baileys' serializer that encodes `Buffer`/`Uint8Array` fields as `{"type":"Buffer","data":"<base64>"}`.

The read path parses them with `JSON.parse(stored, BufferJSON.reviver)` — which correctly reconstructs `Buffer` objects.

However, after `reviver` runs, the code wraps the result with `.create(value)`. The protobuf `.create()` method **performs no type conversion** — it copies fields as-is. It does not coerce a restored `Buffer` to the exact `Uint8Array` layout that the proto field expects for all downstream operations. This produces a `keyData` buffer that is wrong for HKDF key derivation, leading to a wrong AES-256-CBC key and the `bad decrypt` error.

**`.fromObject(value)`**, on the other hand, is specifically designed to accept a plain JS object and convert all fields to their correct proto types — which is exactly what we need after JSON deserialization.

## Fix

In all three auth-state files, change `.create` to `.fromObject`:

```diff
  if (type === 'app-state-sync-key' && value) {
-   value = proto.Message.AppStateSyncKeyData.create(value);
+   value = proto.Message.AppStateSyncKeyData.fromObject(value);
  }
```

Files changed:
- `src/utils/use-multi-file-auth-state-prisma.ts`
- `src/utils/use-multi-file-auth-state-provider-files.ts`
- `src/utils/use-multi-file-auth-state-redis-db.ts`

## Verified Behavior

After this fix:
- App-state decryption succeeds (no more `bad decrypt`)
- Full snapshot sync processes correctly (363 mutations for the `regular` collection on first connect)
- Delta syncs work (only new patches processed on subsequent changes)
- `labels.association`, `chats.update`, and other app-state events fire correctly

Tested with Evolution API v2.3.7, Baileys 7.0.0-rc.9, PostgreSQL auth-state provider.

The fix is identical and necessary for all three providers.

## Summary by Sourcery

Bug Fixes:
- Correct app-state sync key reconstruction by using the protobuf fromObject helper instead of create in Prisma, file-based, and Redis auth-state providers so app-state decryption and events work as expected.