### PR TITLE
fix: mark Chatwoot messages failed on WhatsApp error

### DIFF
--- a/src/api/integrations/channel/whatsapp/whatsapp.baileys.service.ts
+++ b/src/api/integrations/channel/whatsapp/whatsapp.baileys.service.ts
@@ -1669,8 +1669,24 @@ export class BaileysStartupService extends ChannelStartupService {
             continue;
           }
 
-          if (findMessage && update.status !== undefined && status[update.status] !== findMessage.status) {
-            if (!key.fromMe && key.remoteJid) {
+          const updateStatus = status[update.status] ?? 'SERVER_ACK';
+
+          if (findMessage && update.status !== undefined) {
+            if (key.fromMe && updateStatus === 'ERROR') {
+              await this.prismaRepository.message.update({
+                where: { id: findMessage.id },
+                data: { status: updateStatus },
+              });
+
+              if (this.configService.get<Chatwoot>('CHATWOOT').ENABLED && this.localChatwoot?.enabled) {
+                await this.chatwootService.markMessageAsFailed(findMessage, {
+                  status: updateStatus,
+                  code: update.messageStubParameters?.[0],
+                  keyId: key.id ?? undefined,
+                  remoteJid: key.remoteJid ?? undefined,
+                });
+              }
+            } else if (!key.fromMe && key.remoteJid && updateStatus !== findMessage.status) {
               readChatToUpdate[key.remoteJid] = true;
 
               const { remoteJid } = key;
@@ -1689,7 +1705,7 @@ export class BaileysStartupService extends ChannelStartupService {
 
                 await this.prismaRepository.message.update({
                   where: { id: findMessage.id },
-                  data: { status: status[update.status] },
+                  data: { status: updateStatus },
                 });
               } else {
                 this.logger.info(

--- a/src/api/integrations/chatbot/chatwoot/services/chatwoot.service.ts
+++ b/src/api/integrations/chatbot/chatwoot/services/chatwoot.service.ts
@@ -41,6 +41,13 @@ interface ChatwootMessage {
   isRead?: boolean;
 }
 
+interface WhatsAppErrorStatus {
+  code?: string;
+  keyId?: string;
+  remoteJid?: string;
+  status?: string;
+}
+
 export class ChatwootService {
   private readonly logger = new Logger('ChatwootService');
 
@@ -108,6 +115,45 @@ export class ChatwootService {
 
   public getCache() {
     return this.cache;
+  }
+
+  public async markMessageAsFailed(message: MessageModel, error: WhatsAppErrorStatus) {
+    if (!message?.chatwootMessageId) {
+      return;
+    }
+
+    if (!this.pgClient?.query) {
+      this.logger.warn('Chatwoot database connection not available');
+      return;
+    }
+
+    const metadata = {
+      evolution_error: {
+        status: error.status,
+        code: error.code,
+        key_id: error.keyId,
+        remote_jid: error.remoteJid,
+        at: new Date().toISOString(),
+      },
+    };
+
+    const result = await this.pgClient.query(
+      `
+        UPDATE messages
+        SET
+          status = 3,
+          additional_attributes = COALESCE(additional_attributes, '{}'::jsonb) || $1::jsonb,
+          updated_at = NOW()
+        WHERE id = $2
+      `,
+      [JSON.stringify(metadata), message.chatwootMessageId],
+    );
+
+    this.logger.warn(
+      `Marked Chatwoot message ${message.chatwootMessageId} as failed after WhatsApp ${error.status}${
+        error.code ? ` (${error.code})` : ''
+      }; rows affected: ${result.rowCount}`,
+    );
   }
 
   public async create(instance: InstanceDto, data: ChatwootDto) {


### PR DESCRIPTION
## Summary
- update the original Evolution message to ERROR when Baileys emits an outbound WhatsApp ERROR update
- mark the linked Chatwoot message as failed (status 3) so the agent sees the failed send instead of an apparently sent message
- store diagnostic metadata in Chatwoot additional_attributes under evolution_error, including status, WhatsApp stub code, key id, remote jid, and timestamp

## Why
Evolution already stores outbound WhatsApp ERROR updates in MessageUpdate, but the linked original Message and Chatwoot message can remain in their previous state. That makes async WhatsApp send failures invisible in Chatwoot.

We observed this with WhatsApp ERROR status 0 / code 463: the MessageUpdate row existed, but Chatwoot still showed the outbound message as sent. This patch propagates that async failure to the user-visible Chatwoot message.

## Validation
- git diff --check

I attempted npm ci --ignore-scripts to run the project checks, but dependency installation failed in this environment with npm ECONNRESET before tsc/eslint were available.

## Summary by Sourcery

Propagate outbound WhatsApp ERROR updates to the corresponding Chatwoot message so failed sends are visible to agents.

Bug Fixes:
- Update Evolution message status to ERROR when Baileys reports an outbound WhatsApp ERROR.
- Mark the associated Chatwoot message as failed when an outbound WhatsApp message errors, preventing it from appearing as successfully sent.

Enhancements:
- Store WhatsApp error diagnostics in Chatwoot message additional_attributes under evolution_error for easier troubleshooting.