### PR TITLE
Fix: corrigir controle do evolutionBot por variavel de ambiente

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -333,6 +333,9 @@ QRCODE_LIMIT=30
 # Color of the QRCode on base64
 QRCODE_COLOR='#175197'
 
+# EvolutionBot - Environment variables
+EVOLUTIONBOT_ENABLED=false
+
 # Typebot - Environment variables
 TYPEBOT_ENABLED=false
 # old | latest

--- a/env.example
+++ b/env.example
@@ -214,6 +214,9 @@ QRCODE_COLOR=#198754
 # INTEGRAÇÕES
 # ===========================================
 
+# EvolutionBot - Environment variables
+EVOLUTIONBOT_ENABLED=false
+
 # Typebot
 TYPEBOT_ENABLED=false
 TYPEBOT_API_VERSION=old

--- a/src/api/integrations/chatbot/evolutionBot/controllers/evolutionBot.controller.ts
+++ b/src/api/integrations/chatbot/evolutionBot/controllers/evolutionBot.controller.ts
@@ -1,5 +1,6 @@
 import { PrismaRepository } from '@api/repository/repository.service';
 import { WAMonitoringService } from '@api/services/monitor.service';
+import { configService, EvolutionBot as EvolutionBotConfig } from '@config/env.config';
 import { Logger } from '@config/logger.config';
 import { EvolutionBot, IntegrationSession } from '@prisma/client';
 
@@ -23,7 +24,7 @@ export class EvolutionBotController extends BaseChatbotController<EvolutionBot, 
   public readonly logger = new Logger('EvolutionBotController');
   protected readonly integrationName = 'EvolutionBot';
 
-  integrationEnabled = true; // Set to true by default or use config value if available
+  integrationEnabled = configService.get<EvolutionBotConfig>('EVOLUTIONBOT').ENABLED ?? true;
   botRepository: any;
   settingsRepository: any;
   sessionRepository: any;

--- a/src/config/env.config.ts
+++ b/src/config/env.config.ts
@@ -328,6 +328,7 @@ export type Pusher = { ENABLED: boolean; GLOBAL?: GlobalPusher; EVENTS: EventsPu
 export type ConfigSessionPhone = { CLIENT: string; NAME: string };
 export type Baileys = { VERSION?: string };
 export type QrCode = { LIMIT: number; COLOR: string };
+export type EvolutionBot = { ENABLED: boolean };
 export type Typebot = { ENABLED: boolean; API_VERSION: string; SEND_MEDIA_BASE64: boolean };
 export type Chatwoot = {
   ENABLED: boolean;
@@ -427,6 +428,7 @@ export interface Env {
   CONFIG_SESSION_PHONE: ConfigSessionPhone;
   BAILEYS: Baileys;
   QRCODE: QrCode;
+  EVOLUTIONBOT: EvolutionBot;
   TYPEBOT: Typebot;
   CHATWOOT: Chatwoot;
   OPENAI: Openai;
@@ -836,6 +838,9 @@ export class ConfigService {
       QRCODE: {
         LIMIT: Number.parseInt(process.env.QRCODE_LIMIT) || 30,
         COLOR: process.env.QRCODE_COLOR || '#198754',
+      },
+      EVOLUTIONBOT: {
+        ENABLED: process.env?.EVOLUTIONBOT_ENABLED === 'true',
       },
       TYPEBOT: {
         ENABLED: process.env?.TYPEBOT_ENABLED === 'true',


### PR DESCRIPTION
📋 Descrição
Durante a análise de alguns erros relacionado a pool de conexão identifiquei uma chuva de conexões do prisma a cada nova mensagem sendo recebida no whatsapp, mesmo o tipo da Instancia sendo Baileys e não Evolution.

No controller do evolutionBot o integrationEnabled está hardcoded como TRUE, sem variável de ambiente de controle para os casos em que nenhum tipo de bot é utilizado, como é o meu caso de disparo de mensagens apenas, logo, mesmo com todos os chatbots desabilitados no .env (TypeBot, Dify, etc), o EvolutionBot sempre executa ~10 queries por mensagem recebida (busca de configurações, sessão, gatilhos por tipo, fallback) por estar true.

📸 Screenshots (if applicable)
image
📝 Notas Adicionais
O tratamento aplicado foi criar uma variável de ambiente de controle do EvolutionBot assim como já existem para os demais tipos de integrações. Desta forma, caso quem não utilize nenhuma integração e usa apenas disparos de mensagens não é afetado pelas infinitas requisições feitas sem necessidade, estourando pool de conexões quando a muitas instâncias (meu caso).

Obs: Re-open do pull request #2559  , mas agora na branch develop
