### PR TITLE
fix(cloud-api): guard contacts[0].profile.name to stop status webhooks from crashing

### DIFF
--- a/src/api/integrations/channel/meta/whatsapp.business.service.ts
+++ b/src/api/integrations/channel/meta/whatsapp.business.service.ts
@@ -387,7 +387,7 @@ export class BusinessStartupService extends ChannelStartupService {
       let messageRaw: any;
       let pushName: any;
 
-      if (received.contacts) pushName = received.contacts[0].profile.name;
+      if (received.contacts) pushName = received.contacts[0]?.profile?.name;
 
       if (received.messages) {
         const message = received.messages[0]; // Añadir esta línea para definir message


### PR DESCRIPTION
## Problem

WhatsApp Cloud API **status** webhooks (delivered / read receipts) carry a `contacts` array that does **not** include a `profile` object — only message webhooks do. In `BusinessStartupService.messageHandle`, the code unconditionally reads `received.contacts[0].profile.name`:

```ts
if (received.contacts) pushName = received.contacts[0].profile.name;
```

For a status payload, `received.contacts[0].profile` is `undefined`, so this throws:

```
TypeError: Cannot read properties of undefined (reading 'name')
```

The throw happens before the handler can persist/forward the update, so **`MESSAGES_UPDATE` events (delivered/read) are never processed** on the `WHATSAPP-BUSINESS` channel and delivery/read ticks stay broken.

### Repro (abridged)

A Cloud API status webhook looks like:

```json
{
  "statuses": [{ "id": "wamid...", "status": "delivered", "recipient_id": "55..." }],
  "contacts": [{ "wa_id": "55..." }]
}
```

`contacts[0].profile` is absent → `received.contacts[0].profile.name` throws `TypeError: Cannot read properties of undefined (reading 'name')`.

## Fix

One-line guard with optional chaining so `pushName` is simply `undefined` for status webhooks (which don't need a pushName) and the handler continues to process the update:

```ts
if (received.contacts) pushName = received.contacts[0]?.profile?.name;
```
