### PR TITLE
fix: use AppStateSyncKeyData.fromObject instead of .create for app-state keys

### DIFF
--- a/src/utils/proto-helpers.ts
+++ b/src/utils/proto-helpers.ts
@@ -1,0 +1,8 @@
+import { WAProto as proto } from 'baileys';
+
+export function deserializeAppStateSyncKey(type: string, value: unknown): unknown {
+  if (type === 'app-state-sync-key' && value) {
+    return proto.Message.AppStateSyncKeyData.fromObject(value);
+  }
+  return value;
+}

--- a/src/utils/use-multi-file-auth-state-prisma.ts
+++ b/src/utils/use-multi-file-auth-state-prisma.ts
@@ -4,6 +4,7 @@ import { CacheConf, configService } from '@config/env.config';
 import { Logger } from '@config/logger.config';
 import { INSTANCE_DIR } from '@config/path.config';
 import { AuthenticationState, BufferJSON, initAuthCreds, WAProto as proto } from 'baileys';
+import { deserializeAppStateSyncKey } from './proto-helpers';
 import fs from 'fs/promises';
 import path from 'path';
 
@@ -181,9 +182,7 @@ export default async function useMultiFileAuthStatePrisma(
           await Promise.all(
             ids.map(async (id) => {
               let value = await readData(`${type}-${id}`);
-              if (type === 'app-state-sync-key' && value) {
-                value = proto.Message.AppStateSyncKeyData.create(value);
-              }
+              value = deserializeAppStateSyncKey(type, value);
 
               data[id] = value;
             }),

--- a/src/utils/use-multi-file-auth-state-provider-files.ts
+++ b/src/utils/use-multi-file-auth-state-provider-files.ts
@@ -37,6 +37,7 @@
 import { ProviderFiles } from '@api/provider/sessions';
 import { Logger } from '@config/logger.config';
 import { AuthenticationCreds, AuthenticationState, BufferJSON, initAuthCreds, proto, SignalDataTypeMap } from 'baileys';
+import { deserializeAppStateSyncKey } from './proto-helpers';
 import { isNotEmpty } from 'class-validator';
 
 export type AuthState = {
@@ -115,9 +116,7 @@ export class AuthStateProvider {
             await Promise.all(
               ids.map(async (id) => {
                 let value = await readData(`${type}-${id}`);
-                if (type === 'app-state-sync-key' && value) {
-                  value = proto.Message.AppStateSyncKeyData.create(value);
-                }
+                value = deserializeAppStateSyncKey(type, value);
 
                 data[id] = value;
               }),

--- a/src/utils/use-multi-file-auth-state-redis-db.ts
+++ b/src/utils/use-multi-file-auth-state-redis-db.ts
@@ -1,6 +1,7 @@
 import { CacheService } from '@api/services/cache.service';
 import { Logger } from '@config/logger.config';
 import { AuthenticationCreds, AuthenticationState, initAuthCreds, proto, SignalDataTypeMap } from 'baileys';
+import { deserializeAppStateSyncKey } from './proto-helpers';
 
 export async function useMultiFileAuthStateRedisDb(
   instanceName: string,
@@ -60,9 +61,7 @@ export async function useMultiFileAuthStateRedisDb(
           await Promise.all(
             ids.map(async (id) => {
               let value = await readData(`${type}-${id}`);
-              if (type === 'app-state-sync-key' && value) {
-                value = proto.Message.AppStateSyncKeyData.create(value);
-              }
+              value = deserializeAppStateSyncKey(type, value);
 
               data[id] = value;
             }),


### PR DESCRIPTION
## Problem

All three auth-state providers (Prisma, Redis, files) read `app-state-sync-key` data using:

```typescript
value = proto.Message.AppStateSyncKeyData.create(value);
```

This causes `error:1C800064:Provider routines::bad decrypt` whenever Baileys tries to decode app-state mutations (labels, archives, mutes, etc.). The result is that **no app-state events ever fire**.

## Root cause

The write path serializes keys with `JSON.stringify(value, BufferJSON.replacer)`, encoding `Buffer`/`Uint8Array` fields as `{"type":"Buffer","data":"<base64>"}`. The read path restores them via `JSON.parse(stored, BufferJSON.reviver)`, which correctly reconstructs `Buffer` objects.

However, `.create(value)` performs **no type conversion** — it copies fields as-is and does not coerce a restored `Buffer` back to the `Uint8Array` the proto field expects. This produces a structurally wrong `keyData` in the HKDF derivation step, leading to a wrong AES-256-CBC key and the `bad decrypt` error.

**`.fromObject(value)`** is designed to accept a plain JS object and properly convert all fields to their correct proto types — exactly what is needed after `BufferJSON.reviver` deserialization.

## Fix

Replace `.create()` with `.fromObject()` in the three auth-state files. The logic is extracted into a shared `deserializeAppStateSyncKey` helper in `src/utils/proto-helpers.ts` to avoid duplication across providers.

```diff
- value = proto.Message.AppStateSyncKeyData.create(value);
+ value = deserializeAppStateSyncKey(type, value);
```

Files changed:
- `src/utils/proto-helpers.ts` (new — shared helper)
- `src/utils/use-multi-file-auth-state-prisma.ts`
- `src/utils/use-multi-file-auth-state-provider-files.ts`
- `src/utils/use-multi-file-auth-state-redis-db.ts`

## Verified behavior

After this fix:
- App-state decryption succeeds (no more `bad decrypt`)
- Full snapshot sync processes correctly (363 mutations for `regular` collection)
- Delta syncs work on subsequent label changes
- `labels.association`, `chats.update`, and other app-state events fire correctly

Tested with Evolution API v2.3.7, Baileys 7.0.0-rc.9, PostgreSQL auth-state provider.

> Reopened from #2593 against `develop` as requested.

## Summary by Sourcery

Use a shared helper to correctly deserialize app-state sync keys for all auth-state providers so app-state events can be decrypted and processed.

Bug Fixes:
- Fix app-state decryption by using AppStateSyncKeyData.fromObject instead of create when loading stored app-state sync keys.

Enhancements:
- Introduce a shared deserializeAppStateSyncKey utility to centralize app-state key deserialization across file, Redis, and Prisma auth-state providers.