### PR TITLE
feat: add limit sharing privacy toggle

### DIFF
--- a/src/api/controllers/chat.controller.ts
+++ b/src/api/controllers/chat.controller.ts
@@ -3,6 +3,7 @@ import {
   BlockUserDto,
   DeleteMessage,
   getBase64FromMediaMessageDto,
+  LimitSharingDto,
   MarkChatUnreadDto,
   NumberDto,
   PrivacySettingDto,
@@ -36,6 +37,10 @@ export class ChatController {
 
   public async markChatUnread({ instanceName }: InstanceDto, data: MarkChatUnreadDto) {
     return await this.waMonitor.waInstances[instanceName].markChatUnread(data);
+  }
+
+  public async updateLimitSharing({ instanceName }: InstanceDto, data: LimitSharingDto) {
+    return await this.waMonitor.waInstances[instanceName].updateLimitSharing(data);
   }
 
   public async deleteMessage({ instanceName }: InstanceDto, data: DeleteMessage) {

--- a/src/api/dto/chat.dto.ts
+++ b/src/api/dto/chat.dto.ts
@@ -86,6 +86,11 @@ export class MarkChatUnreadDto {
   chat?: string;
 }
 
+export class LimitSharingDto {
+  chat: string;
+  limitSharing: boolean;
+}
+
 export class PrivacySettingDto {
   readreceipts: WAReadReceiptsValue;
   profile: WAPrivacyValue;

--- a/src/api/integrations/channel/whatsapp/whatsapp.baileys.service.ts
+++ b/src/api/integrations/channel/whatsapp/whatsapp.baileys.service.ts
@@ -6,6 +6,7 @@ import {
   DeleteMessage,
   getBase64FromMediaMessageDto,
   LastMessage,
+  LimitSharingDto,
   MarkChatUnreadDto,
   NumberBusiness,
   OnWhatsAppDto,
@@ -3764,6 +3765,24 @@ export class BaileysStartupService extends ChannelStartupService {
       throw new InternalServerErrorException({
         markedChatUnread: false,
         message: ['An error occurred while marked unread the chat. Open a calling.', error.toString()],
+      });
+    }
+  }
+
+  public async updateLimitSharing(data: LimitSharingDto) {
+    try {
+      const remoteJid = createJid(data.chat);
+      const response = await this.client.sendMessage(remoteJid, { limitSharing: data.limitSharing });
+
+      return {
+        chatId: remoteJid,
+        limitSharing: data.limitSharing,
+        message: response,
+      };
+    } catch (error) {
+      throw new InternalServerErrorException({
+        limitSharing: false,
+        message: ['An error occurred while updating advanced chat privacy.', error.toString()],
       });
     }
   }

--- a/src/api/routes/chat.router.ts
+++ b/src/api/routes/chat.router.ts
@@ -4,6 +4,7 @@ import {
   BlockUserDto,
   DeleteMessage,
   getBase64FromMediaMessageDto,
+  LimitSharingDto,
   MarkChatUnreadDto,
   NumberDto,
   PrivacySettingDto,
@@ -24,6 +25,7 @@ import {
   blockUserSchema,
   contactValidateSchema,
   deleteMessageSchema,
+  limitSharingSchema,
   markChatUnreadSchema,
   messageUpSchema,
   messageValidateSchema,
@@ -86,6 +88,16 @@ export class ChatRouter extends RouterBroker {
           schema: markChatUnreadSchema,
           ClassRef: MarkChatUnreadDto,
           execute: (instance, data) => chatController.markChatUnread(instance, data),
+        });
+
+        return res.status(HttpStatus.CREATED).json(response);
+      })
+      .post(this.routerPath('updateLimitSharing'), ...guards, async (req, res) => {
+        const response = await this.dataValidate<LimitSharingDto>({
+          request: req,
+          schema: limitSharingSchema,
+          ClassRef: LimitSharingDto,
+          execute: (instance, data) => chatController.updateLimitSharing(instance, data),
         });
 
         return res.status(HttpStatus.CREATED).json(response);

--- a/src/validate/chat.schema.ts
+++ b/src/validate/chat.schema.ts
@@ -118,6 +118,17 @@ export const markChatUnreadSchema: JSONSchema7 = {
   required: ['lastMessage'],
 };
 
+export const limitSharingSchema: JSONSchema7 = {
+  $id: v4(),
+  type: 'object',
+  properties: {
+    chat: { type: 'string' },
+    limitSharing: { type: 'boolean', enum: [true, false] },
+  },
+  required: ['chat', 'limitSharing'],
+  ...isNotEmpty('chat'),
+};
+
 export const deleteMessageSchema: JSONSchema7 = {
   $id: v4(),
   type: 'object',


### PR DESCRIPTION
## 📋 Description
Adds a chat API endpoint to toggle WhatsApp Advanced Chat Privacy / Limit Sharing for a chat or group.

Baileys already supports sending `{ limitSharing: boolean }` and emits a `LIMIT_SHARING` protocol message. This change exposes that capability through Evolution API with request DTO and JSON schema validation.

Endpoint:

```http
POST /chat/updateLimitSharing/{instance}
```

Payload:

```json
{
  "chat": "120363000000000000@g.us",
  "limitSharing": true
}
```

## 🔗 Related Issue
N/A

## 🧪 Type of Change
- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔧 Configuration change
- [ ] ♻️ Code refactoring
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test improvement

## 🧪 Testing
- [ ] Manual testing completed
- [x] Functionality verified in development environment
- [x] No breaking changes introduced
- [ ] Tested with different connection types (if applicable)

Validation performed:

```sh
npm ci --cache /private/tmp/npm-cache-apgl
cp .env.example .env
./Docker/scripts/generate_database.sh
npm run build
npm run lint:check
```

## 📸 Screenshots (if applicable)
N/A

## ✅ Checklist
- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have manually tested my changes thoroughly
- [ ] I have verified that my changes work with different scenarios
- [ ] Any dependent changes have been merged and published

## 📝 Additional Notes
No live WhatsApp account manual test was performed from this checkout. Existing npm install audit/deprecation warnings are unrelated to this change.

## Summary by Sourcery

Expose a new API endpoint to update WhatsApp advanced chat privacy limit sharing for a specific chat or group.

New Features:
- Add chat controller and service support to toggle WhatsApp limit sharing for a given chat via Baileys.
- Introduce a /chat/updateLimitSharing endpoint with DTO-based handling for instance-scoped requests.
- Add JSON schema validation for limit sharing requests including chat ID and boolean flag.

Chores:
- Define a LimitSharingDto to represent limit sharing update requests in the chat API.