### PR TITLE
fix: remove @lid→remoteJidAlt mutation that causes inconsistent DB storage

### DIFF
--- a/src/api/integrations/channel/whatsapp/whatsapp.baileys.service.ts
+++ b/src/api/integrations/channel/whatsapp/whatsapp.baileys.service.ts
@@ -1475,11 +1475,6 @@ export class BaileysStartupService extends ChannelStartupService {
           this.logger.verbose(messageRaw);
 
           sendTelemetry(`received.message.${messageRaw.messageType ?? 'unknown'}`);
-          if (messageRaw.key.remoteJid?.includes('@lid') && messageRaw.key.remoteJidAlt) {
-            messageRaw.key.remoteJid = messageRaw.key.remoteJidAlt;
-          }
-          console.log(messageRaw);
-
           this.sendDataWebhook(Events.MESSAGES_UPSERT, messageRaw);
 
           await chatbotController.emit({


### PR DESCRIPTION
## Problem

When a message arrives from a LID-addressed WhatsApp contact, the existing code replaces `messageRaw.key.remoteJid` with `remoteJidAlt`:

```typescript
if (messageRaw.key.remoteJid?.includes('@lid') && messageRaw.key.remoteJidAlt) {
  messageRaw.key.remoteJid = messageRaw.key.remoteJidAlt;
}
console.log(messageRaw);
```

This causes two problems:

### 1. Shared reference — unintended mutation of `received.key`

`prepareMessage()` returns `{ key: message.key, ... }` — the `key` is **passed by reference**, not copied:

```typescript
// whatsapp.baileys.service.ts
private prepareMessage(message: proto.IWebMessageInfo): any {
  const messageRaw = {
    key: message.key,  // same object reference as received.key
    ...
  };
}
```

Mutating `messageRaw.key.remoteJid` also mutates `received.key.remoteJid`. However, the `Chat` lookup happens **before** `prepareMessage()` is called:

```typescript
// line ~1178 — uses received.key.remoteJid = @lid
const existingChat = await this.prismaRepository.chat.findFirst({
  where: { instanceId: this.instanceId, remoteJid: received.key.remoteJid },
});

// line ~1204
const messageRaw = this.prepareMessage(received);

// line ~1478 — mutation happens here, AFTER the chat lookup
if (messageRaw.key.remoteJid?.includes('@lid') && messageRaw.key.remoteJidAlt) {
  messageRaw.key.remoteJid = messageRaw.key.remoteJidAlt;  // also changes received.key.remoteJid
}
```

Result: the `Chat` record is stored under `@lid`, but `Contact` and `Message` records (written after this mutation) end up stored under the `phone:device` JID — three entities for the same conversation under three different identifiers.

### 2. Overwrites the canonical chat ID defined by Baileys

Baileys populates the full addressing context directly from the stanza at decode time (`decode-wa-message.js`):

```javascript
const key = {
  remoteJid:      chatId,                        // @lid — the canonical chat ID
  remoteJidAlt:   addressingContext.senderAlt,   // phone:device@s.whatsapp.net
  addressingMode: addressingContext.addressingMode, // 'lid' | 'pn'
  fromMe, id, participant, ...
};
```

`key.remoteJid` (`@lid`) is the identifier Baileys uses for the chat in `chats.upsert`, `labels.association`, and all app-state sync events. Overwriting it in the webhook loses this ID, making it impossible to correlate `messages.upsert` events with chat lookups (e.g. `GET /chat/findChatByRemoteJid`, label queries).

## Fix

Remove the mutation entirely. The webhook payload already includes `key.remoteJidAlt` and `key.addressingMode`, so consumers have all the information they need:

- `key.remoteJid` — use as the canonical chat ID for all API lookups
- `key.remoteJidAlt` — the alternate form (phone number with device suffix)
- `key.addressingMode` — `'lid'` or `'pn'` to know which form WhatsApp used

Also removes a `console.log(messageRaw)` debug statement that was left in production.

## Verified behavior

- `Chat`, `Contact`, and `Message` records are now consistently stored under the same JID
- `GET /chat/findChatByRemoteJid?remoteJid=<remoteJid from webhook>` returns the correct chat with labels
- The `labels.association` webhook `chatId` matches `messages.upsert` webhook `key.remoteJid`
- Consumers can strip the device suffix from `key.remoteJidAlt` (remove `:0` before `@`) to get the bare phone number for display

Tested with Evolution API v2.3.7, Baileys 7.0.0-rc.9.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

## Summary by Sourcery

Ensure WhatsApp message webhooks preserve the canonical chat identifier without mutating message keys.

Bug Fixes:
- Stop mutating message key.remoteJid to remoteJidAlt to keep Chat, Contact, and Message records consistently keyed by the canonical JID.

Enhancements:
- Remove leftover console logging from WhatsApp message handling to reduce noisy production logs.